### PR TITLE
docs: add in-depth competitive analysis (#24)

### DIFF
--- a/docs/competitive-analysis.md
+++ b/docs/competitive-analysis.md
@@ -1,0 +1,347 @@
+# Riffpad 竞品调研分析
+
+> 研究日期：2026-07-08  
+> 研究范围：AI 编程助手、AI 工作区、Prompt-to-App 构建器  
+> 数据来源：公开产品文档、第三方评测、行业统计报告
+
+---
+
+## 1. 执行摘要
+
+Riffpad 的核心定位是 **“AI 原生代码灵感草稿本（AI-Native Code Sketchbook）”**——位于整个 AI 软件工程链路的最上游。它不是替代 Cursor / Claude Code 的生产 IDE，也不是一个单纯的聊天机器人，而是一个把“一句话想法”变成可运行沙箱、验证后再桥接到下游工具的中转站。
+
+当前市场已形成三大阵营：
+
+1. **Chat-first AI 助手**（ChatGPT Canvas、Claude Artifacts、Gemini）——擅长对话与思考，但输出沉淀弱、不可运行。
+2. **Agent IDE / CLI**（Cursor、Windsurf、Claude Code、OpenAI Codex、GitHub Copilot Workspace）——能力强、面向已有代码库，但启动重、桌面优先。
+3. **Prompt-to-App 构建器**（v0、Bolt.new、Lovable、Replit Agent）——一句话生成应用，但生态锁定强、多为全栈托管平台。
+
+Riffpad 的机会在于：**比 Chat 更结构化、比 IDE 更轻、比 App Builder 更开放**。关键差异化包括：移动端第一捕获、Firecracker/gVisor 隔离沙箱、多模型切换、48h 自动休眠的成本控制，以及一键导出到 Cursor / Claude Code 的下游桥接。
+
+---
+
+## 2. 市场数据与趋势
+
+- **开发者采用率极高**：Stack Overflow 2025 调查显示，84% 的开发者已经在使用或计划使用 AI 工具，51% 的专业开发者每天使用 [AI Coding Assistant Statistics 2026](https://uvik.net/blog/ai-coding-assistant-statistics/)。
+- **痛点已从价格转向能力**：2026 年开发者最关注的不再是价格，而是“上下文窗口 / 项目记忆”——62% 认为 AI 记不住项目上下文是最大问题 [AInspiro 2026 Report](https://www.ainspiro.com/en/news/ai-coding-tools-market-report-2026-adoption-statistics/)。
+- **Agent 从辅助走向工作流**：Microsoft 表示已有 1500 万开发者使用 GitHub Copilot；Anthropic 报告称 89% 的技术领导者将 AI 用于编程 [Panto AI 2026](https://www.getpanto.ai/blog/ai-agents-statistics)。
+- **企业最大顾虑是合规**：44% 的组织担忧代码泄露与知识产权暴露，合规成为企业采购的首要障碍 [Fungies.io 2026](https://fungies.io/ai-coding-agent-adoption-statistics-2026/)。
+- **Cursor 验证了天花板**：Cursor 在 2026 年 5 月达到 40 亿美元 ARR，被 SpaceX 以 600 亿美元收购，说明开发者愿意为 AI 编码工具支付高额费用 [AI Business Weekly 2026](https://aibusinessweekly.net/p/cursor-ai-statistics)。
+
+---
+
+## 3. 竞品地图
+
+| 阵营 | 代表产品 | 核心形态 | 典型用户 |
+|---|---|---|---|
+| **Chat-first AI 助手** | ChatGPT Canvas、Claude Artifacts、Gemini | 聊天 + 可编辑面板 | 知识工作者、学生、轻量开发者 |
+| **Agent IDE / CLI** | Cursor、Windsurf、Claude Code、OpenAI Codex、GitHub Copilot Workspace | 桌面 IDE / 终端代理 | 专业工程师、工程团队 |
+| **Prompt-to-App 构建器** | v0、Bolt.new、Lovable、Replit Agent | 浏览器内生成 + 部署 | 创始人、PM、设计师、非开发者 |
+
+---
+
+## 4. 核心竞品分析
+
+### 4.1 ChatGPT Canvas（OpenAI）
+
+**产品概述**：Canvas 是 ChatGPT 内置的协作编辑面板，可在聊天旁并排编辑文档或代码，支持 Python 运行、React/HTML 预览、版本历史与分享 [OpenAI Help Center](https://help.openai.com/en/articles/9930697-what-is-the-canvas-feature-in-chatgpt-and-how-do-i-use-it)。
+
+**目标用户**：需要迭代草稿、简单组件或代码片段的写作者与学生，偏轻量。
+
+**关键特性**：
+- 双栏工作区：聊天 + 可编辑画布
+- 段落级编辑与代码快捷键
+- Python 浏览器内执行、React/HTML 沙箱预览
+- 版本历史、diff 视图、分享导出
+- 企业级代码执行与网络管控
+
+**定价**：Plus $20/月起；Pro/Team/Enterprise 更高 [OpenAI Help Center](https://help.openai.com/en/articles/6950777-what-is-chatgpt-plus)。
+
+**vs Riffpad**：
+- **优势**：用户基数巨大、协作功能成熟、企业治理完善。
+- **劣势**：不是真正的隔离沙箱；移动端“即将推出”；无法桥接到 Cursor/Claude Code；锁定 OpenAI 模型。
+
+### 4.2 Claude Artifacts + Claude Code（Anthropic）
+
+**产品概述**：Artifacts 是 Claude 聊天中生成的可交互面板（HTML/React/文档/仪表盘），可发布为 URL；Claude Code 是终端优先的代码代理，可读写文件、运行测试、集成 IDE [Anthropic Support](https://support.anthropic.com/en/articles/9487310-what-are-artifacts-and-how-do-i-use-them) [Claude Code](https://www.anthropic.com/claude-code)。
+
+**目标用户**：希望先在 Claude 里“草图”，再进入正式代码库的开发者和知识工作者。
+
+**关键特性**：
+- 可发布的 Artifacts 面板
+- AI 驱动的 Artifacts 可调用 Claude API
+- 文件创建/编辑、Python/JS 执行
+- Claude Code：代码库理解、多文件编辑、Issue 到 PR
+- MCP 连接器、持久存储
+
+**定价**：Pro $20/月；Max $100/月起；Team $25/人/月；Enterprise 定制 [Claude Pricing](https://claude.com/pricing)。
+
+**vs Riffpad**：
+- **优势**：Claude 模型能力强、分享便捷、Claude Code 是 Riffpad 计划桥接的下游目标之一。
+- **劣势**：非移动优先；沙箱控制力弱于 Firecracker/gVisor；没有一键重构并导出干净项目骨架的工作流；锁定 Anthropic 模型。
+
+### 4.3 Gemini / Google AI Studio
+
+**产品概述**：Google AI Studio 是浏览器内的 Gemini 原型工作区，支持自然语言生成 React/Tailwind 或 Android 原型，可导出到 Colab、GitHub 或 Antigravity 2.0 [Turion AI](https://turion.ai/blog/google-ai-studio-2026-features-guide/)。
+
+**目标用户**：Google Cloud/Android 生态内的开发者和技术型创客。
+
+**关键特性**：
+- 自然语言生成 React/Tailwind 与 Android 原型
+- 200 万 token 上下文、多模态输入
+- 代码执行、Google Search grounding、Deep Research
+- 一键导出到 Colab/GitHub/Cloud Run
+
+**定价**：AI Studio UI 免费（额度限制）；API 按量付费 [Metacto](https://www.metacto.com/blogs/the-true-cost-of-google-gemini-a-guide-to-api-pricing-and-integration)。
+
+**vs Riffpad**：
+- **优势**：免费起点低、上下文窗口大、搜索 grounding、Google 生态集成。
+- **劣势**：桌面浏览器优先；沙箱主要面向 Web 预览；没有专门的下游 IDE 桥接；生态锁定明显。
+
+### 4.4 Cursor（Anysphere）
+
+**产品概述**：Cursor 是 AI 原生代码编辑器（VS Code 分支），主打内联补全、Composer 多文件代理、背景云代理和 PR 审查 [Cursor](https://cursor.com) [Cursor Pricing](https://cursor.com/pricing)。
+
+**目标用户**：日常编写真实代码库的专业工程师。
+
+**关键特性**：
+- 自主代理：规划、编辑多文件、运行测试
+- Tab 预测编辑
+- Composer 2.5 自研模型
+- Bugbot PR 审查
+- Cursor CLI、Slack 集成、GitHub 工作流
+- 团队控制：SSO、SCIM、审计日志
+
+**定价**：Hobby 免费；Individual $20/月；Teams $40/人/月；Enterprise 定制 [Cursor Pricing](https://cursor.com/pricing)。
+
+**vs Riffpad**：
+- **优势**：IDE 体验成熟、生产级代理工作流、模型可选、企业控制强。
+- **劣势**：桌面安装重、无一次性沙箱、不适合手机捕获灵感、是按量计费的生产工具而非上游草稿本。
+
+### 4.5 Windsurf（Codeium）
+
+**产品概述**：Windsurf 是 Codeium 推出的 AI 原生 IDE，核心为 Cascade 代理，可在多文件中规划、执行、运行终端命令并回退 [Windsurf Docs](https://docs.windsurf.com/plugins/cascade/cascade-overview)。
+
+**目标用户**：想要深度集成 Agent 的 VS Code 用户。
+
+**关键特性**：
+- Cascade 代理（Write/Chat 模式）
+- 无限 Windsurf Tab 补全、Supercomplete
+- 代码库索引 / Codemaps
+- Memories 学习项目约定
+- 支持 Claude、GPT、Gemini、Kimi K2 等模型
+
+**定价**：免费层含 25 个高级 Cascade 任务/月；Pro 约 $15/月起 [Ivern AI](https://ivern.ai/blog/codeium-vs-windsurf-comparison)。
+
+**vs Riffpad**：
+- **优势**：独立 IDE 体验好、Cascade 多文件编辑强、免费层可用。
+- **劣势**：桌面 IDE、无隔离运行时沙箱、无下游桥接设计。
+
+### 4.6 GitHub Copilot / Copilot Workspace
+
+**产品概述**：GitHub Copilot 提供 IDE 内联补全、Chat、多文件编辑和 Agent 模式；Copilot Workspace / Coding Agent 可把 GitHub Issue 变成计划、代码修改和 PR [GitHub Copilot FAQ](https://github.com/features/copilot) [Java Code Geeks](https://www.javacodegeeks.com/2026/02/github-copilot-workspace-the-agentic-era.html)。
+
+**目标用户**：已经在 GitHub/VS Code 生态中的开发者与团队。
+
+**关键特性**：
+- 内联补全与 Next Edit Suggestions
+- Copilot Chat / Edits / Agent 模式
+- Issue → Plan → Diff → PR
+- GitHub Actions、Advanced Security、组织知识库集成
+- 企业策略、IP 赔偿、数据保护
+
+**定价**：免费层 2,000 补全 + 50 聊天/月；Pro $10/月；Pro+ $39/月；Max $100/月；Business $19/人/月；Enterprise $39/人/月 [GitHub Copilot FAQ](https://github.com/features/copilot)。
+
+**vs Riffpad**：
+- **优势**：GitHub 生态无缝集成、企业合规成熟、规模大。
+- **劣势**：仓库/IDE 优先，不是轻量灵感捕获工具；无一次性沙箱；AI Credits 计费复杂。
+
+### 4.7 OpenAI Codex
+
+**产品概述**：OpenAI Codex 是面向软件工程的代理层，可在隔离沙箱中自主编写、编辑、测试、审查代码，通过 ChatGPT、Codex App、IDE 扩展和开源 CLI 提供服务 [OpenAI Codex](https://openai.com/codex)。
+
+**目标用户**：已有代码库、希望把任务委派给背景代理的专业开发者。
+
+**关键特性**：
+- 多表面：Web、桌面 App、IDE、CLI
+- 云代理：在隔离沙箱中并行执行多任务
+- Skills、Automations、Diff 审查
+- 仅使用 OpenAI GPT-5 / Codex 模型
+
+**定价**：捆绑 ChatGPT 订阅；Plus $20/月、Pro $100/月、Business ~$25/人/月；CLI 需自备 API Key [AI Agent Square](https://aiagentsquare.com/agents/openai-codex)。
+
+**vs Riffpad**：
+- **优势**：多代理并行、ChatGPT 分发、开源 CLI。
+- **劣势**：非移动优先、非上游孵化器、无下游桥接、OpenAI 模型锁定。
+
+### 4.8 v0.dev（Vercel）
+
+**产品概述**：v0 是 Vercel 的 AI 应用构建器，从自然语言生成 React/Next.js/TypeScript/Tailwind/shadcn 应用，提供隔离的 Vercel Sandbox、内置编辑器、Git 原生工作流和一键部署 [v0 Docs](https://v0.app/docs/) [v0 Pricing](https://v0.app/pricing)。
+
+**目标用户**：Vercel / Next.js 生态内的前端工程师、设计工程师、技术创始人。
+
+**关键特性**：
+- 自然语言生成 Next.js 全栈应用
+- 真正的 Node.js 沙箱（终端、日志、文件编辑器）
+- GitHub 分支级工作流
+- 一键部署到 Vercel
+- iOS App 支持移动端 prompting
+
+**定价**：免费层 7 条消息/天 + $5 额度；Team $30/人/月；Business $100/人/月；Enterprise 定制 [v0 Pricing](https://v0.app/pricing)。
+
+**vs Riffpad**：
+- **优势**：生产部署能力强、代码质量好、Git 集成深、Next.js 生态完美。
+- **劣势**：锁定 React/Next.js + Vercel；免费层有限；移动端捕获非核心；希望用户留在 Vercel 而非桥接到其他 IDE。
+
+### 4.9 Bolt.new（StackBlitz）
+
+**产品概述**：Bolt.new 是 StackBlitz 的浏览器 AI 编码代理，基于 WebContainers 在浏览器中运行 Node.js，支持多框架、实时预览和一键部署 [Bolt Pricing](https://bolt.new/pricing)。
+
+**目标用户**：开发者、创始人、会写代码的设计师，需要快速生成前端原型。
+
+**关键特性**：
+- Prompt-to-App
+- 浏览器内 Node.js/WebAssembly 运行时
+- React/Vue/Svelte/Astro/Next.js 多框架
+- 多模型选择
+- 发布到 `.bolt.host` 或 Netlify
+- ZIP/GitHub 导出
+
+**定价**：免费层 30 万 tokens/天、100 万/月；付费约 $20–$25/月起 [Bolt Pricing](https://bolt.new/pricing)。
+
+**vs Riffpad**：
+- **优势**：零安装、框架灵活、导出友好、成熟的浏览器运行时。
+- **劣势**：前端偏重；WebContainers 在 Safari/移动端受限；后端/数据库需手动集成；token 经济可能限制高频迭代。
+
+### 4.10 Lovable
+
+**产品概述**：Lovable 是面向非开发者的全栈 AI 应用构建器，从聊天生成 React/TypeScript + 后端 + 数据库 + 认证，支持可视化编辑和 GitHub 双向同步 [Lovable Docs](https://docs.lovable.dev/introduction/welcome.md)。
+
+**目标用户**：创始人、PM、设计师、非技术创客。
+
+**关键特性**：
+- 聊天式全栈生成
+- 可视化编辑器 + Plan Mode
+- GitHub 双向同步
+- Supabase / Lovable Cloud 托管
+- SOC 2 / ISO 27001 / SSO / SCIM
+
+**定价**：免费层 5 每日积分；Pro $25/月；Business $50/月；Enterprise 定制 [Lovable Pricing](https://docs.lovable.dev/introduction/subscription-plans.md)。
+
+**vs Riffpad**：
+- **优势**：全栈托管、企业合规、代码所有权、非开发者友好。
+- **劣势**：不是移动灵感捕获工具；调试循环消耗积分；锁定 Supabase/Lovable 托管；不强调桥接到 Cursor/Claude Code。
+
+### 4.11 Replit Agent
+
+**产品概述**：Replit Agent 是 Replit 云 IDE 内的 AI 构建器，可从自然语言生成全栈应用并直接部署到 `*.replit.app`，无需本地环境 [Replit Agent](https://replit.com/agent) [Espressio AI](https://espressio.ai/blog/replit-guide-2026/)。
+
+**目标用户**：非开发者、学生、创始人、教育者、小型团队。
+
+**关键特性**：
+- Prompt-to-App，自动处理依赖与数据库
+- 浏览器云 IDE，支持 50+ 语言
+- Agent 3/4：最长 200 分钟自主运行、浏览器自测、并行子任务
+- 160+ 第三方集成
+- 实时协作
+
+**定价**：Starter 免费；Core $20/月；Pro $95/月；Enterprise 定制 [Replit Pricing](https://replit.com/pricing)。
+
+**vs Riffpad**：
+- **优势**：最成熟的端到端平台；零本地设置；5000 万+ 用户；教育市场强。
+- **劣势**：平台锁定深；希望全生命周期留在 Replit；浏览器 IDE 对高级工程师有天花板；成本随使用增长。
+
+---
+
+## 5. 综合对比矩阵
+
+| 产品 | 定位 | 启动摩擦 | 移动端 | 隔离沙箱 | 下游桥接 | 价格起点 | 最适合 |
+|---|---|---|---|---|---|---|---|
+| **ChatGPT Canvas** | Chat + 编辑面板 | 低 | 弱 | 有限 | 导出文件 | $20/月 | 文档/轻量代码草稿 |
+| **Claude Artifacts** | Chat 内可交互面板 | 低 | 弱 | 有限 | 发布/复制 | $20/月 | 小应用/可视化原型 |
+| **Gemini / AI Studio** | 模型原型工作区 | 低 | 弱 | Web 预览 | 导出代码 | 免费 | Google 生态开发者 |
+| **Cursor** | AI 生产 IDE | 高（安装） | 无 | 本地项目 | 不适用 | 免费 / $20 | 专业工程师日常开发 |
+| **Windsurf** | AI 原生 IDE | 高（安装） | 无 | 本地项目 | 不适用 | 免费 / ~$15 | 多文件 Agent 编辑 |
+| **Claude Code** | 终端代码代理 | 中 | 无 | 本地 repo | 不适用 | $20/月 | 复杂代码库任务 |
+| **OpenAI Codex** | 云端工程代理 | 中 | 无 | 云端隔离 | 不适用 | $20/月 | 背景并行工程任务 |
+| **GitHub Copilot Workspace** | GitHub 原生 Agent | 中 | App 聊天 | 本地/沙箱终端 | PR 工作流 | 免费 / $10 | GitHub 团队 |
+| **v0.dev** | Next.js AI 构建器 | 低 | iOS App | Vercel Sandbox | GitHub PR | 免费 / $30 | Next.js 前端/全栈 |
+| **Bolt.new** | 浏览器 AI IDE | 低 | 弱 | WebContainers | ZIP/GitHub | 免费 / ~$20 | 前端原型 |
+| **Lovable** | 无代码全栈构建器 | 低 | 管理 App | 托管平台 | GitHub 双向同步 | 免费 / $25 | 非开发者 MVP |
+| **Replit Agent** | 云 IDE + 构建器 | 低 | 弱 | Replit 沙箱 | 导出代码 | 免费 / $20 | 教育/小团队 |
+| **Riffpad（目标）** | 上游灵感草稿本 | 极低 | 第一优先 | Firecracker/gVisor | Cursor/Claude/Zip/MCP | 待定价 | 碎片化灵感验证 |
+
+---
+
+## 6. Riffpad 的机会与差异化
+
+### 6.1 核心空白：上游孵化器
+
+市场里的产品要么“说”（Chat），要么“做生产”（IDE），要么“直接托管”（App Builder）。Riffpad 占据的 **“快速验证后桥接”** 位置几乎空白：
+
+- **比 Chat 更结构化**：每个灵感都是文件树 + 版本历史 + 可运行沙箱，不再埋在聊天记录里。
+- **比 IDE 更轻**：无需本地环境、无需 Git、无需命名项目；手机上说两句就能启动。
+- **比 App Builder 更开放**：不锁定 hosting 或框架，验证后直接交给 Cursor / Claude Code / MCP。
+
+### 6.2 关键差异化能力
+
+| 能力 | 竞品状态 | Riffpad 机会 |
+|---|---|---|
+| **移动端 + 语音捕获** | 普遍弱或无 | 作为核心入口，通勤/散步场景独占 |
+| **秒级隔离沙箱** | Chat/IDE 无；App Builder 有但锁定 | Firecracker/gVisor 真隔离、多运行时 |
+| **多模型切换** | 多数锁定单一厂商 | Kimi/GLM/Qwen/DeepSeek 灵活切换 |
+| **下游桥接** | 多为导出文件或锁定平台 | 一键重构骨架 + README → Cursor/Claude |
+| **成本控制** | 订阅/按量，调试易超额 | 48h 自动休眠 + 预热池，灵感低成本 |
+
+### 6.3 目标用户细分建议
+
+1. **独立开发者 / 全栈黑客**：地铁上想到点子，3 秒开 Spark，到公司时已验证。
+2. **技术产品经理**：评审前快速做出可点击原型，丢给团队。
+3. **AI 重度探索者**：管理多条技术实验分支，沉淀、分叉、导出。
+
+---
+
+## 7. 风险与挑战
+
+1. **巨头生态挤压**：Cursor、Copilot、v0 都在向“Agent + 沙箱”方向扩展，可能蚕食上游空间。
+2. **用户习惯迁移**：开发者已习惯在 Chat/IDE 中工作，需要教育“先验证再迁移”的新流程。
+3. **沙箱成本与安全**：任意 Bash + 网络隔离 + 长时间运行会带来基础设施复杂度和安全审计压力。
+4. **收费模式验证**：按 Spark、按资源、按订阅都各有优劣，需在早期用户中快速测试。
+
+---
+
+## 8. 策略建议
+
+1. **强化“上游桥接”叙事**：所有营销材料都围绕“Capture → Validate → Bridge”三段式，避免与 Cursor/Claude Code 正面竞争。
+2. **移动端体验作为护城河**：把语音输入、PWA、跨设备同步做到极致，这是现有竞品最薄弱的环节。
+3. **模板与导出质量优先**：导出到 Cursor/Claude Code 的代码骨架、README、上下文描述必须“开箱即用”，让用户一次迁移就回不去。
+4. **定价从免费 + 资源配额开始**：用 10 个免费 Spark/月降低门槛，Pro 解锁长驻项目、更大沙箱、优先队列。
+5. **建立 MCP / Skills 生态**：让社区贡献下游导出模板（Cursor rules、Claude Skills、VS Code 扩展），形成网络效应。
+
+---
+
+## 9. 参考来源
+
+- [OpenAI Help Center — Canvas](https://help.openai.com/en/articles/9930697-what-is-the-canvas-feature-in-chatgpt-and-how-do-i-use-it)
+- [Anthropic — What are Artifacts](https://support.anthropic.com/en/articles/9487310-what-are-artifacts-and-how-do-i-use-them)
+- [Claude Code](https://www.anthropic.com/claude-code)
+- [Claude Pricing](https://claude.com/pricing)
+- [Turion AI — Google AI Studio 2026](https://turion.ai/blog/google-ai-studio-2026-features-guide/)
+- [Cursor](https://cursor.com)
+- [Cursor Pricing](https://cursor.com/pricing)
+- [Ivern AI — Windsurf Comparison](https://ivern.ai/blog/codeium-vs-windsurf-comparison)
+- [GitHub Copilot FAQ](https://github.com/features/copilot)
+- [OpenAI Codex](https://openai.com/codex)
+- [v0 Pricing](https://v0.app/pricing)
+- [v0 Docs](https://v0.app/docs/)
+- [Bolt Pricing](https://bolt.new/pricing)
+- [Lovable Docs](https://docs.lovable.dev/introduction/welcome.md)
+- [Lovable Pricing](https://docs.lovable.dev/introduction/subscription-plans.md)
+- [Replit Agent](https://replit.com/agent)
+- [Replit Pricing](https://replit.com/pricing)
+- [Espressio AI — Replit Guide 2026](https://espressio.ai/blog/replit-guide-2026/)
+- [UVIK — AI Coding Assistant Statistics 2026](https://uvik.net/blog/ai-coding-assistant-statistics/)
+- [AInspiro — 2026 AI Coding Tools Market Report](https://www.ainspiro.com/en/news/ai-coding-tools-market-report-2026-adoption-statistics/)
+- [Panto AI — AI Agents Statistics 2026](https://www.getpanto.ai/blog/ai-agents-statistics)
+- [Fungies.io — AI Coding Agent Adoption 2026](https://fungies.io/ai-coding-agent-adoption-statistics-2026/)
+- [AI Business Weekly — Cursor AI Statistics 2026](https://aibusinessweekly.net/p/cursor-ai-statistics)


### PR DESCRIPTION
## Summary
Adds a comprehensive competitive analysis document covering the AI coding / workspace / prompt-to-app landscape.

## What's inside
- Market adoption data and 2026 trends
- Competitor map across three segments
- 11 competitor profiles (ChatGPT Canvas, Claude Artifacts/Code, Gemini, Cursor, Windsurf, Claude Code, OpenAI Codex, Copilot Workspace, v0, Bolt.new, Lovable, Replit Agent)
- Comparison matrix
- Riffpad differentiation, risks, and strategic recommendations

## Related Issues
Closes #24