### PR TITLE
feat(app): Pi-style agent chat interaction

### DIFF
--- a/apps/app/src/app/page.tsx
+++ b/apps/app/src/app/page.tsx
@@ -22,9 +22,18 @@ import { Button } from "@/components/ui/button";
 import { CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
+import { ChatPanel } from "@/components/chat/ChatPanel";
+import type { ChatItem } from "@/components/chat/types";
 import { useI18n } from "@/lib/i18n";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+interface AgentMessage {
+  role: "user" | "assistant" | "tool";
+  content?: string;
+  tool_calls?: { id: string; function: { name: string; arguments: string } }[];
+  timestamp: number;
+}
 
 interface AgentEvent {
   type: string;
@@ -36,7 +45,7 @@ interface AgentEvent {
   toolCallId?: string;
   toolName?: string;
   isError?: boolean;
-  message?: Record<string, unknown>;
+  message?: AgentMessage;
   timestamp: number;
 }
 
@@ -47,14 +56,6 @@ interface FileInfo {
   size: number;
 }
 
-interface ChatMessage {
-  id: string;
-  role: "user" | "agent";
-  content: string;
-  timestamp: number;
-  meta?: AgentEvent;
-}
-
 export default function Home() {
   const { t, locale, setLocale } = useI18n();
   const { setTheme, resolvedTheme } = useTheme();
@@ -63,8 +64,7 @@ export default function Home() {
   const [prompt, setPrompt] = useState("");
   const [workspaceId, setWorkspaceId] = useState<string | null>(null);
   const [workspaceSlug, setWorkspaceSlug] = useState<string | null>(null);
-  const [events, setEvents] = useState<AgentEvent[]>([]);
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [chatItems, setChatItems] = useState<ChatItem[]>([]);
   const [connected, setConnected] = useState(false);
   const [files, setFiles] = useState<FileInfo[]>([]);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
@@ -76,6 +76,8 @@ export default function Home() {
   const wsRef = useRef<WebSocket | null>(null);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const langRef = useRef<HTMLDivElement>(null);
+  const chatIdRef = useRef(0);
+  const assistantIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     setMounted(true);
@@ -140,24 +142,96 @@ export default function Home() {
       ws.onmessage = (msg) => {
         try {
           const event: AgentEvent = JSON.parse(msg.data);
-          setEvents((prev) => [...prev, event]);
-          setMessages((prev) => [
-            ...prev,
-            {
-              id: `${event.type}-${event.timestamp}-${prev.length}`,
-              role: "agent",
-              content:
-                event.content ||
-                (event.toolName ? `${event.toolName}${event.path ? ` · ${event.path}` : ""}` : event.type),
-              timestamp: event.timestamp,
-              meta: event,
-            },
-          ]);
-          if (
-            event.type === "file_change" ||
-            event.type === "tool_execution_end"
-          ) {
-            void fetchFiles(id);
+          const makeId = () => `${++chatIdRef.current}`;
+
+          switch (event.type) {
+            case "agent_start": {
+              assistantIdRef.current = makeId();
+              setChatItems((prev) => [
+                ...prev,
+                {
+                  type: "assistant",
+                  id: assistantIdRef.current!,
+                  content: "",
+                  isStreaming: true,
+                  timestamp: event.timestamp,
+                },
+              ]);
+              break;
+            }
+            case "message_end": {
+              if (event.message?.role === "assistant" && assistantIdRef.current) {
+                setChatItems((prev) =>
+                  prev.map((item) =>
+                    item.id === assistantIdRef.current && item.type === "assistant"
+                      ? { ...item, content: event.message?.content ?? "", isStreaming: false }
+                      : item
+                  )
+                );
+              }
+              break;
+            }
+            case "tool_execution_start": {
+              setChatItems((prev) => [
+                ...prev,
+                {
+                  type: "tool",
+                  id: `tool-${event.toolCallId ?? makeId()}`,
+                  toolName: event.toolName ?? "tool",
+                  args: event.args,
+                  isPartial: true,
+                  timestamp: event.timestamp,
+                },
+              ]);
+              break;
+            }
+            case "tool_execution_end": {
+              setChatItems((prev) =>
+                prev.map((item) =>
+                  item.type === "tool" && item.id === `tool-${event.toolCallId}`
+                    ? {
+                        ...item,
+                        isPartial: false,
+                        result: event.result,
+                        isError: event.isError,
+                      }
+                    : item
+                )
+              );
+              void fetchFiles(id);
+              break;
+            }
+            case "file_change": {
+              if (event.path) {
+                setChatItems((prev) => [
+                  ...prev,
+                  {
+                    type: "file",
+                    id: makeId(),
+                    path: event.path!,
+                    timestamp: event.timestamp,
+                  },
+                ]);
+              }
+              void fetchFiles(id);
+              break;
+            }
+            case "agent_end": {
+              assistantIdRef.current = null;
+              break;
+            }
+            case "error": {
+              setChatItems((prev) => [
+                ...prev,
+                {
+                  type: "assistant",
+                  id: makeId(),
+                  content: event.content ?? "Agent error",
+                  timestamp: event.timestamp,
+                },
+              ]);
+              break;
+            }
           }
         } catch {
           console.error("Failed to parse event:", msg.data);
@@ -188,11 +262,11 @@ export default function Home() {
       id = ws.id;
     }
 
-    setMessages((prev) => [
+    setChatItems((prev) => [
       ...prev,
       {
-        id: `user-${Date.now()}`,
-        role: "user",
+        id: `${++chatIdRef.current}`,
+        type: "user",
         content: prompt,
         timestamp: Date.now(),
       },
@@ -204,7 +278,7 @@ export default function Home() {
 
   useEffect(() => {
     chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
+  }, [chatItems]);
 
   useEffect(() => {
     return () => {
@@ -224,16 +298,6 @@ export default function Home() {
   };
 
   const isDark = resolvedTheme === "dark";
-
-  const eventBadge = (event: AgentEvent) => {
-    if (event.isError)
-      return "bg-accent-red-soft text-accent-red border-accent-red/20";
-    if (event.type === "tool_execution_end")
-      return "bg-accent-green-soft text-accent-green border-accent-green/20";
-    if (event.type === "message_end")
-      return "bg-accent-blue-soft text-accent-blue border-accent-blue/20";
-    return "bg-card-soft text-mute border-hairline-soft";
-  };
 
   const fileTree = (
     <>
@@ -512,43 +576,7 @@ export default function Home() {
               </CardTitle>
             </CardHeader>
 
-            <ScrollArea className="flex-1 px-3">
-              <div className="space-y-3 py-3">
-                {messages.length === 0 && events.length === 0 && (
-                  <p className="text-xs text-mute">{t("chat.empty")}</p>
-                )}
-                {messages.map((msg) =>
-                  msg.role === "user" ? (
-                    <div key={msg.id} className="flex justify-end">
-                      <div className="max-w-[90%] rounded-2xl rounded-tr-sm bg-primary text-primary-foreground px-3 py-2 text-sm">
-                        {msg.content}
-                      </div>
-                    </div>
-                  ) : (
-                    <div key={msg.id} className="rounded-md border border-hairline bg-card-doc/80 p-2.5 text-xs">
-                      {msg.meta && (
-                        <div className="flex items-center gap-2 mb-1.5">
-                          <span
-                            className={`inline-flex items-center px-1.5 py-0.5 rounded border text-[10px] font-bold uppercase tracking-wide ${eventBadge(
-                              msg.meta
-                            )}`}
-                          >
-                            {msg.meta.type}
-                          </span>
-                          <span className="text-[10px] text-ash tabular-nums">
-                            {new Date(msg.timestamp).toLocaleTimeString()}
-                          </span>
-                        </div>
-                      )}
-                      <p className="text-body whitespace-pre-wrap leading-relaxed">
-                        {msg.content}
-                      </p>
-                    </div>
-                  )
-                )}
-                <div ref={chatEndRef} />
-              </div>
-            </ScrollArea>
+            <ChatPanel items={chatItems} emptyHint={t("chat.empty")} scrollRef={chatEndRef} />
 
             <div className="p-3 border-t border-hairline bg-card/80 backdrop-blur">
               <form onSubmit={handleSubmit} className="flex gap-2">

--- a/apps/app/src/components/chat/AssistantMessage.tsx
+++ b/apps/app/src/components/chat/AssistantMessage.tsx
@@ -1,0 +1,28 @@
+import { Bot } from "lucide-react";
+
+interface AssistantMessageProps {
+  content: string;
+  isStreaming?: boolean;
+}
+
+export function AssistantMessage({ content, isStreaming }: AssistantMessageProps) {
+  return (
+    <div className="flex gap-2">
+      <div className="mt-1 h-5 w-5 shrink-0 rounded-full bg-accent-blue/10 flex items-center justify-center">
+        <Bot className="h-3 w-3 text-accent-blue" />
+      </div>
+      <div className="max-w-[90%] min-w-0">
+        {content ? (
+          <div className="text-sm text-body leading-relaxed whitespace-pre-wrap">
+            {content}
+          </div>
+        ) : isStreaming ? (
+          <div className="flex items-center gap-2 text-xs text-mute">
+            <span className="inline-block h-1.5 w-1.5 rounded-full bg-accent-blue animate-pulse" />
+            Working...
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/chat/ChatPanel.tsx
+++ b/apps/app/src/components/chat/ChatPanel.tsx
@@ -1,0 +1,52 @@
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { AssistantMessage } from "./AssistantMessage";
+import { FileChange } from "./FileChange";
+import { ToolExecution } from "./ToolExecution";
+import { UserMessage } from "./UserMessage";
+import type { ChatItem } from "./types";
+
+interface ChatPanelProps {
+  items: ChatItem[];
+  emptyHint?: string;
+  scrollRef?: React.RefObject<HTMLDivElement>;
+}
+
+export function ChatPanel({ items, emptyHint, scrollRef }: ChatPanelProps) {
+  return (
+    <ScrollArea className="flex-1 px-3">
+      <div className="space-y-3 py-3">
+        {items.length === 0 && emptyHint && (
+          <p className="text-xs text-mute">{emptyHint}</p>
+        )}
+        {items.map((item) => {
+          switch (item.type) {
+            case "user":
+              return <UserMessage key={item.id} content={item.content} />;
+            case "assistant":
+              return (
+                <AssistantMessage
+                  key={item.id}
+                  content={item.content}
+                  isStreaming={item.isStreaming}
+                />
+              );
+            case "tool":
+              return (
+                <ToolExecution
+                  key={item.id}
+                  toolName={item.toolName}
+                  args={item.args}
+                  result={item.result}
+                  isError={item.isError}
+                  isPartial={item.isPartial}
+                />
+              );
+            case "file":
+              return <FileChange key={item.id} path={item.path} />;
+          }
+        })}
+        <div ref={scrollRef} />
+      </div>
+    </ScrollArea>
+  );
+}

--- a/apps/app/src/components/chat/FileChange.tsx
+++ b/apps/app/src/components/chat/FileChange.tsx
@@ -1,0 +1,14 @@
+import { FileCode } from "lucide-react";
+
+interface FileChangeProps {
+  path: string;
+}
+
+export function FileChange({ path }: FileChangeProps) {
+  return (
+    <div className="ml-7 flex items-center gap-2 rounded-md border border-hairline bg-card-doc/80 px-3 py-2 text-xs text-body">
+      <FileCode className="h-3.5 w-3.5 text-mute shrink-0" />
+      <span className="truncate">{path}</span>
+    </div>
+  );
+}

--- a/apps/app/src/components/chat/ToolExecution.tsx
+++ b/apps/app/src/components/chat/ToolExecution.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Wrench } from "lucide-react";
+
+interface ToolExecutionProps {
+  toolName: string;
+  args: unknown;
+  result?: unknown;
+  isError?: boolean;
+  isPartial?: boolean;
+}
+
+function safeStringify(value: unknown): string {
+  if (value === undefined) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function ToolExecution({
+  toolName,
+  args,
+  result,
+  isError,
+  isPartial,
+}: ToolExecutionProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const statusClass = isError
+    ? "bg-accent-red-soft border-accent-red/20"
+    : isPartial
+    ? "bg-accent-blue-soft border-accent-blue/20"
+    : "bg-accent-green-soft border-accent-green/20";
+
+  const statusText = isError ? "Error" : isPartial ? "Running" : "Done";
+
+  return (
+    <div className={`ml-7 rounded-md border ${statusClass} overflow-hidden`}>
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-center justify-between px-3 py-2 text-left"
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <Wrench className="h-3.5 w-3.5 text-mute shrink-0" />
+          <span className="text-xs font-semibold text-ink truncate">{toolName}</span>
+          <span
+            className={`text-[10px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded ${
+              isError
+                ? "bg-accent-red text-white"
+                : isPartial
+                ? "bg-accent-blue text-white"
+                : "bg-accent-green text-white"
+            }`}
+          >
+            {statusText}
+          </span>
+        </div>
+        {expanded ? (
+          <ChevronDown className="h-3.5 w-3.5 text-mute shrink-0" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 text-mute shrink-0" />
+        )}
+      </button>
+      {expanded && (
+        <div className="px-3 pb-3 space-y-2 border-t border-hairline-soft/50">
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-wide text-mute mb-1">Arguments</p>
+            <pre className="text-[11px] font-mono text-body bg-card/60 rounded p-2 overflow-x-auto">
+              {safeStringify(args)}
+            </pre>
+          </div>
+          {result !== undefined && (
+            <div>
+              <p className="text-[10px] font-bold uppercase tracking-wide text-mute mb-1">Result</p>
+              <pre className="text-[11px] font-mono text-body bg-card/60 rounded p-2 overflow-x-auto">
+                {safeStringify(result)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/app/src/components/chat/UserMessage.tsx
+++ b/apps/app/src/components/chat/UserMessage.tsx
@@ -1,0 +1,18 @@
+import { User } from "lucide-react";
+
+interface UserMessageProps {
+  content: string;
+}
+
+export function UserMessage({ content }: UserMessageProps) {
+  return (
+    <div className="flex justify-end gap-2">
+      <div className="max-w-[85%] rounded-2xl rounded-tr-sm bg-card-soft px-4 py-2.5 text-sm text-ink shadow-sm">
+        <p className="whitespace-pre-wrap leading-relaxed">{content}</p>
+      </div>
+      <div className="mt-1 h-5 w-5 shrink-0 rounded-full bg-primary/10 flex items-center justify-center">
+        <User className="h-3 w-3 text-primary" />
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/chat/types.ts
+++ b/apps/app/src/components/chat/types.ts
@@ -1,0 +1,38 @@
+export interface ChatUserItem {
+  type: "user";
+  id: string;
+  content: string;
+  timestamp: number;
+}
+
+export interface ChatAssistantItem {
+  type: "assistant";
+  id: string;
+  content: string;
+  isStreaming?: boolean;
+  timestamp: number;
+}
+
+export interface ChatToolItem {
+  type: "tool";
+  id: string;
+  toolName: string;
+  args: unknown;
+  result?: unknown;
+  isError?: boolean;
+  isPartial?: boolean;
+  timestamp: number;
+}
+
+export interface ChatFileItem {
+  type: "file";
+  id: string;
+  path: string;
+  timestamp: number;
+}
+
+export type ChatItem =
+  | ChatUserItem
+  | ChatAssistantItem
+  | ChatToolItem
+  | ChatFileItem;


### PR DESCRIPTION
## What

Replicates Pi's agent chat interaction in the web UI:

- **User message**: right-aligned bubble with a user avatar.
- **Assistant message**: left-aligned, plain text, with a bot avatar and a "Working..." pulse while streaming.
- **Tool execution**: collapsible cards that start in a pending state, then turn green (success) or red (error). Expanded view shows arguments and result JSON.
- **File change**: small inline card showing the changed file path.

The raw agent event log is replaced by a grouped conversation stream built from `agent_start` / `message_end` / `tool_execution_*` / `file_change` / `agent_end` events.

## Tests

- Existing E2E still passes (workspace creation, theme, locale, mobile drawer, agent file creation).

## Verify

```bash
pnpm --filter app lint
pnpm --filter app build
pnpm --filter app e2e
```
