### PR TITLE
feat(landing): refactor export mockup to SVG and remove ReactFlow

### DIFF
--- a/apps/landing/app/globals.css
+++ b/apps/landing/app/globals.css
@@ -88,4 +88,11 @@ body {
   .text-balance {
     text-wrap: balance;
   }
+  .hide-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .hide-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
 }

--- a/apps/landing/app/globals.css
+++ b/apps/landing/app/globals.css
@@ -96,3 +96,17 @@ body {
     display: none;
   }
 }
+
+@keyframes exportFlow {
+  to {
+    stroke-dashoffset: -12;
+  }
+}
+
+.export-flow-line {
+  animation: exportFlow 2.5s linear infinite;
+}
+
+.riffpad-logo-white {
+  filter: brightness(0) saturate(100%) invert(100%);
+}

--- a/apps/landing/app/page.tsx
+++ b/apps/landing/app/page.tsx
@@ -1,5 +1,6 @@
 import { Header } from "@/components/Header";
 import { Hero } from "@/components/Hero";
+import { SaasWorkspaceMockup } from "@/components/mockups";
 import { Features } from "@/components/Features";
 import { Comparison } from "@/components/Comparison";
 import { FAQ } from "@/components/FAQ";
@@ -37,6 +38,9 @@ export default function Home() {
       <Header />
       <main className="bg-background">
         <Hero />
+        <section className="px-4 pb-16 pt-4 sm:px-6 sm:pb-20 lg:px-8">
+          <SaasWorkspaceMockup />
+        </section>
         <Features />
         <Comparison />
         <Testimonials />

--- a/apps/landing/components/Features.tsx
+++ b/apps/landing/components/Features.tsx
@@ -36,7 +36,7 @@ export function Features() {
         <div className="mt-20 space-y-32">
           {order.map((originalIndex, i) => {
             const block = blocks[originalIndex];
-            const isFullWidth = originalIndex === 0 || originalIndex === 1;
+            const isFullWidth = true;
             return (
               <motion.div
                 key={`${lang}-${i}`}
@@ -50,13 +50,9 @@ export function Features() {
               >
                 <div
                   className={
-                    isFullWidth
-                      ? originalIndex === 1
-                        ? "ml-auto max-w-2xl text-right"
-                        : "max-w-2xl"
-                      : i % 2 === 1
-                        ? "lg:order-2"
-                        : ""
+                    originalIndex === 2
+                      ? "ml-auto max-w-2xl text-right"
+                      : "max-w-2xl"
                   }
                 >
                   <span className="text-xs font-bold uppercase tracking-wider text-accent">

--- a/apps/landing/components/Features.tsx
+++ b/apps/landing/components/Features.tsx
@@ -2,17 +2,23 @@
 
 import { motion } from "framer-motion";
 import { useLanguage } from "./LanguageProvider";
+import {
+  SkillsMockup,
+  MobileVoiceMockup,
+  ExportMockup,
+} from "./mockups";
 
 export function Features() {
   const { t, lang } = useLanguage();
   const blocks = t.features.blocks;
 
   const mockups = [
-    <AgentWorkspaceMockup key="m1" />,
-    <SkillsMockup key="m2" />,
-    <MobileVoiceMockup key="m3" />,
-    <ExportMockup key="m4" />,
+    <SkillsMockup key="m1" />,
+    <MobileVoiceMockup key="m2" />,
+    <ExportMockup key="m3" />,
   ];
+
+  const order = [0, 2, 1];
 
   return (
     <section id="features" className="bg-background px-4 py-24 sm:px-6 lg:px-8">
@@ -28,211 +34,53 @@ export function Features() {
         </div>
 
         <div className="mt-20 space-y-32">
-          {blocks.map((block, i) => (
-            <motion.div
-              key={`${lang}-${i}`}
-              initial={{ opacity: 0, y: 40 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, margin: "-100px" }}
-              transition={{ duration: 0.7, ease: "easeOut" }}
-              className="grid items-center gap-12 lg:grid-cols-2"
-            >
-              <div className={i % 2 === 1 ? "lg:order-2" : ""}>
-                <span className="text-xs font-bold uppercase tracking-wider text-accent">
-                  0{i + 1}
-                </span>
-                <h3 className="mt-2 text-2xl font-bold text-foreground sm:text-3xl">
-                  {block.title}
-                </h3>
-                <p className="mt-4 text-lg leading-relaxed text-body">{block.description}</p>
-              </div>
-              <div className={i % 2 === 1 ? "lg:order-1" : ""}>
-                {mockups[i]}
-              </div>
-            </motion.div>
-          ))}
+          {order.map((originalIndex, i) => {
+            const block = blocks[originalIndex];
+            const isFullWidth = originalIndex === 0 || originalIndex === 1;
+            return (
+              <motion.div
+                key={`${lang}-${i}`}
+                initial={{ opacity: 0, y: 40 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, margin: "-100px" }}
+                transition={{ duration: 0.7, ease: "easeOut" }}
+                className={`grid items-center gap-12 ${
+                  isFullWidth ? "" : "lg:grid-cols-2"
+                }`}
+              >
+                <div
+                  className={
+                    isFullWidth
+                      ? originalIndex === 1
+                        ? "ml-auto max-w-2xl text-right"
+                        : "max-w-2xl"
+                      : i % 2 === 1
+                        ? "lg:order-2"
+                        : ""
+                  }
+                >
+                  <span className="text-xs font-bold uppercase tracking-wider text-accent">
+                    0{i + 1}
+                  </span>
+                  <h3 className="mt-2 text-2xl font-bold text-foreground sm:text-3xl">
+                    {block.title}
+                  </h3>
+                  <p className="mt-4 text-lg leading-relaxed text-body">
+                    {block.description}
+                  </p>
+                </div>
+                <div
+                  className={
+                    isFullWidth ? "" : i % 2 === 1 ? "lg:order-1" : ""
+                  }
+                >
+                  {mockups[originalIndex]}
+                </div>
+              </motion.div>
+            );
+          })}
         </div>
       </div>
     </section>
-  );
-}
-
-function AgentWorkspaceMockup() {
-  return (
-    <motion.div
-      initial={{ opacity: 0, scale: 0.96 }}
-      whileInView={{ opacity: 1, scale: 1 }}
-      viewport={{ once: true }}
-      transition={{ duration: 0.6 }}
-      className="overflow-hidden rounded-xl border border-hairline bg-surface shadow-xl"
-    >
-      <div className="flex h-64 sm:h-80">
-        {/* Chat */}
-        <div className="flex w-1/3 flex-col gap-2 border-r border-hairline bg-surface p-3">
-          <div className="mb-2 text-[10px] font-bold uppercase tracking-wider text-muted">Chat</div>
-          <div className="ml-auto max-w-[90%] rounded-lg bg-foreground px-3 py-2 text-xs text-background">
-            Build a countdown page
-          </div>
-          <div className="max-w-[90%] rounded-lg border border-hairline bg-surface-doc px-3 py-2 text-xs text-body">
-            Done. Files created.
-          </div>
-          <div className="ml-auto max-w-[90%] rounded-lg bg-foreground px-3 py-2 text-xs text-background">
-            Show preview
-          </div>
-        </div>
-
-        {/* Editor */}
-        <div className="flex w-1/3 flex-col border-r border-hairline bg-surface-doc p-4">
-          <div className="mb-2 text-[10px] font-bold uppercase tracking-wider text-muted">Editor</div>
-          <div className="font-mono text-xs leading-relaxed text-body">
-            <span className="text-accent">const</span> target =
-            <span className="text-accent-green"> new</span> Date(
-            <span className="text-accent-blue">&quot;2026-08-01&quot;</span>);
-          </div>
-          <div className="mt-4 rounded-md bg-surface p-2">
-            <div className="h-20 rounded bg-accent/10" />
-          </div>
-        </div>
-
-        {/* File tree */}
-        <div className="w-1/3 bg-surface p-4">
-          <div className="mb-3 text-[10px] font-bold uppercase tracking-wider text-muted">Files</div>
-          <div className="space-y-2">
-            <div className="flex items-center gap-2 text-xs text-body">
-              <span className="text-accent-blue">◈</span> index.html
-            </div>
-            <div className="flex items-center gap-2 text-xs text-body">
-              <span className="text-accent-purple">◈</span> style.css
-            </div>
-            <div className="flex items-center gap-2 text-xs text-body">
-              <span className="text-accent">◈</span> main.js
-            </div>
-          </div>
-        </div>
-      </div>
-    </motion.div>
-  );
-}
-
-function SkillsMockup() {
-  return (
-    <motion.div
-      initial={{ opacity: 0, scale: 0.96 }}
-      whileInView={{ opacity: 1, scale: 1 }}
-      viewport={{ once: true }}
-      transition={{ duration: 0.6 }}
-      className="grid gap-4 sm:grid-cols-5"
-    >
-      <div className="overflow-hidden rounded-xl border border-hairline bg-surface p-4 shadow-xl sm:col-span-3">
-        <div className="mb-3 text-[10px] font-bold uppercase tracking-wider text-muted">Chat</div>
-        <div className="ml-auto max-w-[85%] rounded-lg bg-foreground px-3 py-2 text-xs text-background">
-          Install the GitHub skill
-        </div>
-        <div className="mt-2 max-w-[90%] rounded-lg border border-hairline bg-surface-doc px-3 py-2 text-xs text-body">
-          Installing...
-        </div>
-        <div className="mt-2 rounded-md bg-surface-dark p-2 font-mono text-[10px] text-on-dark">
-          npx skills add github --source https://...
-        </div>
-        <div className="mt-2 max-w-[90%] rounded-lg border border-hairline bg-surface-doc px-3 py-2 text-xs text-body">
-          GitHub skill is ready.
-        </div>
-      </div>
-
-      <div className="overflow-hidden rounded-xl border border-hairline bg-surface p-4 shadow-xl sm:col-span-2">
-        <div className="mb-3 text-[10px] font-bold uppercase tracking-wider text-muted">Skills</div>
-        <div className="space-y-3">
-          {["GitHub", "Figma", "Stripe"].map((skill) => (
-            <div key={skill} className="flex items-center justify-between">
-              <span className="text-sm text-body">{skill}</span>
-              <div className="h-5 w-9 rounded-full bg-accent p-0.5">
-                <div className="ml-auto h-4 w-4 rounded-full bg-on-accent" />
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </motion.div>
-  );
-}
-
-function MobileVoiceMockup() {
-  return (
-    <motion.div
-      initial={{ opacity: 0, scale: 0.96 }}
-      whileInView={{ opacity: 1, scale: 1 }}
-      viewport={{ once: true }}
-      transition={{ duration: 0.6 }}
-      className="flex justify-center"
-    >
-      <div className="relative w-56 rounded-[2.5rem] border-[6px] border-hairline bg-background p-3 shadow-2xl sm:w-64">
-        <div className="absolute left-1/2 top-0 h-6 w-24 -translate-x-1/2 rounded-b-xl bg-hairline" />
-        <div className="flex h-96 flex-col rounded-2xl bg-surface p-4">
-          <div className="text-center text-xs font-semibold text-muted">Riffpad</div>
-
-          <div className="mt-6 flex-1 space-y-3">
-            <div className="ml-auto max-w-[85%] rounded-2xl rounded-br-sm bg-foreground px-3 py-2 text-xs text-background">
-              Build a habit tracker app
-            </div>
-            <div className="max-w-[90%] rounded-2xl rounded-bl-sm border border-hairline bg-surface-doc px-3 py-2 text-xs text-body">
-              Got it. Creating the workspace now.
-            </div>
-            <div className="rounded-xl bg-surface-soft p-2">
-              <div className="h-24 rounded-lg bg-accent/10" />
-            </div>
-          </div>
-
-          <div className="flex flex-col items-center gap-2 py-4">
-            <div className="flex h-2 w-32 items-center justify-between">
-              {[...Array(5)].map((_, i) => (
-                <div
-                  key={i}
-                  className="w-1 rounded-full bg-accent"
-                  style={{ height: `${16 + Math.random() * 24}px` }}
-                />
-              ))}
-            </div>
-            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-accent shadow-lg">
-              <svg className="h-5 w-5 text-on-accent" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
-                <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
-                <line x1="12" y1="19" x2="12" y2="23" />
-              </svg>
-            </div>
-          </div>
-        </div>
-      </div>
-    </motion.div>
-  );
-}
-
-function ExportMockup() {
-  return (
-    <motion.div
-      initial={{ opacity: 0, scale: 0.96 }}
-      whileInView={{ opacity: 1, scale: 1 }}
-      viewport={{ once: true }}
-      transition={{ duration: 0.6 }}
-      className="rounded-xl border border-hairline bg-surface p-6 shadow-xl"
-    >
-      <div className="mb-4 text-[10px] font-bold uppercase tracking-wider text-muted">Export</div>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="rounded-lg border border-hairline bg-surface-doc p-5 transition hover:border-ash">
-          <div className="flex items-center gap-2">
-            <div className="flex h-8 w-8 items-center justify-center rounded-md bg-accent text-sm font-bold text-on-accent">P</div>
-            <div className="text-base font-bold text-foreground">Prompt package</div>
-          </div>
-          <p className="mt-2 text-sm text-body">Context + files + README for Cursor / Claude Code.</p>
-        </div>
-
-        <div className="rounded-lg border border-hairline bg-surface-doc p-5 transition hover:border-ash">
-          <div className="flex items-center gap-2">
-            <div className="flex h-8 w-8 items-center justify-center rounded-md bg-accent text-sm font-bold text-on-accent">Z</div>
-            <div className="text-base font-bold text-foreground">.zip skeleton</div>
-          </div>
-          <p className="mt-2 text-sm text-body">Clean project archive ready for any IDE.</p>
-        </div>
-      </div>
-    </motion.div>
   );
 }

--- a/apps/landing/components/Hero.tsx
+++ b/apps/landing/components/Hero.tsx
@@ -22,89 +22,43 @@ export function Hero() {
 
   return (
     <section className="bg-background px-4 pb-20 pt-16 sm:px-6 sm:pt-20 lg:px-8">
-      <div className="mx-auto max-w-6xl">
-        <div className="grid items-center gap-12 lg:grid-cols-2">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, ease: "easeOut" }}
-          >
-            <h1 className="text-4xl font-bold leading-tight text-foreground sm:text-5xl lg:text-[42px]">
-              {t.hero.h1}
-            </h1>
+      <div className="mx-auto max-w-3xl text-center">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: "easeOut" }}
+        >
+          <h1 className="text-4xl font-bold leading-tight text-foreground sm:text-5xl lg:text-[56px]">
+            {t.hero.h1}
+          </h1>
 
-            <p className="mt-5 text-lg text-body">{t.hero.description}</p>
+          <p className="mx-auto mt-5 max-w-2xl text-lg text-body sm:text-xl">{t.hero.description}</p>
 
-            <div className="mt-8 max-w-md">
-              <WaitlistForm />
-              <div className="mt-3 flex flex-wrap items-center gap-3">
-                <a
-                  href="https://discord.gg/CDNFTg2QyM"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 rounded-md border border-hairline bg-surface px-4 py-2 text-sm font-semibold text-body transition hover:border-ash hover:text-foreground"
-                >
-                  <Discord className="h-4 w-4" />
-                  {t.hero.contact.discord}
-                </a>
-                <button
-                  type="button"
-                  onClick={handleCopyEmail}
-                  className="inline-flex items-center gap-2 rounded-md border border-hairline bg-surface px-4 py-2 text-sm font-semibold text-body transition hover:border-ash hover:text-foreground"
-                >
-                  <Mail className="h-4 w-4" />
-                  {copied ? t.hero.contact.copied : t.hero.contact.email}
-                </button>
-              </div>
-              <p className="mt-3 text-sm text-muted">{t.hero.trust}</p>
+          <div className="mx-auto mt-8 max-w-md">
+            <WaitlistForm />
+            <div className="mt-3 flex flex-wrap items-center justify-center gap-3">
+              <a
+                href="https://discord.gg/CDNFTg2QyM"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-md border border-hairline bg-surface px-4 py-2 text-sm font-semibold text-body transition hover:border-ash hover:text-foreground"
+              >
+                <Discord className="h-4 w-4" />
+                {t.hero.contact.discord}
+              </a>
+              <button
+                type="button"
+                onClick={handleCopyEmail}
+                className="inline-flex items-center gap-2 rounded-md border border-hairline bg-surface px-4 py-2 text-sm font-semibold text-body transition hover:border-ash hover:text-foreground"
+              >
+                <Mail className="h-4 w-4" />
+                {copied ? t.hero.contact.copied : t.hero.contact.email}
+              </button>
             </div>
-          </motion.div>
-
-          <motion.div
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.7, delay: 0.15 }}
-            className="relative"
-          >
-            <ChatMockup />
-          </motion.div>
-        </div>
+            <p className="mt-3 text-sm text-muted">{t.hero.trust}</p>
+          </div>
+        </motion.div>
       </div>
     </section>
-  );
-}
-
-function ChatMockup() {
-  const { t } = useLanguage();
-
-  return (
-    <div className="overflow-hidden rounded-md border border-hairline bg-surface shadow-sm">
-      <div className="flex items-center justify-between border-b border-hairline-soft px-4 py-3">
-        <span className="text-sm font-semibold text-foreground">{t.hero.chat.title}</span>
-        <span className="h-2 w-2 rounded-full bg-accent-green" />
-      </div>
-      <div className="space-y-4 p-4">
-        <div className="flex justify-end">
-          <div className="max-w-[80%] rounded-2xl rounded-br-sm bg-foreground px-4 py-2.5 text-sm text-background">
-            {t.hero.chat.userMessage}
-          </div>
-        </div>
-        <div className="flex justify-start">
-          <div className="max-w-[90%] rounded-2xl rounded-bl-sm border border-hairline bg-surface-doc px-4 py-3 text-sm text-body">
-            <p>{t.hero.chat.assistantIntro}</p>
-            <div className="mt-2 rounded-md bg-surface-dark p-2 font-mono text-xs text-on-dark">
-              {t.hero.chat.codeSnippet}
-            </div>
-            <p className="mt-2">{t.hero.chat.assistantOutro}</p>
-          </div>
-        </div>
-      </div>
-      <div className="border-t border-hairline-soft px-4 py-3">
-        <div className="flex items-center gap-2 rounded-full border border-hairline bg-surface px-3 py-2">
-          <span className="text-sm text-muted">{t.hero.chat.inputPlaceholder}</span>
-          <span className="ml-auto text-xs text-accent">↵</span>
-        </div>
-      </div>
-    </div>
   );
 }

--- a/apps/landing/components/Icons.tsx
+++ b/apps/landing/components/Icons.tsx
@@ -123,3 +123,33 @@ export function Discord(props: SVGProps<SVGSVGElement>) {
   );
 }
 
+export function RefreshCw(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+      <path d="M21 3v5h-5" />
+      <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+      <path d="M8 21H3v-5" />
+    </svg>
+  );
+}
+
+export function Copy(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+      <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+    </svg>
+  );
+}
+
+export function MoreHorizontal(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <circle cx="12" cy="12" r="1" />
+      <circle cx="19" cy="12" r="1" />
+      <circle cx="5" cy="12" r="1" />
+    </svg>
+  );
+}
+

--- a/apps/landing/components/mockups/ExportMockup.tsx
+++ b/apps/landing/components/mockups/ExportMockup.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export function ExportMockup() {
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.96 }}
+      whileInView={{ opacity: 1, scale: 1 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+      className="rounded-xl border border-hairline bg-surface p-6 shadow-xl"
+    >
+      <div className="mb-4 text-[10px] font-bold uppercase tracking-wider text-muted">Export</div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="rounded-lg border border-hairline bg-surface-doc p-5 transition hover:border-ash">
+          <div className="flex items-center gap-2">
+            <div className="flex h-8 w-8 items-center justify-center rounded-md bg-accent text-sm font-bold text-on-accent">P</div>
+            <div className="text-base font-bold text-foreground">Prompt package</div>
+          </div>
+          <p className="mt-2 text-sm text-body">Context + files + README for Cursor / Claude Code.</p>
+        </div>
+
+        <div className="rounded-lg border border-hairline bg-surface-doc p-5 transition hover:border-ash">
+          <div className="flex items-center gap-2">
+            <div className="flex h-8 w-8 items-center justify-center rounded-md bg-accent text-sm font-bold text-on-accent">Z</div>
+            <div className="text-base font-bold text-foreground">.zip skeleton</div>
+          </div>
+          <p className="mt-2 text-sm text-body">Clean project archive ready for any IDE.</p>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/apps/landing/components/mockups/ExportMockup.tsx
+++ b/apps/landing/components/mockups/ExportMockup.tsx
@@ -2,33 +2,216 @@
 
 import { motion } from "framer-motion";
 
+const CLAUDE_PATH =
+  "M21 10.5h3v3h-3v3h-1.5v3H18v-3h-1.5v3H15v-3H9v3H7.5v-3H6v3H4.5v-3H3v-3H0v-3h3v-6h18Zm-15 0h1.5v-3H6Zm10.5 0H18v-3h-1.5z";
+
+const CURSOR_PATH =
+  "M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23";
+
+const OPENAI_PATH =
+  "M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.896zm16.597 3.855-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365 2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z";
+
+type NodeDef = {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  icon: React.ReactNode;
+};
+
+type EdgeDef = {
+  id: string;
+  d: string;
+};
+
+const edges: EdgeDef[] = [
+  { id: "riffpad-zip", d: "M 15 50 L 50 50 L 50 25" },
+  { id: "riffpad-prompt", d: "M 15 50 L 50 50 L 50 75" },
+  { id: "zip-claude", d: "M 50 25 L 85 25 L 85 15" },
+  { id: "zip-codex", d: "M 50 25 L 50 50 L 85 50" },
+  { id: "prompt-codex", d: "M 50 75 L 50 50 L 85 50" },
+  { id: "prompt-cursor", d: "M 50 75 L 85 75 L 85 85" },
+];
+
 export function ExportMockup() {
+  const nodes: NodeDef[] = [
+    {
+      id: "riffpad",
+      label: "Riffpad",
+      x: 15,
+      y: 50,
+      icon: <RiffpadIcon />,
+    },
+    {
+      id: "zip",
+      label: ".zip",
+      x: 50,
+      y: 25,
+      icon: <ZipIcon />,
+    },
+    {
+      id: "prompt",
+      label: "Prompt package",
+      x: 50,
+      y: 75,
+      icon: <PackageIcon />,
+    },
+    {
+      id: "claude",
+      label: "Claude Code",
+      x: 85,
+      y: 15,
+      icon: (
+        <svg width="6" height="6" viewBox="0 0 24 24" role="img" aria-label="Claude Code">
+          <path d={CLAUDE_PATH} fill="currentColor" />
+        </svg>
+      ),
+    },
+    {
+      id: "codex",
+      label: "Codex",
+      x: 85,
+      y: 50,
+      icon: <OpenAIIcon />,
+    },
+    {
+      id: "cursor",
+      label: "Cursor",
+      x: 85,
+      y: 85,
+      icon: (
+        <svg width="6" height="6" viewBox="0 0 24 24" role="img" aria-label="Cursor">
+          <path d={CURSOR_PATH} fill="currentColor" />
+        </svg>
+      ),
+    },
+  ];
+
   return (
     <motion.div
-      initial={{ opacity: 0, scale: 0.96 }}
-      whileInView={{ opacity: 1, scale: 1 }}
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
-      transition={{ duration: 0.6 }}
-      className="rounded-xl border border-hairline bg-surface p-6 shadow-xl"
+      transition={{ duration: 0.6, ease: "easeOut" }}
+      className="flex w-full flex-col items-center"
     >
-      <div className="mb-4 text-[10px] font-bold uppercase tracking-wider text-muted">Export</div>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="rounded-lg border border-hairline bg-surface-doc p-5 transition hover:border-ash">
-          <div className="flex items-center gap-2">
-            <div className="flex h-8 w-8 items-center justify-center rounded-md bg-accent text-sm font-bold text-on-accent">P</div>
-            <div className="text-base font-bold text-foreground">Prompt package</div>
-          </div>
-          <p className="mt-2 text-sm text-body">Context + files + README for Cursor / Claude Code.</p>
-        </div>
+      <div className="relative mx-auto aspect-square w-full max-w-sm sm:max-w-md">
+        <svg
+          className="absolute inset-0 h-full w-full overflow-visible"
+          viewBox="0 0 100 100"
+          preserveAspectRatio="xMidYMid meet"
+          aria-hidden="true"
+        >
+          {/* Connection lines */}
+          {edges.map((edge) => (
+            <path
+              key={edge.id}
+              d={edge.d}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="0.7"
+              strokeDasharray="3 3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              vectorEffect="non-scaling-stroke"
+              className="text-muted export-flow-line"
+            />
+          ))}
 
-        <div className="rounded-lg border border-hairline bg-surface-doc p-5 transition hover:border-ash">
-          <div className="flex items-center gap-2">
-            <div className="flex h-8 w-8 items-center justify-center rounded-md bg-accent text-sm font-bold text-on-accent">Z</div>
-            <div className="text-base font-bold text-foreground">.zip skeleton</div>
-          </div>
-          <p className="mt-2 text-sm text-body">Clean project archive ready for any IDE.</p>
-        </div>
+          {/* Nodes */}
+          {nodes.map((node, i) => (
+            <g key={node.id} transform={`translate(${node.x}, ${node.y})`}>
+              <motion.g
+                initial={{ opacity: 0 }}
+                whileInView={{ opacity: 1 }}
+                viewport={{ once: true }}
+                transition={{
+                  duration: 0.4,
+                  delay: 0.1 + i * 0.07,
+                  ease: "easeOut",
+                }}
+                className="text-foreground"
+              >
+                <circle r="4.5" fill="var(--background)" />
+                <g transform="translate(-3, -3)">{node.icon}</g>
+                <text
+                  y="8.5"
+                  fontSize="3.2"
+                  textAnchor="middle"
+                  fill="currentColor"
+                  className="font-sans font-semibold"
+                >
+                  {node.label}
+                </text>
+              </motion.g>
+            </g>
+          ))}
+        </svg>
       </div>
     </motion.div>
+  );
+}
+
+function RiffpadIcon() {
+  return (
+    <svg width="6" height="6" viewBox="0 0 6 6">
+      <title>Riffpad</title>
+      <image
+        href="/rounded_rect_rotated_shapes_only_favicon.png"
+        width="6"
+        height="6"
+        preserveAspectRatio="xMidYMid meet"
+        className="riffpad-logo-white"
+      />
+    </svg>
+  );
+}
+
+function ZipIcon() {
+  return (
+    <svg
+      width="6"
+      height="6"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
+      <polyline points="14 2 14 8 20 8" />
+      <path d="M8 12v-1" />
+      <path d="M8 16v-1" />
+      <path d="M8 20v-1" />
+    </svg>
+  );
+}
+
+function PackageIcon() {
+  return (
+    <svg
+      width="6"
+      height="6"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m7.5 4.27 9 5.15" />
+      <path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z" />
+      <path d="m3.3 7 8.7 5 8.7-5" />
+      <path d="M12 22V12" />
+    </svg>
+  );
+}
+
+function OpenAIIcon() {
+  return (
+    <svg width="6" height="6" viewBox="0 0 24 24" role="img" aria-label="OpenAI" fill="currentColor">
+      <path d={OPENAI_PATH} />
+    </svg>
   );
 }

--- a/apps/landing/components/mockups/MobileVoiceMockup.tsx
+++ b/apps/landing/components/mockups/MobileVoiceMockup.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { motion } from "framer-motion";
+import { DeviceFrameset } from "react-device-frameset";
+import "react-device-frameset/styles/marvel-devices.min.css";
+import { useLanguage } from "../LanguageProvider";
+import { RefreshCw, Copy, MoreHorizontal } from "../Icons";
+
+export function MobileVoiceMockup() {
+  const { t } = useLanguage();
+  const s = t.saasWorkspace;
+  const m = t.mobileWorkspace;
+  const [typedText, setTypedText] = useState("");
+  const [waveHeights, setWaveHeights] = useState<number[]>(() =>
+    Array(32).fill(3)
+  );
+
+  useEffect(() => {
+    let rafId: number;
+    let lastTime = 0;
+
+    const tick = (time: number) => {
+      if (time - lastTime < 16) {
+        rafId = requestAnimationFrame(tick);
+        return;
+      }
+      lastTime = time;
+
+      const now = time / 1000;
+      const envelope = speechEnvelope(now);
+
+      setWaveHeights(
+        Array.from({ length: 32 }, (_, i) => {
+          const spatial = i * 0.35;
+          const slow = noise(spatial + now * 1.4) * 0.5 + 0.5;
+          const fast = Math.abs(noise(spatial * 1.4 + now * 7.5));
+          const burst = Math.abs(noise(spatial * 2.1 - now * 9.0));
+          const value =
+            0.08 + envelope * (0.22 * slow + 0.5 * fast + 0.28 * burst);
+          return Math.min(38, 3 + value * 36);
+        })
+      );
+
+      rafId = requestAnimationFrame(tick);
+    };
+
+    rafId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafId);
+  }, []);
+
+  useEffect(() => {
+    const text = m.voiceText;
+    let index = 0;
+    let direction = 1;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const tick = () => {
+      if (direction === 1) {
+        if (index < text.length) {
+          index += 1;
+          setTypedText(text.slice(0, index));
+          timer = setTimeout(tick, 80);
+        } else {
+          timer = setTimeout(() => {
+            direction = -1;
+            tick();
+          }, 1500);
+        }
+      } else {
+        if (index > 0) {
+          index -= 1;
+          setTypedText(text.slice(0, index));
+          timer = setTimeout(tick, 50);
+        } else {
+          timer = setTimeout(() => {
+            direction = 1;
+            tick();
+          }, 800);
+        }
+      }
+    };
+
+    tick();
+    return () => clearTimeout(timer);
+  }, [m.voiceText]);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.96 }}
+      whileInView={{ opacity: 1, scale: 1 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+      className="flex justify-center"
+    >
+      <DeviceFrameset device="iPhone X" color="black" zoom={0.85}>
+        <div className="flex h-full flex-col overflow-hidden bg-surface">
+          {/* Workspace header */}
+          <div className="flex items-center justify-between border-b border-hairline bg-surface px-4 py-3">
+            <button
+              type="button"
+              className="flex h-8 w-8 items-center justify-center rounded-md text-muted transition hover:bg-surface-soft hover:text-foreground"
+            >
+              <MenuIcon className="h-4 w-4" />
+            </button>
+            <div className="flex flex-col items-center">
+              <span className="text-sm font-semibold text-foreground">
+                {m.workspaceName}
+              </span>
+              <span className="text-xs text-muted">{m.workspaceLabel}</span>
+            </div>
+            <div className="h-8 w-8" />
+          </div>
+
+          {/* Chat content */}
+          <div className="hide-scrollbar flex-1 space-y-6 overflow-auto p-4">
+            {/* Round 1 — from SaaS workspace mockup */}
+            <div className="space-y-3">
+              <div className="flex justify-end">
+                <div className="max-w-[90%] rounded-2xl rounded-br-sm border border-hairline bg-surface-doc px-4 py-2.5 text-sm text-body">
+                  {s.userMessage}
+                </div>
+              </div>
+
+              <div className="flex flex-col items-start gap-2.5">
+                <StatusLine label={s.stepThinking} />
+                <StatusLine label={s.stepSearch} />
+                <StatusLine label={s.stepWrite} />
+              </div>
+
+              <div className="text-sm leading-relaxed text-body">
+                <span className="text-muted">{s.assistantReply}</span>{" "}
+                <span className="font-mono font-semibold text-foreground">
+                  {s.filesContent.analysis.name}
+                </span>
+                <span className="text-muted">{s.assistantReplySuffix}</span>
+                <MessageActions />
+              </div>
+            </div>
+
+            {/* Round 2 — mobile voice follow-up */}
+            <div className="space-y-3">
+              <div className="flex justify-end">
+                <div className="max-w-[90%] rounded-2xl rounded-br-sm border border-hairline bg-surface-doc px-4 py-2.5 text-sm text-body">
+                  {m.userMessage}
+                </div>
+              </div>
+
+              <div className="flex flex-col items-start gap-2.5">
+                <StatusLine label={m.stepRead} />
+                <StatusLine label={m.stepSearch} />
+                <StatusLine label={m.stepWrite} />
+              </div>
+
+              <div className="text-sm leading-relaxed text-body">
+                <span className="text-muted">{m.assistantReply}</span>{" "}
+                <span className="font-mono font-semibold text-foreground">
+                  {m.assistantReplyName}
+                </span>
+                <span className="text-muted">{m.assistantReplySuffix}</span>
+                <MessageActions />
+              </div>
+            </div>
+          </div>
+
+          {/* Voice input area */}
+          <div className="flex flex-col items-center gap-3 px-4 pb-6 pt-2">
+            <div className="min-h-[2.25rem] text-center">
+              <span className="text-base font-medium text-foreground">
+                {typedText}
+              </span>
+              <motion.span
+                animate={{ opacity: [1, 0, 1] }}
+                transition={{ repeat: Infinity, duration: 1 }}
+                className="ml-0.5 inline-block h-5 w-0.5 bg-accent"
+              />
+            </div>
+
+            <span className="text-xs font-medium uppercase tracking-wider text-muted">
+              {m.listening}
+            </span>
+
+            <div className="flex h-10 w-full items-end justify-between gap-0.5 px-2">
+              {waveHeights.map((h, i) => (
+                <motion.div
+                  key={i}
+                  className="flex-1 rounded-[1px] bg-accent"
+                  animate={{ height: h }}
+                  transition={{ duration: 0.05, ease: "linear" }}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </DeviceFrameset>
+    </motion.div>
+  );
+}
+
+function StatusLine({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2 text-sm text-muted">
+      <span className="h-1.5 w-1.5 rounded-full bg-accent" />
+      {label}
+    </div>
+  );
+}
+
+function MenuIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      viewBox="0 0 24 24"
+    >
+      <line x1="4" x2="20" y1="6" y2="6" />
+      <line x1="4" x2="20" y1="12" y2="12" />
+      <line x1="4" x2="20" y1="18" y2="18" />
+    </svg>
+  );
+}
+
+function noise(x: number) {
+  return (
+    Math.sin(x) * 0.5 +
+    Math.sin(x * 2.1 + 1.3) * 0.25 +
+    Math.sin(x * 4.7 + 0.7) * 0.125 +
+    Math.sin(x * 8.3 + 2.1) * 0.06
+  );
+}
+
+function speechEnvelope(t: number) {
+  const phrase = (Math.sin(t * 0.45) + 1) / 2;
+  const word = Math.max(0, Math.sin(t * 2.3 + Math.sin(t * 0.9) * 1.5));
+  const syllable = Math.max(0, Math.sin(t * 7.0) * Math.sin(t * 3.2));
+  return Math.min(1, phrase * 0.35 + word * 0.55 + syllable * 0.25);
+}
+
+function MessageActions() {
+  return (
+    <div className="mt-2 flex items-center gap-0.5">
+      <button
+        type="button"
+        className="flex h-6 w-6 items-center justify-center rounded-md text-muted transition hover:bg-surface-soft hover:text-foreground"
+        aria-label="Regenerate"
+      >
+        <RefreshCw className="h-3 w-3" />
+      </button>
+      <button
+        type="button"
+        className="flex h-6 w-6 items-center justify-center rounded-md text-muted transition hover:bg-surface-soft hover:text-foreground"
+        aria-label="Copy"
+      >
+        <Copy className="h-3 w-3" />
+      </button>
+      <button
+        type="button"
+        className="flex h-6 w-6 items-center justify-center rounded-md text-muted transition hover:bg-surface-soft hover:text-foreground"
+        aria-label="More"
+      >
+        <MoreHorizontal className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/apps/landing/components/mockups/SaasWorkspaceMockup.tsx
+++ b/apps/landing/components/mockups/SaasWorkspaceMockup.tsx
@@ -1,0 +1,446 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { motion } from "framer-motion";
+import { ChevronDown, X, RefreshCw, Copy, MoreHorizontal } from "../Icons";
+import { useLanguage } from "../LanguageProvider";
+import { Logo } from "../Logo";
+
+export function SaasWorkspaceMockup() {
+  const { t } = useLanguage();
+  const s = t.saasWorkspace;
+
+  const files = useMemo(
+    (): Record<string, { type: "md"; name: string; content: string }> => ({
+      "docs/prd.md": {
+        type: "md",
+        name: s.filesContent.prd.name,
+        content: s.filesContent.prd.content,
+      },
+      "docs/competitive-analysis.md": {
+        type: "md",
+        name: s.filesContent.analysis.name,
+        content: s.filesContent.analysis.content,
+      },
+    }),
+    [s]
+  );
+
+  const [docsOpen, setDocsOpen] = useState(true);
+  const [openTabs, setOpenTabs] = useState<string[]>([
+    "docs/competitive-analysis.md",
+    "docs/prd.md",
+  ]);
+  const [activeTab, setActiveTab] = useState<string | null>(
+    "docs/competitive-analysis.md"
+  );
+  const [view, setView] = useState<"editor" | "preview">("preview");
+
+  const activeFile = activeTab ? files[activeTab] : null;
+
+  const openFile = (path: string) => {
+    setOpenTabs((tabs) => (tabs.includes(path) ? tabs : [...tabs, path]));
+    setActiveTab(path);
+  };
+
+  const closeTab = (path: string) => {
+    setOpenTabs((tabs) => {
+      const idx = tabs.indexOf(path);
+      const next = tabs.filter((p) => p !== path);
+      if (activeTab === path) {
+        const nextActive = next[idx] ?? next[idx - 1] ?? next[0] ?? null;
+        setActiveTab(nextActive);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-6xl overflow-hidden rounded-xl border border-hairline bg-surface shadow-2xl">
+      {/* App header — mac traffic lights only */}
+      <div className="flex items-center gap-2 border-b border-hairline bg-surface-soft px-4 py-3">
+        <span className="h-3 w-3 rounded-full bg-[#ff5f57] ring-1 ring-inset ring-black/5" />
+        <span className="h-3 w-3 rounded-full bg-[#febc2e] ring-1 ring-inset ring-black/5" />
+        <span className="h-3 w-3 rounded-full bg-[#28c840] ring-1 ring-inset ring-black/5" />
+      </div>
+
+      <div className="flex h-[560px] flex-col sm:flex-row">
+        {/* Files pane */}
+        <div className="flex w-full flex-col border-b border-hairline bg-surface sm:w-56 sm:border-b-0 sm:border-r">
+          <div className="border-b border-hairline px-3 py-2 text-[10px] font-bold uppercase tracking-wider text-muted">
+            {s.files}
+          </div>
+          <div className="flex-1 overflow-auto p-3">
+            <button
+              onClick={() => setDocsOpen((v) => !v)}
+              className="flex w-full items-center gap-1.5 text-left text-sm font-semibold text-foreground transition hover:text-accent"
+            >
+              <ChevronDown
+                className={`h-3.5 w-3.5 text-muted transition ${
+                  docsOpen ? "" : "-rotate-90"
+                }`}
+              />
+              <FolderIcon />
+              {s.docs}
+            </button>
+
+            <motion.div
+              initial={false}
+              animate={{
+                height: docsOpen ? "auto" : 0,
+                opacity: docsOpen ? 1 : 0,
+              }}
+              className="overflow-hidden"
+            >
+              <div className="mt-1 space-y-0.5 border-l border-hairline-soft pl-5">
+                <FileButton
+                  name={files["docs/prd.md"].name}
+                  active={activeTab === "docs/prd.md"}
+                  onClick={() => openFile("docs/prd.md")}
+                />
+                <FileButton
+                  name={files["docs/competitive-analysis.md"].name}
+                  active={activeTab === "docs/competitive-analysis.md"}
+                  onClick={() => openFile("docs/competitive-analysis.md")}
+                />
+              </div>
+            </motion.div>
+          </div>
+        </div>
+
+        {/* Editor / Preview pane */}
+        <div className="flex flex-1 flex-col border-b border-hairline bg-surface sm:border-b-0 sm:border-r">
+          {/* IDE-style tabs */}
+          <div className="flex items-center justify-between border-b border-hairline bg-surface-soft">
+            <div className="flex flex-1 items-end overflow-x-auto">
+              {openTabs.map((path) => {
+                const file = files[path];
+                const isActive = activeTab === path;
+                return (
+                  <button
+                    key={path}
+                    onClick={() => setActiveTab(path)}
+                    className={`group relative flex min-w-0 max-w-[160px] items-center gap-2 border-r border-hairline px-3 py-2 text-xs transition ${
+                      isActive
+                        ? "bg-surface font-semibold text-foreground"
+                        : "bg-surface-soft text-body hover:bg-surface"
+                    }`}
+                  >
+                    <FileIcon className="h-3.5 w-3.5 flex-shrink-0 text-muted" />
+                    <span className="truncate">{file?.name ?? path}</span>
+                    <span
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        closeTab(path);
+                      }}
+                      className={`ml-1 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded transition ${
+                        isActive
+                          ? "text-muted hover:bg-hairline hover:text-foreground"
+                          : "text-muted/60 opacity-0 group-hover:opacity-100 hover:bg-hairline hover:text-foreground"
+                      }`}
+                    >
+                      <X className="h-3 w-3" />
+                    </span>
+                    {isActive && (
+                      <span className="absolute bottom-0 left-0 right-0 h-[1px] bg-surface" />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Editor / Preview icon toggle */}
+            <button
+              onClick={() => setView((v) => (v === "editor" ? "preview" : "editor"))}
+              className="flex-shrink-0 p-2 text-muted transition hover:text-foreground"
+              title={view === "editor" ? s.preview : s.editor}
+            >
+              {view === "editor" ? (
+                <EyeIcon className="h-4 w-4" />
+              ) : (
+                <CodeIcon className="h-4 w-4" />
+              )}
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-auto bg-surface-doc">
+            {activeFile ? (
+              view === "editor" ? (
+                <MarkdownEditor content={activeFile.content} />
+              ) : (
+                <div className="p-5">
+                  <MarkdownPreview content={activeFile.content} />
+                </div>
+              )
+            ) : (
+              <div className="flex h-full flex-col items-center justify-center gap-3 text-muted">
+                <Logo className="h-16 w-16 opacity-20 grayscale" />
+                <p className="text-sm">{s.empty}</p>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Chat pane */}
+        <div className="flex flex-1 flex-col bg-surface">
+          <div className="border-b border-hairline px-4 py-2 text-[10px] font-bold uppercase tracking-wider text-muted">
+            {s.chat}
+          </div>
+
+          <div className="flex-1 space-y-5 overflow-auto p-4 text-sm">
+            <motion.div
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.2 }}
+              className="text-foreground"
+            >
+              <span className="mb-1 block text-[10px] font-bold uppercase tracking-wider text-muted">
+                You
+              </span>
+              {s.userMessage}
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.5 }}
+              className="space-y-2"
+            >
+              <span className="block text-[10px] font-bold uppercase tracking-wider text-muted">
+                Agent
+              </span>
+              <StepDot label={s.stepThinking} />
+              <StepDot label={s.stepSearch} />
+              <StepDot label={s.stepWrite} />
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 2.1 }}
+              className="text-body"
+            >
+              <p className="text-sm leading-relaxed">
+                {s.assistantReply}{" "}
+                <span className="font-mono font-semibold text-foreground">
+                  {files["docs/competitive-analysis.md"].name}
+                </span>
+                {s.assistantReplySuffix}
+              </p>
+              <MessageActions />
+            </motion.div>
+          </div>
+
+          <div className="px-4 py-3">
+            <div className="flex items-center gap-2 rounded-full border border-hairline bg-surface px-3 py-2">
+              <span className="text-sm text-muted">{s.inputPlaceholder}</span>
+              <button
+                type="button"
+                className="ml-auto flex h-7 w-7 items-center justify-center rounded-full bg-accent text-on-accent transition hover:opacity-90"
+              >
+                <ArrowUpIcon className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FileButton({
+  name,
+  active,
+  onClick,
+}: {
+  name: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-left text-xs transition ${
+        active
+          ? "bg-accent/10 font-semibold text-foreground"
+          : "text-body hover:bg-surface-soft hover:text-foreground"
+      }`}
+    >
+      <FileIcon className="h-3.5 w-3.5 text-muted" />
+      {name}
+    </button>
+  );
+}
+
+function StepDot({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2 text-xs text-muted">
+      <span className="h-1.5 w-1.5 rounded-full bg-accent" />
+      {label}
+    </div>
+  );
+}
+
+function FolderIcon() {
+  return (
+    <svg
+      className="h-4 w-4 text-accent"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 2H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
+    </svg>
+  );
+}
+
+function FileIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+    >
+      <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
+      <polyline points="14 2 14 8 20 8" />
+    </svg>
+  );
+}
+
+function CodeIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      viewBox="0 0 24 24"
+    >
+      <polyline points="16 18 22 12 16 6" />
+      <polyline points="8 6 2 12 8 18" />
+    </svg>
+  );
+}
+
+function EyeIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      viewBox="0 0 24 24"
+    >
+      <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+function ArrowUpIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      viewBox="0 0 24 24"
+    >
+      <path d="M12 19V5" />
+      <path d="m5 12 7-7 7 7" />
+    </svg>
+  );
+}
+
+function MarkdownEditor({ content }: { content: string }) {
+  const lines = content.split("\n");
+  return (
+    <div className="flex min-h-full font-mono text-xs leading-6">
+      <div className="select-none border-r border-hairline bg-surface-soft px-3 py-4 text-right text-muted">
+        {lines.map((_, i) => (
+          <div key={i}>{i + 1}</div>
+        ))}
+      </div>
+      <div className="flex-1 whitespace-pre-wrap p-4 text-body">{content}</div>
+    </div>
+  );
+}
+
+function MarkdownPreview({ content }: { content: string }) {
+  return (
+    <div className="prose prose-sm max-w-none text-body">
+      {content.split("\n").map((line, i) => {
+        const trimmed = line.trim();
+        if (!trimmed) return <div key={i} className="h-3" />;
+        if (trimmed.startsWith("# ")) {
+          return (
+            <h1 key={i} className="mb-2 mt-4 text-xl font-bold text-foreground">
+              {trimmed.slice(2)}
+            </h1>
+          );
+        }
+        if (trimmed.startsWith("## ")) {
+          return (
+            <h2 key={i} className="mb-2 mt-4 text-base font-bold text-foreground">
+              {trimmed.slice(3)}
+            </h2>
+          );
+        }
+        if (trimmed.startsWith("- ")) {
+          return (
+            <li key={i} className="ml-4 list-disc text-sm">
+              {trimmed.slice(2)}
+            </li>
+          );
+        }
+        if (/^\d+\.\s/.test(trimmed)) {
+          return (
+            <li key={i} className="ml-4 list-decimal text-sm">
+              {trimmed.replace(/^\d+\.\s/, "")}
+            </li>
+          );
+        }
+        return (
+          <p key={i} className="text-sm leading-relaxed">
+            {trimmed}
+          </p>
+        );
+      })}
+    </div>
+  );
+}
+
+function MessageActions() {
+  return (
+    <div className="mt-2 flex items-center gap-1">
+      <button
+        type="button"
+        className="flex h-7 w-7 items-center justify-center rounded-md text-muted transition hover:bg-surface-soft hover:text-foreground"
+        aria-label="Regenerate"
+      >
+        <RefreshCw className="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        className="flex h-7 w-7 items-center justify-center rounded-md text-muted transition hover:bg-surface-soft hover:text-foreground"
+        aria-label="Copy"
+      >
+        <Copy className="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        className="flex h-7 w-7 items-center justify-center rounded-md text-muted transition hover:bg-surface-soft hover:text-foreground"
+        aria-label="More"
+      >
+        <MoreHorizontal className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/apps/landing/components/mockups/SkillsMockup.tsx
+++ b/apps/landing/components/mockups/SkillsMockup.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { useLanguage } from "../LanguageProvider";
+
+const mcpServersData = [
+  {
+    id: "github",
+    name: "GitHub",
+    desc: "Sync repos, issues and pull requests",
+    status: "connected",
+  },
+  {
+    id: "linear",
+    name: "Linear",
+    desc: "Connect project issues and cycles",
+    status: "connected",
+  },
+  {
+    id: "notion",
+    name: "Notion",
+    desc: "Read and write Notion pages",
+    status: "disconnected",
+  },
+];
+
+export function SkillsMockup() {
+  const { t } = useLanguage();
+  const s = t.skillsMockup;
+  const [activeSetting, setActiveSetting] = useState<"skills" | "mcp">("skills");
+  const [skills, setSkills] = useState([
+    {
+      id: "frontend-design",
+      name: "frontend-design",
+      desc: "Generate polished frontend interfaces",
+      active: true,
+    },
+    {
+      id: "ppt-generation",
+      name: "ppt-generation",
+      desc: "Create presentation decks from text",
+      active: true,
+    },
+    {
+      id: "docx",
+      name: "docx",
+      desc: "Generate and edit Word documents",
+      active: false,
+    },
+  ]);
+
+  const toggleSkill = (id: string) => {
+    setSkills((prev) =>
+      prev.map((skill) =>
+        skill.id === id ? { ...skill, active: !skill.active } : skill
+      )
+    );
+  };
+
+  const [mcpServers, setMcpServers] = useState(mcpServersData);
+
+  const toggleMcp = (id: string) => {
+    setMcpServers((prev) =>
+      prev.map((server) =>
+        server.id === id
+          ? {
+              ...server,
+              status:
+                server.status === "connected" ? "disconnected" : "connected",
+            }
+          : server
+      )
+    );
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.96 }}
+      whileInView={{ opacity: 1, scale: 1 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+      className="grid w-full grid-cols-1 gap-4 lg:grid-cols-[1fr_2fr]"
+    >
+      {/* Settings pane */}
+      <div className="flex min-h-[320px] overflow-hidden rounded-xl border border-hairline bg-surface shadow-xl">
+        {/* Sidebar */}
+        <div className="flex w-12 flex-col border-r border-hairline bg-surface-soft py-2">
+          <button
+            onClick={() => setActiveSetting("skills")}
+            className={`px-2 py-4 text-[10px] font-semibold leading-tight transition ${
+              activeSetting === "skills"
+                ? "text-foreground"
+                : "text-muted hover:text-foreground"
+            }`}
+          >
+            Skills
+          </button>
+          <button
+            onClick={() => setActiveSetting("mcp")}
+            className={`px-2 py-4 text-[10px] font-semibold leading-tight transition ${
+              activeSetting === "mcp"
+                ? "text-foreground"
+                : "text-muted hover:text-foreground"
+            }`}
+          >
+            MCP
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-auto p-4">
+          {activeSetting === "skills" ? (
+            <div className="space-y-3">
+              <div className="mb-3 text-[10px] font-bold uppercase tracking-wider text-muted">
+                Skills
+              </div>
+              {skills.map((skill) => (
+                <div
+                  key={skill.id}
+                  className="flex min-h-[78px] flex-col justify-between rounded-lg border border-hairline bg-surface-doc p-3"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-semibold text-foreground">
+                      {skill.name}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => toggleSkill(skill.id)}
+                      className={`h-5 w-9 rounded-full border p-0.5 transition ${
+                        skill.active
+                          ? "border-transparent bg-accent"
+                          : "border-hairline bg-surface-soft"
+                      }`}
+                    >
+                      <motion.div
+                        initial={false}
+                        animate={{ x: skill.active ? 16 : 0 }}
+                        transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                        className={`h-4 w-4 rounded-full shadow-sm ${
+                          skill.active ? "bg-surface" : "bg-muted"
+                        }`}
+                      />
+                    </button>
+                  </div>
+                  <p className="mt-1 text-[10px] leading-relaxed text-muted">
+                    {skill.desc}
+                  </p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <div className="mb-3 text-[10px] font-bold uppercase tracking-wider text-muted">
+                MCP
+              </div>
+              {mcpServers.map((server) => (
+                <div
+                  key={server.id}
+                  className="flex min-h-[78px] flex-col justify-between rounded-lg border border-hairline bg-surface-doc p-3"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-semibold text-foreground">
+                      {server.name}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => toggleMcp(server.id)}
+                      className={`rounded-full px-2.5 py-1 text-[10px] font-semibold transition ${
+                        server.status === "connected"
+                          ? "bg-accent-green/10 text-accent-green"
+                          : "bg-surface-soft text-muted hover:text-foreground"
+                      }`}
+                    >
+                      {server.status === "connected"
+                        ? "Connected"
+                        : "Connect"}
+                    </button>
+                  </div>
+                  <p className="mt-1 text-[10px] leading-relaxed text-muted">
+                    {server.desc}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Chat pane */}
+      <div className="flex flex-col overflow-hidden">
+        <div className="flex-1 space-y-4 overflow-auto p-4 text-sm">
+          <div className="flex justify-end">
+            <div className="max-w-[85%] rounded-2xl rounded-br-sm border border-hairline bg-surface-doc px-4 py-2.5 text-xs text-body">
+              <div>{s.userMessageShort}...</div>
+              <div className="mt-0.5 cursor-pointer text-[10px] text-muted transition hover:text-foreground">
+                {s.showMore}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col items-start gap-2">
+            <StatusLine label={s.thinking} />
+            <StatusLine label={`${s.runCommandLabel}: ${s.runCommand}`} />
+          </div>
+
+          <div className="text-xs text-body">
+            {s.assistantReply}{" "}
+            <span className="font-mono font-semibold text-foreground">
+              {s.assistantReplyName}
+            </span>{" "}
+            {s.assistantReplySuffix}
+          </div>
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+function StatusLine({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2 text-xs text-muted">
+      <span className="h-1.5 w-1.5 rounded-full bg-accent" />
+      {label}
+    </div>
+  );
+}

--- a/apps/landing/components/mockups/index.ts
+++ b/apps/landing/components/mockups/index.ts
@@ -1,0 +1,4 @@
+export { SkillsMockup } from "./SkillsMockup";
+export { MobileVoiceMockup } from "./MobileVoiceMockup";
+export { ExportMockup } from "./ExportMockup";
+export { SaasWorkspaceMockup } from "./SaasWorkspaceMockup";

--- a/apps/landing/lib/i18n.ts
+++ b/apps/landing/lib/i18n.ts
@@ -33,6 +33,105 @@ export const messages = {
       placeholder: "you@example.com",
       success: "Thanks! You're on the list.",
     },
+    saasWorkspace: {
+      files: "Files",
+      docs: "docs",
+      editor: "Editor",
+      preview: "Preview",
+      empty: "Select a file",
+      chat: "Chat",
+      userMessage: "Do a competitive analysis for cloud AI Agent products.",
+      stepThinking: "Thinking...",
+      stepSearch: "Web search: AI coding tools 2026",
+      stepWrite: "Write file: docs/competitive-analysis.md",
+      assistantReply: "Written",
+      assistantReplySuffix: "with 11 competitor profiles, market data, and strategic recommendations.",
+      inputPlaceholder: "Describe your idea...",
+      filesContent: {
+        prd: {
+          name: "prd.md",
+          content: `# Riffpad PRD
+
+## Positioning
+AI-native code sketchbook. Capture inspiration anywhere and turn a sentence into a running workspace.
+
+## Core Flow
+1. Describe an idea in plain language.
+2. Agent builds files and starts a sandbox preview.
+3. Validate, then bridge to Cursor / Claude Code.
+`,
+        },
+        analysis: {
+          name: "competitive-analysis.md",
+          content: `# Competitive Analysis
+
+## Market
+- 84% of developers use or plan to use AI tools.
+- 62% cite context window as the biggest pain point.
+
+## Competitors
+1. ChatGPT / Gemini — chat-first, no running workspace.
+2. Cursor / Claude Code — heavy, local-first IDE agents.
+3. v0 / Bolt / Lovable — prompt-to-app builders with platform lock-in.
+
+## Riffpad's gap
+Upstream incubator: lighter than an IDE, more structured than chat, more open than app builders.
+`,
+        },
+      },
+    },
+    skillsMockup: {
+      chat: "Chat",
+      you: "You",
+      agent: "Agent",
+      userMessageShort: "install this agent skill for me",
+      showMore: "show more",
+      userMessage: `Install this Agent Skill for me.
+
+Skill page: https://skillsmp.com/creators/anthropics/skills/skills-frontend-design
+Source URL: https://github.com/anthropics/skills/tree/main/skills/frontend-design
+Skill name: frontend-design
+Creator: anthropics
+Preferred install command: npx skills add https://github.com/anthropics/skills --skill frontend-design
+
+Please open the skill page and source, review SKILL.md plus any companion files, and explain anything risky before installing.
+
+If shell commands are available, prefer the install command above. If you install manually, copy the complete skill directory that contains SKILL.md, including scripts, references, assets, agents, and any other files shown on the skill page. Preserve the relative folder structure. Do not install SKILL.md alone. After installing, verify the target skills folder contains SKILL.md and all companion files needed by this skill.`,
+      agentStep: "Running command: npx skills add https://github.com/anthropics/skills --skill frontend-design",
+      thinking: "Thinking...",
+      runCommandLabel: "Run command",
+      runCommand: "npx skills add https://github.com/anthropics/skills --skill frontend-design",
+      assistantReply: "Skill",
+      assistantReplyName: "frontend-design",
+      assistantReplySuffix: "has been installed successfully.",
+      inputPlaceholder: "Describe your idea...",
+    },
+    mobileWorkspace: {
+      workspaceName: "amber-spark-9",
+      workspaceLabel: "workspace",
+      userMessage: "Add a comparison between Cursor and Claude Code.",
+      stepRead: "Reading docs/competitive-analysis.md",
+      stepSearch: "Web search: Cursor vs Claude Code 2026",
+      stepWrite: "Write file: docs/competitive-analysis.md",
+      filesTitle: "Files",
+      prdFile: "prd.md",
+      analysisFile: "competitive-analysis.md",
+      assistantReply: "Updated",
+      assistantReplyName: "competitive-analysis.md",
+      assistantReplySuffix:
+        "with a new comparison of Cursor and Claude Code across local-first setup, cloud sync, and engineering scenarios.",
+      previewTitle: "Preview",
+      previewType: "Markdown",
+      previewHeading: "Cursor / Claude Code",
+      previewPoints: [
+        "Local-first IDE agent",
+        "Requires repo & environment setup",
+        "Best for heavy engineering",
+      ],
+      voiceText: "Add a comparison between Cursor and Claude Code",
+      listening: "Listening...",
+      holdToSpeak: "Hold to speak",
+    },
     features: {
       eyebrow: "What Riffpad does",
       title: "A cloud AI Agent in your pocket",
@@ -40,14 +139,9 @@ export const messages = {
         "No installs, no setup, no scattered chat threads. Describe what you want and get a running workspace with files, preview, and an agent.",
       blocks: [
         {
-          title: "Lightweight AI Agent, instant start",
+          title: "Skills + MCP, extend on demand",
           description:
-            "Spin up a sandbox in seconds. Chat on the left, code and preview in the middle, file tree on the right — a focused, agent-first workspace.",
-        },
-        {
-          title: "Install Skills in one sentence",
-          description:
-            "Extend the agent with Skills. Ask to add a capability, watch the command run, then toggle Skills on or off from the settings panel.",
+            "Install Skills and connect MCP servers to give the agent real capabilities — from generating polished frontends and documents to syncing with GitHub, Linear, and Notion.",
         },
         {
           title: "Use Riffpad anywhere",
@@ -315,6 +409,95 @@ export const messages = {
       placeholder: "you@example.com",
       success: "已收到！你在列表里了。",
     },
+    saasWorkspace: {
+      files: "文件",
+      docs: "docs",
+      editor: "编辑",
+      preview: "预览",
+      empty: "选择文件以查看",
+      chat: "对话",
+      userMessage: "帮我做一个云端 AI Agent 产品的调研分析",
+      stepThinking: "思考中...",
+      stepSearch: "网页搜索：AI 编程工具 2026",
+      stepWrite: "写入文件：docs/competitive-analysis.md",
+      assistantReply: "已写入",
+      assistantReplySuffix: "，包含 11 个竞品画像、市场数据和策略建议。",
+      inputPlaceholder: "描述你的想法...",
+      filesContent: {
+        prd: {
+          name: "prd.md",
+          content: `# Riffpad 产品需求文档
+
+## 定位
+AI 原生代码速写本。随时随地捕捉灵感，把一句话变成可运行的工作空间。
+
+## 核心流程
+1. 用自然语言描述想法。
+2. Agent 生成文件并启动沙箱预览。
+3. 验证后桥接到 Cursor / Claude Code。
+`,
+        },
+        analysis: {
+          name: "competitive-analysis.md",
+          content: `# 竞品调研分析
+
+## 市场
+- 84% 的开发者正在使用或计划使用 AI 工具。
+- 62% 的开发者认为上下文窗口是最大的痛点。
+
+## 竞品
+1. ChatGPT / Gemini —— 以聊天为主，没有可运行工作空间。
+2. Cursor / Claude Code —— 重型、本地优先的 IDE Agent。
+3. v0 / Bolt / Lovable —— 一句话生成应用，但平台锁定严重。
+
+## Riffpad 的差异化
+上游孵化器：比 IDE 更轻，比聊天更有结构，比应用生成器更开放。
+`,
+        },
+      },
+    },
+    skillsMockup: {
+      chat: "对话",
+      you: "用户",
+      agent: "Agent",
+      userMessageShort: "帮我安装这个 agent skill",
+      showMore: "显示更多",
+      userMessage: `帮我安装这个 Agent Skill。\n\nSkill page: https://skillsmp.com/creators/anthropics/skills/skills-frontend-design\nSource URL: https://github.com/anthropics/skills/tree/main/skills/frontend-design\nSkill name: frontend-design\nCreator: anthropics\nPreferred install command: npx skills add https://github.com/anthropics/skills --skill frontend-design\n\nPlease open the skill page and source, review SKILL.md plus any companion files, and explain anything risky before installing.\n\nIf shell commands are available, prefer the install command above. If you install manually, copy the complete skill directory that contains SKILL.md, including scripts, references, assets, agents, and any other files shown on the skill page. Preserve the relative folder structure. Do not install SKILL.md alone. After installing, verify the target skills folder contains SKILL.md and all companion files needed by this skill.`,
+      agentStep: "运行命令：npx skills add https://github.com/anthropics/skills --skill frontend-design",
+      thinking: "思考中...",
+      runCommandLabel: "运行命令",
+      runCommand: "npx skills add https://github.com/anthropics/skills --skill frontend-design",
+      assistantReply: "Skill",
+      assistantReplyName: "frontend-design",
+      assistantReplySuffix: "已安装完毕",
+      inputPlaceholder: "描述你的想法...",
+    },
+    mobileWorkspace: {
+      workspaceName: "amber-spark-9",
+      workspaceLabel: "workspace",
+      userMessage: "再补充一下 Cursor 和 Claude Code 的对比。",
+      stepRead: "读取 docs/competitive-analysis.md",
+      stepSearch: "网页搜索：Cursor vs Claude Code 2026",
+      stepWrite: "写入文件：docs/competitive-analysis.md",
+      filesTitle: "文件",
+      prdFile: "prd.md",
+      analysisFile: "competitive-analysis.md",
+      assistantReply: "已更新",
+      assistantReplyName: "competitive-analysis.md",
+      assistantReplySuffix:
+        "，新增了 Cursor 与 Claude Code 在本地优先、云端同步和工程场景上的对比。",
+      previewTitle: "预览",
+      previewType: "Markdown",
+      previewHeading: "Cursor / Claude Code",
+      previewPoints: [
+        "本地优先的 IDE Agent",
+        "需要仓库和环境配置",
+        "适合重型工程",
+      ],
+      voiceText: "再补充一下 Cursor 和 Claude Code 的对比",
+      listening: "聆听中...",
+      holdToSpeak: "按住说话",
+    },
     features: {
       eyebrow: "Riffpad 能做什么",
       title: "随身可用的云端 AI Agent",
@@ -322,14 +505,9 @@ export const messages = {
         "无需安装，无需配置，没有散落在聊天里的片段。描述你想要什么，就能得到一个带文件、预览和 Agent 的可运行工作空间。",
       blocks: [
         {
-          title: "轻量 AI Agent，秒级启动",
+          title: "Skill + MCP，按需扩展 Agent",
           description:
-            "几秒内启动沙箱。左侧 Chat，中间代码与实时预览，右侧文件树——一个以 Agent 为核心的沉浸式工作空间。",
-        },
-        {
-          title: "一句话安装 Skill",
-          description:
-            "按需扩展 Agent 能力。用自然语言要求安装某个 Skill，看命令执行，然后在设置面板里随时开关。",
+            "安装 Skill、接入 MCP 服务器，让 Agent 真正拥有能力——从生成精美前端和文档，到同步 GitHub、Linear、Notion，一切按需启用。",
         },
         {
           title: "在任何地方使用 Riffpad",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -14,6 +14,7 @@
     "framer-motion": "^12.42.2",
     "next": "14.2.35",
     "react": "^18",
+    "react-device-frameset": "^1.3.4",
     "react-dom": "^18"
   },
   "devDependencies": {

--- a/apps/landing/pnpm-lock.yaml
+++ b/apps/landing/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       react:
         specifier: ^18
         version: 18.3.1
+      react-device-frameset:
+        specifier: ^1.3.4
+        version: 1.3.4(react@18.3.1)
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
@@ -1466,6 +1469,11 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  react-device-frameset@1.3.4:
+    resolution: {integrity: sha512-M9VUa2up9TFOgsELHBFRkZf8ER0AyOYF5+5qbtYseQCZfg6XUxuNDX5VsJNfMGu6Zz6x9Dgh4rfFDFONK9H7dg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -2540,8 +2548,8 @@ snapshots:
       '@typescript-eslint/parser': 8.63.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -2560,7 +2568,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -2571,22 +2579,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.63.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -2597,7 +2605,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -3360,6 +3368,10 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  react-device-frameset@1.3.4(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:

--- a/apps/landing/pnpm-lock.yaml
+++ b/apps/landing/pnpm-lock.yaml
@@ -2548,8 +2548,8 @@ snapshots:
       '@typescript-eslint/parser': 8.63.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -2568,7 +2568,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -2579,22 +2579,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.63.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -2605,7 +2605,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3

--- a/landing-page-tuning
+++ b/landing-page-tuning
@@ -1,0 +1,30 @@
+Brainstorm, capture ideas, and build light prototypes anywhere—on your phone, tablet, or desktop. Riffpad turns a sentence into a running workspace, no setup required.
+改为
+运行在云端的完整的AI agent能力，开箱即用，触手可及。在任何地方，电脑、手机、平板。记录灵感，处理文件，原型验证，它无所不能
+
+然后，下面是三大feature,注意 ui mockup全部独占一行:
+1. 轻量的ai agent，极速启动，无需任何安装或配置
+   对应的ui mockup:类似IDE的三栏布局，最左侧是chat interface，中间是打开的文件，最右侧是file tree
+2. 一句话安装skill，按需启用，扩展能力
+    对应的ui mockup:chat interface，用户说“帮我安装agent skill:Skill page:... Source URL: ...Skill name: ..."，riffpad显示run a command"npx skills add ...",回复“已为您装好”
+    右边还有一个管理各个agent skill是否启用的设置页面
+3. 在任何地方使用riffpad, 充分利用碎片时间，使用先进的语音识别
+    ui mockup:移动端app，交互页面，语音识别ing
+4. 想给 codex/claude code使用？一键导出上下文
+    ui mockup:可以看到分发形式有prompt, .zip
+
+接下来是对比环节：
+1. vs. chatGPT/gemini 等网页版chat
+ | riffpad | chatGPT/gemini
+本质 Agent loop，持续运行直到问题解决 | 单次LLM call
+扩展 安装各种skill | 局限于自家生态
+知识沉淀 真实的文件系统 | 散落在对话里
+
+2. vs. codex/claude code等coding agent
+ | riffpad | codex/claude code
+启动 一键启动，无需配置 | 安装，新建目录
+运行在 云端，多端同步 | 本地
+适合 快速，轻度，创意 | 重型开发
+
+后面的 user voices和faq都保持原样
+   


### PR DESCRIPTION
- Removed @xyflow/react dependency\n- Rewrote ExportMockup with SVG-native nodes and orthogonal dashed lines\n- Nodes align vertically by layer and are centered\n- Connection lines flow left-to-right and are covered by node logos\n- Riffpad logo restored and filled white via CSS filter\n- Updated Features layout to keep mockups full-width\n\nVerified with pnpm build and pnpm lint.