### PR TITLE
feat(daemon): no-tmux adapters for kimi/codex/claude (#55)

### DIFF
--- a/apps/daemon/cmd/riffpad/main.go
+++ b/apps/daemon/cmd/riffpad/main.go
@@ -88,7 +88,7 @@ Usage:
   riffpad status                show daemon status
   riffpad pair                  print a pairing code and QR
   riffpad sessions              list sessions
-  riffpad run [--name N] [--prompt P] [--cwd D] [--cli claude]
+  riffpad run [--name N] [--prompt P] [--cwd D] [--cli claude|kimi|codex]
   riffpad attach                inject Claude Code hooks so the daemon captures your own CLI session
   riffpad detach                remove injected hooks
   riffpad relay login           log in to the relay (--url wss://… --username …)
@@ -227,7 +227,7 @@ func runCmd(args []string, base string) error {
 	name := fs.String("name", "", "session name")
 	prompt := fs.String("prompt", "", "initial prompt")
 	cwd := fs.String("cwd", "", "working directory")
-	cli := fs.String("cli", "claude", "agent CLI (claude)")
+	cli := fs.String("cli", "claude", "agent CLI (claude|kimi|codex)")
 	_ = fs.Parse(args)
 	body, _ := json.Marshal(map[string]string{
 		"name": *name, "prompt": *prompt, "cwd": *cwd, "cli": *cli,
@@ -296,14 +296,14 @@ func attachCmd(base string) error {
 		}
 	}
 	settings["hooks"] = map[string]any{
-		"SessionStart":       []any{httpHook("/hooks/claude/session-start", 10)},
-		"SessionEnd":         []any{httpHook("/hooks/claude/session-end", 10)},
-		"UserPromptSubmit":   []any{httpHook("/hooks/claude/user-prompt-submit", 30)},
-		"MessageDisplay":     []any{httpHook("/hooks/claude/message-display", 10)},
-		"PreToolUse":         []any{httpHook("/hooks/claude/pre-tool-use", 10)},
-		"PostToolUse":        []any{httpHook("/hooks/claude/post-tool-use", 10)},
-		"PermissionRequest":  []any{httpHook("/hooks/claude/permission", 600)},
-		"Notification":       []any{httpHook("/hooks/claude/notification", 10)},
+		"SessionStart":      []any{httpHook("/hooks/claude/session-start", 10)},
+		"SessionEnd":        []any{httpHook("/hooks/claude/session-end", 10)},
+		"UserPromptSubmit":  []any{httpHook("/hooks/claude/user-prompt-submit", 30)},
+		"MessageDisplay":    []any{httpHook("/hooks/claude/message-display", 10)},
+		"PreToolUse":        []any{httpHook("/hooks/claude/pre-tool-use", 10)},
+		"PostToolUse":       []any{httpHook("/hooks/claude/post-tool-use", 10)},
+		"PermissionRequest": []any{httpHook("/hooks/claude/permission", 600)},
+		"Notification":      []any{httpHook("/hooks/claude/notification", 10)},
 	}
 	raw, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {

--- a/apps/daemon/internal/claude/claude.go
+++ b/apps/daemon/internal/claude/claude.go
@@ -72,7 +72,7 @@ func New(req adapter.CreateRequest) *Claude {
 	}
 }
 
-func (c *Claude) ID() string              { return c.id }
+func (c *Claude) ID() string                    { return c.id }
 func (c *Claude) Events() <-chan protocol.Event { return c.events }
 func (c *Claude) Meta() protocol.SessionStartPayload {
 	return protocol.SessionStartPayload{Name: c.name, CLI: "claude", Cwd: c.cwd}
@@ -116,7 +116,6 @@ func (c *Claude) spawn(ctx context.Context) error {
 		return fmt.Errorf("write settings: %w", err)
 	}
 	args := []string{
-		"-p",
 		"--input-format", "stream-json",
 		"--output-format", "stream-json",
 		"--verbose",
@@ -147,6 +146,15 @@ func (c *Claude) spawn(ctx context.Context) error {
 	c.stdin = stdin
 	go c.readLoop(stdout)
 	go c.copyStderr(stderr)
+	// Host-mode control protocol: register hooks so the daemon can answer
+	// UserPromptSubmit callbacks. Without this, prompts still work, but hook
+	// notifications would be missing and future approval events would not
+	// reach the adapter.
+	go func() {
+		if err := c.initControl(); err != nil {
+			log.Printf("claude[%s] control initialize: %v", c.id, err)
+		}
+	}()
 	go func() {
 		<-c.stopCh
 		if c.cmd != nil && c.cmd.Process != nil {
@@ -154,6 +162,28 @@ func (c *Claude) spawn(ctx context.Context) error {
 		}
 	}()
 	return nil
+}
+
+// initControl sends the stream-json control-protocol initialize frame.
+// Claude 2.1.x requires camelCase matchers/hookCallbackIds arrays.
+func (c *Claude) initControl() error {
+	msg := map[string]any{
+		"type": "control_request",
+		"request": map[string]any{
+			"subtype":    "initialize",
+			"request_id": "riffpad_init_1",
+			"hooks": map[string]any{
+				"UserPromptSubmit": []any{
+					map[string]any{
+						"matchers":        []any{""},
+						"hookCallbackIds": []any{"hook_user_prompt"},
+					},
+				},
+			},
+			"sdk_mcp_servers": []any{},
+		},
+	}
+	return c.writeLine(msg)
 }
 
 // Stop terminates the wrapped process.
@@ -308,6 +338,7 @@ func (c *Claude) handleLine(line []byte) {
 		Subtype   string          `json:"subtype"`
 		RequestID string          `json:"request_id"`
 		Message   json.RawMessage `json:"message"`
+		Request   json.RawMessage `json:"request"`
 	}
 	if err := json.Unmarshal(line, &raw); err != nil {
 		return
@@ -315,19 +346,24 @@ func (c *Claude) handleLine(line []byte) {
 	switch raw.Type {
 	case "system":
 		c.handleSystem(raw.Subtype, line)
+	case "control_response":
+		// initialize ack; nothing to do.
 	case "assistant":
 		c.handleAssistant(raw.Message)
 	case "user":
 		c.handleUser(raw.Message)
-	case "control_request":
-		c.handleControlRequest(raw.RequestID, raw.Message)
+	case "control_request", "sdk_control_request":
+		body := raw.Message
+		if len(body) == 0 {
+			body = raw.Request
+		}
+		c.handleControlRequest(raw.RequestID, body)
 	case "result":
 		status := protocol.StatusDone
 		if raw.Subtype == "error" || raw.Subtype == "error_max_turns" {
 			status = protocol.StatusError
 		}
 		_ = c.emit(protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: status})
-		_ = c.emit(protocol.EventSessionEnd, protocol.SessionEndPayload{Reason: raw.Subtype})
 	}
 }
 
@@ -425,7 +461,12 @@ func (c *Claude) handleUser(msg json.RawMessage) {
 
 func (c *Claude) handleControlRequest(requestID string, msg json.RawMessage) {
 	var cr struct {
-		Type      string `json:"type"`
+		Type     string `json:"type"`
+		Subtype  string `json:"subtype"`
+		Callback string `json:"callback_id"`
+		Input    struct {
+			HookEventName string `json:"hook_event_name"`
+		} `json:"input"`
 		ToolUseID string `json:"tool_use_id"`
 		ToolUse   struct {
 			Name  string         `json:"name"`
@@ -433,6 +474,16 @@ func (c *Claude) handleControlRequest(requestID string, msg json.RawMessage) {
 		} `json:"tool_use"`
 	}
 	if err := json.Unmarshal(msg, &cr); err != nil {
+		return
+	}
+	if cr.Subtype == "hook_callback" {
+		c.replyHook(requestID, cr.Input.HookEventName)
+		return
+	}
+	// Old SDK format used message.type == "request_permission"; the control
+	// protocol may also emit subtype == "permission". Everything else (e.g.
+	// mcp_message) is ignored.
+	if cr.Subtype == "" && cr.Type != "request_permission" {
 		return
 	}
 	ch := make(chan string, 1)
@@ -461,6 +512,30 @@ func (c *Claude) handleControlRequest(requestID string, msg json.RawMessage) {
 			log.Printf("claude[%s] write control_response: %v", c.id, err)
 		}
 	}()
+}
+
+// replyHook answers a control-protocol hook callback. Prompt-related hooks are
+// allowed immediately; the daemon already forwarded the prompt to the user.
+func (c *Claude) replyHook(requestID, hookEventName string) {
+	if hookEventName == "" {
+		hookEventName = "UserPromptSubmit"
+	}
+	resp := map[string]any{
+		"type": "control_response",
+		"response": map[string]any{
+			"subtype":    "success",
+			"request_id": requestID,
+			"response": map[string]any{
+				"hookSpecificOutput": map[string]any{
+					"hookEventName": hookEventName,
+					"decision":      map[string]any{"behavior": "allow"},
+				},
+			},
+		},
+	}
+	if err := c.writeLine(resp); err != nil {
+		log.Printf("claude[%s] write hook response: %v", c.id, err)
+	}
 }
 
 func (c *Claude) emit(typ string, payload any) error {

--- a/apps/daemon/internal/claude/claude_test.go
+++ b/apps/daemon/internal/claude/claude_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
 	"github.com/riffpad/riffpad/packages/protocol"
@@ -67,16 +68,21 @@ func TestHandleControlRequest(t *testing.T) {
 	}
 }
 
-func TestResultEndsSession(t *testing.T) {
+func TestResultEmitsStatusOnly(t *testing.T) {
 	c := New(adapter.CreateRequest{ID: "s1"})
 	c.handleLine([]byte(`{"type":"result","subtype":"success","result":"done"}`))
-	ev := <-c.Events()
-	if ev.Type != protocol.EventAgentStatus {
-		t.Fatalf("expected agent_status, got %s", ev.Type)
+	select {
+	case ev := <-c.Events():
+		if ev.Type != protocol.EventAgentStatus {
+			t.Fatalf("expected agent_status, got %s", ev.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected agent_status event")
 	}
-	ev2 := <-c.Events()
-	if ev2.Type != protocol.EventSessionEnd {
-		t.Fatalf("expected session_end, got %s", ev2.Type)
+	select {
+	case ev := <-c.Events():
+		t.Fatalf("expected no session_end after turn result in host mode, got %s", ev.Type)
+	case <-time.After(50 * time.Millisecond):
 	}
 }
 
@@ -120,5 +126,15 @@ func TestWriteSettingsHookShape(t *testing.T) {
 	}
 	if len(n[0].Hooks) != 1 {
 		t.Fatalf("expected hooks array with 1 entry, got %d", len(n[0].Hooks))
+	}
+}
+
+func TestHookCallbackAutoAllowed(t *testing.T) {
+	c := New(adapter.CreateRequest{ID: "s1"})
+	c.handleLine([]byte(`{"type":"control_request","request_id":"r2","request":{"subtype":"hook_callback","callback_id":"hook_user_prompt","input":{"hook_event_name":"UserPromptSubmit"}}}`))
+	select {
+	case ev := <-c.Events():
+		t.Fatalf("expected no approval event for hook callback, got %s", ev.Type)
+	case <-time.After(50 * time.Millisecond):
 	}
 }

--- a/apps/daemon/internal/codex/codex.go
+++ b/apps/daemon/internal/codex/codex.go
@@ -1,0 +1,658 @@
+// Package codex implements the Codex adapter over the official
+// `codex app-server` JSON-RPC protocol (stdio transport). The daemon spawns
+// an app-server per session, creates a thread, and drives turns with
+// turn/start / turn/steer. Command/file/permission approvals arrive as
+// server-initiated JSON-RPC requests and are answered by the daemon.
+package codex
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
+	"github.com/riffpad/riffpad/packages/protocol"
+)
+
+type pendingApproval struct {
+	kind      string // command | file | permissions
+	action    string
+	summary   string
+	requested []string // permissions request: requested permission names
+}
+
+// Codex is a Codex session driven through the app-server protocol.
+type Codex struct {
+	id     string
+	name   string
+	cwd    string
+	prompt string
+	binary string
+	events chan protocol.Event
+	stopCh chan struct{}
+	doneCh chan struct{}
+	ready  chan struct{}
+
+	mu            sync.Mutex
+	ctx           context.Context
+	cmd           *exec.Cmd
+	stdin         io.WriteCloser
+	launched      bool
+	exited        bool
+	threadID      string
+	turnActive    bool
+	initError     error
+	nextRequestID int
+	pending       map[string]pendingApproval
+	messages      map[string]*strings.Builder
+}
+
+// New creates a Codex app-server session adapter.
+func New(req adapter.CreateRequest) *Codex {
+	binary := req.Binary
+	if binary == "" {
+		binary = "codex"
+	}
+	return &Codex{
+		id:            req.ID,
+		name:          req.Name,
+		cwd:           req.Cwd,
+		prompt:        req.Prompt,
+		binary:        binary,
+		events:        make(chan protocol.Event, 256),
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+		ready:         make(chan struct{}),
+		nextRequestID: 1,
+		pending:       make(map[string]pendingApproval),
+		messages:      make(map[string]*strings.Builder),
+	}
+}
+
+func (c *Codex) ID() string                    { return c.id }
+func (c *Codex) Events() <-chan protocol.Event { return c.events }
+func (c *Codex) Meta() protocol.SessionStartPayload {
+	return protocol.SessionStartPayload{Name: c.name, CLI: "codex", Cwd: c.cwd}
+}
+
+// Start records the context, spawns the app-server, and (when a prompt is
+// present) waits for the thread to be ready before sending it.
+func (c *Codex) Start(ctx context.Context) error {
+	c.mu.Lock()
+	c.ctx = ctx
+	c.mu.Unlock()
+	if err := c.ensureStarted(); err != nil {
+		return err
+	}
+	if c.prompt != "" {
+		if err := c.waitReady(); err != nil {
+			return err
+		}
+		return c.SendPrompt(c.prompt)
+	}
+	return nil
+}
+
+func (c *Codex) ensureStarted() error {
+	c.mu.Lock()
+	if c.launched {
+		c.mu.Unlock()
+		return nil
+	}
+	if c.ctx == nil {
+		c.mu.Unlock()
+		return fmt.Errorf("session not started")
+	}
+	c.launched = true
+	ctx := c.ctx
+	c.mu.Unlock()
+	return c.spawn(ctx)
+}
+
+func (c *Codex) spawn(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, c.binary, "app-server", "--listen", "stdio://")
+	if c.cwd != "" {
+		cmd.Dir = c.cwd
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start %s app-server: %w", c.binary, err)
+	}
+	c.mu.Lock()
+	c.cmd = cmd
+	c.stdin = stdin
+	c.mu.Unlock()
+	go c.readLoop(stdout)
+	go c.copyStderr(stderr)
+	go func() {
+		<-c.stopCh
+		if c.cmd != nil && c.cmd.Process != nil {
+			_ = c.cmd.Process.Kill()
+		}
+	}()
+	_ = c.request("initialize", map[string]any{
+		"clientInfo": map[string]any{"name": "riffpad", "version": "0.1.0"},
+	})
+	return nil
+}
+
+// Stop terminates the app-server.
+func (c *Codex) Stop() error {
+	c.mu.Lock()
+	launched := c.launched
+	c.mu.Unlock()
+	select {
+	case <-c.stopCh:
+		return nil
+	default:
+		close(c.stopCh)
+	}
+	if !launched {
+		return nil
+	}
+	if c.cmd != nil && c.cmd.Process != nil {
+		_ = c.cmd.Process.Kill()
+	}
+	<-c.doneCh
+	return nil
+}
+
+// Alive reports whether the app-server process is running.
+func (c *Codex) Alive() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.launched && !c.exited
+}
+
+// SendPrompt starts a new turn, or steers the in-flight turn.
+func (c *Codex) SendPrompt(text string) error {
+	if err := c.ensureStarted(); err != nil {
+		return err
+	}
+	if err := c.waitReady(); err != nil {
+		return err
+	}
+	input := []any{map[string]any{"type": "text", "text": text}}
+	c.mu.Lock()
+	active := c.turnActive
+	c.mu.Unlock()
+	if active {
+		return c.request("turn/steer", map[string]any{
+			"threadId": c.threadID,
+			"input":    input,
+		})
+	}
+	return c.request("turn/start", map[string]any{
+		"threadId": c.threadID,
+		"input":    input,
+	})
+}
+
+// SendApproval resolves a pending app-server approval request.
+func (c *Codex) SendApproval(requestID, decision string) error {
+	c.mu.Lock()
+	p, ok := c.pending[requestID]
+	if ok {
+		delete(c.pending, requestID)
+	}
+	c.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("no pending approval %s", requestID)
+	}
+	var result any
+	switch p.kind {
+	case "command", "file":
+		d := "decline"
+		if decision == "approve" {
+			d = "accept"
+		}
+		result = map[string]any{"decision": d}
+	case "permissions":
+		granted := []any{}
+		if decision == "approve" {
+			for _, name := range p.requested {
+				granted = append(granted, name)
+			}
+		}
+		result = map[string]any{"permissions": granted, "scope": "turn"}
+	default:
+		return fmt.Errorf("unsupported approval kind %q", p.kind)
+	}
+	return c.writeJSON(map[string]any{"id": requestID, "result": result})
+}
+
+func (c *Codex) waitReady() error {
+	select {
+	case <-c.ready:
+		c.mu.Lock()
+		err := c.initError
+		tid := c.threadID
+		c.mu.Unlock()
+		if err != nil {
+			return err
+		}
+		if tid == "" {
+			return fmt.Errorf("codex thread not initialized")
+		}
+		return nil
+	case <-c.stopCh:
+		return fmt.Errorf("session stopped")
+	case <-time.After(30 * time.Second):
+		return fmt.Errorf("codex app-server initialization timed out")
+	}
+}
+
+func (c *Codex) request(method string, params map[string]any) error {
+	c.mu.Lock()
+	id := c.nextRequestID
+	c.nextRequestID++
+	c.mu.Unlock()
+	return c.writeJSON(map[string]any{"method": method, "id": id, "params": params})
+}
+
+func (c *Codex) writeJSON(v any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.stdin == nil {
+		return fmt.Errorf("stdin not ready")
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(c.stdin, string(data)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Codex) readLoop(r io.Reader) {
+	defer close(c.doneCh)
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		c.handleLine(line)
+	}
+	if c.cmd != nil && c.cmd.Process != nil {
+		_ = c.cmd.Wait()
+	}
+	c.flushMessages()
+	c.mu.Lock()
+	c.exited = true
+	c.mu.Unlock()
+	_ = c.emit(protocol.EventSessionEnd, protocol.SessionEndPayload{Reason: "process_exit"})
+}
+
+func (c *Codex) copyStderr(r io.Reader) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		log.Printf("codex[%s] stderr: %s", c.id, scanner.Text())
+	}
+}
+
+func (c *Codex) handleLine(line []byte) {
+	var msg struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+		Result json.RawMessage `json:"result"`
+		Error  json.RawMessage `json:"error"`
+		Params json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return
+	}
+	if len(msg.Error) > 0 && string(msg.Error) != "null" {
+		var e struct {
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(msg.Error, &e)
+		c.mu.Lock()
+		c.initError = fmt.Errorf("codex app-server error: %s", e.Message)
+		c.mu.Unlock()
+		c.closeReady()
+		_ = c.emit(protocol.EventNotify, protocol.NotifyPayload{Level: "error", Message: e.Message})
+		return
+	}
+	if msg.Method != "" && len(msg.ID) > 0 && string(msg.ID) != "null" {
+		c.handleServerRequest(msg.Method, msg.ID, msg.Params)
+		return
+	}
+	if msg.Method != "" {
+		c.handleNotification(msg.Method, msg.Params)
+		return
+	}
+	c.handleResponse(msg.ID, msg.Result)
+}
+
+func (c *Codex) closeReady() {
+	select {
+	case <-c.ready:
+	default:
+		close(c.ready)
+	}
+}
+
+func (c *Codex) handleResponse(id json.RawMessage, result json.RawMessage) {
+	var rid int
+	if json.Unmarshal(id, &rid) != nil {
+		return
+	}
+	switch rid {
+	case 1:
+		// initialize response; acknowledge then create the thread.
+		_ = c.writeJSON(map[string]any{"method": "initialized", "params": map[string]any{}})
+		_ = c.request("thread/start", map[string]any{"cwd": c.cwd})
+	case 2:
+		var res struct {
+			Thread struct {
+				ID string `json:"id"`
+			} `json:"thread"`
+		}
+		_ = json.Unmarshal(result, &res)
+		c.mu.Lock()
+		c.threadID = res.Thread.ID
+		if c.threadID == "" {
+			c.initError = fmt.Errorf("thread/start returned no thread id")
+		}
+		c.mu.Unlock()
+		c.closeReady()
+	default:
+		var res struct {
+			Turn struct {
+				Status string `json:"status"`
+			} `json:"turn"`
+		}
+		if err := json.Unmarshal(result, &res); err == nil && res.Turn.Status != "" {
+			c.mu.Lock()
+			c.turnActive = true
+			c.mu.Unlock()
+			_ = c.emit(protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: protocol.StatusRunning})
+		}
+	}
+}
+
+func (c *Codex) handleNotification(method string, params json.RawMessage) {
+	switch method {
+	case "item/started":
+		c.handleItemStarted(params)
+	case "item/completed":
+		c.handleItemCompleted(params)
+	case "item/agentMessage/delta":
+		c.handleAgentDelta(params)
+	case "turn/completed":
+		c.handleTurnCompleted(params)
+	case "thread/status/changed":
+		// turn/completed is authoritative; ignore.
+	default:
+		// Ignore noisy notifications (usage, diffs, plans, review, etc).
+	}
+}
+
+func (c *Codex) handleItemStarted(params json.RawMessage) {
+	var n struct {
+		Item struct {
+			ID      string          `json:"id"`
+			Type    string          `json:"type"`
+			Command string          `json:"command"`
+			Changes json.RawMessage `json:"changes"`
+			Tool    string          `json:"tool"`
+			Server  string          `json:"server"`
+			Status  string          `json:"status"`
+		} `json:"item"`
+	}
+	if err := json.Unmarshal(params, &n); err != nil {
+		return
+	}
+	switch n.Item.Type {
+	case "agentMessage":
+		c.mu.Lock()
+		c.messages[n.Item.ID] = &strings.Builder{}
+		c.mu.Unlock()
+	case "commandExecution":
+		_ = c.emit(protocol.EventToolCall, protocol.ToolCallPayload{
+			Tool: "Command", Status: "started", Summary: n.Item.Command,
+		})
+	case "fileChange":
+		paths := fileChangePaths(n.Item.Changes)
+		_ = c.emit(protocol.EventToolCall, protocol.ToolCallPayload{
+			Tool: "FileChange", Status: "started", Summary: strings.Join(paths, ", "),
+		})
+	case "mcpToolCall", "dynamicToolCall":
+		_ = c.emit(protocol.EventToolCall, protocol.ToolCallPayload{
+			Tool: firstNonEmpty(n.Item.Server, n.Item.Tool), Status: "started",
+		})
+	}
+}
+
+func (c *Codex) handleItemCompleted(params json.RawMessage) {
+	var n struct {
+		Item struct {
+			ID       string          `json:"id"`
+			Type     string          `json:"type"`
+			Command  string          `json:"command"`
+			Changes  json.RawMessage `json:"changes"`
+			Tool     string          `json:"tool"`
+			Server   string          `json:"server"`
+			Status   string          `json:"status"`
+			ExitCode *int            `json:"exitCode"`
+			Output   string          `json:"aggregatedOutput"`
+		} `json:"item"`
+	}
+	if err := json.Unmarshal(params, &n); err != nil {
+		return
+	}
+	switch n.Item.Type {
+	case "agentMessage":
+		c.mu.Lock()
+		b, ok := c.messages[n.Item.ID]
+		if ok {
+			delete(c.messages, n.Item.ID)
+		}
+		c.mu.Unlock()
+		if ok && strings.TrimSpace(b.String()) != "" {
+			_ = c.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: b.String()})
+		}
+	case "commandExecution":
+		status := "completed"
+		if n.Item.Status == "declined" || n.Item.Status == "failed" {
+			status = "failed"
+		}
+		_ = c.emit(protocol.EventToolCall, protocol.ToolCallPayload{Tool: "Command", Status: status})
+		_ = c.emit(protocol.EventCommand, protocol.CommandPayload{
+			Command: n.Item.Command, ExitCode: n.Item.ExitCode, Output: truncate(n.Item.Output, 2000),
+		})
+	case "fileChange":
+		status := "completed"
+		if n.Item.Status == "declined" || n.Item.Status == "failed" {
+			status = "failed"
+		}
+		_ = c.emit(protocol.EventToolCall, protocol.ToolCallPayload{Tool: "FileChange", Status: status})
+		for _, p := range fileChangePaths(n.Item.Changes) {
+			_ = c.emit(protocol.EventFileChange, protocol.FileChangePayload{Path: p, Summary: "updated"})
+		}
+	case "mcpToolCall", "dynamicToolCall":
+		_ = c.emit(protocol.EventToolCall, protocol.ToolCallPayload{Tool: firstNonEmpty(n.Item.Server, n.Item.Tool), Status: "completed"})
+	}
+}
+
+func (c *Codex) handleAgentDelta(params json.RawMessage) {
+	var n struct {
+		ItemID string `json:"itemId"`
+		Delta  string `json:"delta"`
+	}
+	if err := json.Unmarshal(params, &n); err != nil {
+		return
+	}
+	c.mu.Lock()
+	if b, ok := c.messages[n.ItemID]; ok {
+		b.WriteString(n.Delta)
+	}
+	c.mu.Unlock()
+}
+
+func (c *Codex) handleTurnCompleted(params json.RawMessage) {
+	var n struct {
+		Turn struct {
+			Status string `json:"status"`
+		} `json:"turn"`
+	}
+	_ = json.Unmarshal(params, &n)
+	c.mu.Lock()
+	c.turnActive = false
+	c.mu.Unlock()
+	c.flushMessages()
+	status := protocol.StatusDone
+	if n.Turn.Status == "failed" {
+		status = protocol.StatusError
+	}
+	_ = c.emit(protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: status})
+}
+
+func (c *Codex) handleServerRequest(method string, id json.RawMessage, params json.RawMessage) {
+	requestID := ""
+	if json.Unmarshal(id, &requestID) != nil {
+		var n int
+		if json.Unmarshal(id, &n) != nil {
+			return
+		}
+		requestID = strconv.Itoa(n)
+	}
+	var req struct {
+		ItemID      string `json:"itemId"`
+		Command     string `json:"command"`
+		Reason      string `json:"reason"`
+		Permissions []struct {
+			Name string `json:"name"`
+		} `json:"permissions"`
+		Changes []struct {
+			Path string `json:"path"`
+		} `json:"changes"`
+	}
+	_ = json.Unmarshal(params, &req)
+	var kind, action, summary string
+	switch method {
+	case "item/commandExecution/requestApproval":
+		kind = "command"
+		action = "Command"
+		summary = firstNonEmpty(req.Command, req.Reason)
+	case "item/fileChange/requestApproval":
+		kind = "file"
+		action = "FileChange"
+		var paths []string
+		for _, ch := range req.Changes {
+			paths = append(paths, ch.Path)
+		}
+		summary = strings.Join(paths, ", ")
+	case "item/permissions/requestApproval":
+		kind = "permissions"
+		action = "Permissions"
+		var names []string
+		for _, p := range req.Permissions {
+			names = append(names, p.Name)
+		}
+		summary = strings.Join(names, ", ")
+	default:
+		log.Printf("codex[%s] unhandled server request %s", c.id, method)
+		return
+	}
+	p := pendingApproval{kind: kind, action: action, summary: summary}
+	if kind == "permissions" {
+		for _, perm := range req.Permissions {
+			p.requested = append(p.requested, perm.Name)
+		}
+	}
+	c.mu.Lock()
+	c.pending[requestID] = p
+	c.mu.Unlock()
+	_ = c.emit(protocol.EventApprovalReq, protocol.ApprovalRequestPayload{
+		RequestID: requestID,
+		Action:    action,
+		Summary:   summary,
+		Options:   []string{"approve", "reject"},
+	})
+}
+
+func (c *Codex) flushMessages() {
+	c.mu.Lock()
+	msgs := make([]string, 0, len(c.messages))
+	for id, b := range c.messages {
+		if strings.TrimSpace(b.String()) != "" {
+			msgs = append(msgs, b.String())
+		}
+		delete(c.messages, id)
+	}
+	c.mu.Unlock()
+	for _, text := range msgs {
+		_ = c.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: text})
+	}
+}
+
+func (c *Codex) emit(typ string, payload any) error {
+	ev, err := protocol.NewEvent(c.id, typ, payload)
+	if err != nil {
+		return err
+	}
+	select {
+	case c.events <- ev:
+		return nil
+	case <-c.stopCh:
+		return nil
+	default:
+		return nil
+	}
+}
+
+func fileChangePaths(raw json.RawMessage) []string {
+	var changes []struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(raw, &changes); err != nil {
+		return nil
+	}
+	var out []string
+	for _, ch := range changes {
+		if ch.Path != "" {
+			out = append(out, ch.Path)
+		}
+	}
+	return out
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "\n…[truncated]"
+}

--- a/apps/daemon/internal/codex/codex_test.go
+++ b/apps/daemon/internal/codex/codex_test.go
@@ -1,0 +1,122 @@
+package codex
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
+	"github.com/riffpad/riffpad/packages/protocol"
+)
+
+type fakeWriteCloser struct {
+	bytes.Buffer
+}
+
+func (f *fakeWriteCloser) Close() error { return nil }
+
+func nextEvent(t *testing.T, c *Codex) protocol.Event {
+	t.Helper()
+	select {
+	case ev := <-c.Events():
+		return ev
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+		return protocol.Event{}
+	}
+}
+
+func TestInitializeAndThreadStart(t *testing.T) {
+	c := New(adapter.CreateRequest{ID: "s1", Cwd: "/tmp/proj"})
+	c.handleLine([]byte(`{"id":1,"result":{"userAgent":"riffpad/0.146.1"}}`))
+	c.handleLine([]byte(`{"id":2,"result":{"thread":{"id":"thr_123"}}}`))
+	select {
+	case <-c.ready:
+	case <-time.After(time.Second):
+		t.Fatal("expected ready after thread/start")
+	}
+	if c.threadID != "thr_123" {
+		t.Fatalf("unexpected thread id %q", c.threadID)
+	}
+}
+
+func TestAgentMessageAggregation(t *testing.T) {
+	c := New(adapter.CreateRequest{ID: "s1"})
+	c.handleLine([]byte(`{"method":"item/started","params":{"item":{"id":"msg1","type":"agentMessage"}}}`))
+	c.handleLine([]byte(`{"method":"item/agentMessage/delta","params":{"threadId":"t","turnId":"u","itemId":"msg1","delta":"Hel"}}`))
+	c.handleLine([]byte(`{"method":"item/agentMessage/delta","params":{"threadId":"t","turnId":"u","itemId":"msg1","delta":"lo"}}`))
+	c.handleLine([]byte(`{"method":"item/completed","params":{"item":{"id":"msg1","type":"agentMessage","text":"Hello"}}}`))
+	ev := nextEvent(t, c)
+	if ev.Type != protocol.EventAgentMessage {
+		t.Fatalf("expected agent_message, got %s", ev.Type)
+	}
+	var p protocol.AgentMessagePayload
+	if err := ev.DecodePayload(&p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Text != "Hello" {
+		t.Fatalf("expected %q, got %q", "Hello", p.Text)
+	}
+}
+
+func TestTurnCompletedStatus(t *testing.T) {
+	c := New(adapter.CreateRequest{ID: "s1"})
+	c.handleLine([]byte(`{"id":3,"result":{"turn":{"id":"t1","status":"inProgress"}}}`))
+	ev := nextEvent(t, c)
+	if ev.Type != protocol.EventAgentStatus {
+		t.Fatalf("expected agent_status, got %s", ev.Type)
+	}
+	c.handleLine([]byte(`{"method":"turn/completed","params":{"turn":{"id":"t1","status":"completed"}}}`))
+	ev = nextEvent(t, c)
+	if ev.Type != protocol.EventAgentStatus {
+		t.Fatalf("expected agent_status, got %s", ev.Type)
+	}
+	if c.turnActive {
+		t.Fatal("turn should be inactive after completion")
+	}
+}
+
+func TestCommandApproval(t *testing.T) {
+	c := New(adapter.CreateRequest{ID: "s1"})
+	fw := &fakeWriteCloser{}
+	c.stdin = fw
+	c.handleLine([]byte(`{"id":"req_1","method":"item/commandExecution/requestApproval","params":{"itemId":"it1","threadId":"thr1","turnId":"tu1","command":"rm -rf build","reason":"clean"}}`))
+	ev := nextEvent(t, c)
+	if ev.Type != protocol.EventApprovalReq {
+		t.Fatalf("expected approval_request, got %s", ev.Type)
+	}
+	var p protocol.ApprovalRequestPayload
+	if err := ev.DecodePayload(&p); err != nil {
+		t.Fatal(err)
+	}
+	if p.RequestID != "req_1" || p.Action != "Command" || p.Summary != "rm -rf build" {
+		t.Fatalf("unexpected approval: %+v", p)
+	}
+	if err := c.SendApproval("req_1", "approve"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(fw.String(), `"decision":"accept"`) {
+		t.Fatalf("unexpected approval response: %s", fw.String())
+	}
+	if err := c.SendApproval("req_1", "approve"); err == nil {
+		t.Fatal("expected error for already-resolved approval")
+	}
+}
+
+func TestPermissionsApproval(t *testing.T) {
+	c := New(adapter.CreateRequest{ID: "s1"})
+	fw := &fakeWriteCloser{}
+	c.stdin = fw
+	c.handleLine([]byte(`{"id":"req_2","method":"item/permissions/requestApproval","params":{"itemId":"it2","threadId":"thr1","turnId":"tu1","permissions":[{"name":"network","reason":"download"}]}}`))
+	ev := nextEvent(t, c)
+	if ev.Type != protocol.EventApprovalReq {
+		t.Fatalf("expected approval_request, got %s", ev.Type)
+	}
+	if err := c.SendApproval("req_2", "approve"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(fw.String(), `"permissions":["network"]`) {
+		t.Fatalf("unexpected approval response: %s", fw.String())
+	}
+}

--- a/apps/daemon/internal/daemon/server.go
+++ b/apps/daemon/internal/daemon/server.go
@@ -15,7 +15,9 @@ import (
 
 	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
 	"github.com/riffpad/riffpad/apps/daemon/internal/claude"
+	"github.com/riffpad/riffpad/apps/daemon/internal/codex"
 	"github.com/riffpad/riffpad/apps/daemon/internal/config"
+	"github.com/riffpad/riffpad/apps/daemon/internal/kimi"
 	"github.com/riffpad/riffpad/packages/protocol"
 	"github.com/riffpad/riffpad/packages/webui"
 )
@@ -109,6 +111,10 @@ func DefaultFactory() adapter.Factory {
 		switch req.CLI {
 		case "", "claude":
 			return claude.New(req), nil
+		case "kimi":
+			return kimi.New(req), nil
+		case "codex":
+			return codex.New(req), nil
 		default:
 			return nil, fmt.Errorf("unsupported cli %q", req.CLI)
 		}

--- a/apps/daemon/internal/kimi/kimi.go
+++ b/apps/daemon/internal/kimi/kimi.go
@@ -1,0 +1,603 @@
+// Package kimi implements the Kimi Code adapter over the Agent Client
+// Protocol (ACP). The daemon spawns `kimi acp` (a stdio JSON-RPC server) and
+// acts as an ACP client: initialize -> session/new -> session/prompt, with
+// streamed session/update notifications and session/request_permission
+// approvals. No tmux is required.
+package kimi
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
+	"github.com/riffpad/riffpad/packages/protocol"
+)
+
+type pendingApproval struct {
+	sessionID string
+	action    string
+	summary   string
+	options   map[string]string // optionId -> name
+}
+
+// Kimi is a Kimi Code session driven through the ACP stdio server.
+type Kimi struct {
+	id      string
+	name    string
+	cwd     string
+	prompt  string
+	binary  string
+	events  chan protocol.Event
+	stopCh  chan struct{}
+	doneCh  chan struct{}
+	readyCh chan struct{}
+
+	mu            sync.Mutex
+	ctx           context.Context
+	cmd           *exec.Cmd
+	stdin         io.WriteCloser
+	launched      bool
+	exited        bool
+	sessionID     string
+	initError     error
+	nextRequestID int
+	pending       map[string]pendingApproval
+	msgBuf        strings.Builder
+	msgActive     bool
+}
+
+// New creates a Kimi Code ACP session adapter.
+func New(req adapter.CreateRequest) *Kimi {
+	binary := req.Binary
+	if binary == "" {
+		binary = "kimi"
+	}
+	return &Kimi{
+		id:            req.ID,
+		name:          req.Name,
+		cwd:           req.Cwd,
+		prompt:        req.Prompt,
+		binary:        binary,
+		events:        make(chan protocol.Event, 256),
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+		readyCh:       make(chan struct{}),
+		nextRequestID: 1,
+		pending:       make(map[string]pendingApproval),
+	}
+}
+
+func (k *Kimi) ID() string                    { return k.id }
+func (k *Kimi) Events() <-chan protocol.Event { return k.events }
+func (k *Kimi) Meta() protocol.SessionStartPayload {
+	return protocol.SessionStartPayload{Name: k.name, CLI: "kimi", Cwd: k.cwd}
+}
+
+// Start records the context and spawns `kimi acp`. The initial prompt is sent
+// once the ACP session is ready.
+func (k *Kimi) Start(ctx context.Context) error {
+	k.mu.Lock()
+	k.ctx = ctx
+	k.mu.Unlock()
+	if err := k.ensureStarted(); err != nil {
+		return err
+	}
+	if k.prompt != "" {
+		if err := k.waitReady(); err != nil {
+			return err
+		}
+		return k.SendPrompt(k.prompt)
+	}
+	return nil
+}
+
+func (k *Kimi) ensureStarted() error {
+	k.mu.Lock()
+	if k.launched {
+		k.mu.Unlock()
+		return nil
+	}
+	if k.ctx == nil {
+		k.mu.Unlock()
+		return fmt.Errorf("session not started")
+	}
+	k.launched = true
+	ctx := k.ctx
+	k.mu.Unlock()
+	return k.spawn(ctx)
+}
+
+func (k *Kimi) spawn(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, k.binary, "acp")
+	if k.cwd != "" {
+		cmd.Dir = k.cwd
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start %s acp: %w", k.binary, err)
+	}
+	k.mu.Lock()
+	k.cmd = cmd
+	k.stdin = stdin
+	k.mu.Unlock()
+	go k.readLoop(stdout)
+	go k.copyStderr(stderr)
+	go func() {
+		<-k.stopCh
+		if k.cmd != nil && k.cmd.Process != nil {
+			_ = k.cmd.Process.Kill()
+		}
+	}()
+	// ACP initialization: protocol negotiation, then session creation.
+	_ = k.request("initialize", map[string]any{
+		"protocolVersion": 1,
+		"clientCapabilities": map[string]any{
+			"fs":       map[string]any{"readTextFile": false, "writeTextFile": false},
+			"terminal": false,
+		},
+		"clientInfo": map[string]any{"name": "riffpad", "version": "0.1.0"},
+	})
+	return nil
+}
+
+// Stop terminates the ACP server.
+func (k *Kimi) Stop() error {
+	k.mu.Lock()
+	launched := k.launched
+	k.mu.Unlock()
+	select {
+	case <-k.stopCh:
+		return nil
+	default:
+		close(k.stopCh)
+	}
+	if !launched {
+		return nil
+	}
+	if k.cmd != nil && k.cmd.Process != nil {
+		_ = k.cmd.Process.Kill()
+	}
+	<-k.doneCh
+	return nil
+}
+
+// Alive reports whether the ACP server process is running.
+func (k *Kimi) Alive() bool {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	return k.launched && !k.exited
+}
+
+// SendPrompt sends a text prompt to the current ACP session.
+func (k *Kimi) SendPrompt(text string) error {
+	if err := k.ensureStarted(); err != nil {
+		return err
+	}
+	if err := k.waitReady(); err != nil {
+		return err
+	}
+	return k.request("session/prompt", map[string]any{
+		"sessionId": k.sessionID,
+		"prompt":    []any{map[string]any{"type": "text", "text": text}},
+	})
+}
+
+// SendApproval resolves a pending session/request_permission.
+func (k *Kimi) SendApproval(requestID, decision string) error {
+	k.mu.Lock()
+	p, ok := k.pending[requestID]
+	if ok {
+		delete(k.pending, requestID)
+	}
+	k.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("no pending approval %s", requestID)
+	}
+	kind := "allow_once"
+	if decision == "reject" {
+		kind = "reject_once"
+	}
+	optionID := ""
+	for id, name := range p.options {
+		if decision == "reject" && strings.Contains(name, "Reject") {
+			optionID = id
+			break
+		}
+		if decision == "approve" && !strings.Contains(name, "Reject") {
+			optionID = id
+			break
+		}
+		_ = kind
+	}
+	if optionID == "" {
+		// Fall back to the first option id.
+		for id := range p.options {
+			optionID = id
+			break
+		}
+	}
+	if optionID == "" {
+		return fmt.Errorf("approval %s has no selectable option", requestID)
+	}
+	return k.writeJSON(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      requestID,
+		"result": map[string]any{
+			"outcome": map[string]any{"outcome": "selected", "optionId": optionID},
+		},
+	})
+}
+
+func (k *Kimi) waitReady() error {
+	select {
+	case <-k.readyCh:
+		k.mu.Lock()
+		err := k.initError
+		sid := k.sessionID
+		k.mu.Unlock()
+		if err != nil {
+			return err
+		}
+		if sid == "" {
+			return fmt.Errorf("kimi session not initialized")
+		}
+		return nil
+	case <-k.stopCh:
+		return fmt.Errorf("session stopped")
+	case <-time.After(30 * time.Second):
+		return fmt.Errorf("kimi ACP initialization timed out")
+	}
+}
+
+func (k *Kimi) request(method string, params map[string]any) error {
+	k.mu.Lock()
+	id := k.nextRequestID
+	k.nextRequestID++
+	k.mu.Unlock()
+	return k.writeJSON(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  method,
+		"params":  params,
+	})
+}
+
+func (k *Kimi) writeJSON(v any) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.stdin == nil {
+		return fmt.Errorf("stdin not ready")
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(k.stdin, string(data)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (k *Kimi) readLoop(r io.Reader) {
+	defer close(k.doneCh)
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		k.handleLine(line)
+	}
+	if k.cmd != nil && k.cmd.Process != nil {
+		_ = k.cmd.Wait()
+	}
+	k.flushMessage()
+	k.mu.Lock()
+	k.exited = true
+	k.mu.Unlock()
+	_ = k.emit(protocol.EventSessionEnd, protocol.SessionEndPayload{Reason: "process_exit"})
+}
+
+func (k *Kimi) copyStderr(r io.Reader) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		log.Printf("kimi[%s] stderr: %s", k.id, scanner.Text())
+	}
+}
+
+// handleLine processes one JSON-RPC line from the ACP server.
+func (k *Kimi) handleLine(line []byte) {
+	var msg struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Method  string          `json:"method"`
+		Result  json.RawMessage `json:"result"`
+		Error   json.RawMessage `json:"error"`
+		Params  json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return
+	}
+	if len(msg.Error) > 0 && string(msg.Error) != "null" {
+		var e struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(msg.Error, &e)
+		k.mu.Lock()
+		k.initError = fmt.Errorf("kimi ACP error: %s", e.Message)
+		k.mu.Unlock()
+		k.closeReady()
+		_ = k.emit(protocol.EventNotify, protocol.NotifyPayload{Level: "error", Message: e.Message})
+		return
+	}
+	if msg.Method != "" {
+		k.handleNotification(msg.Method, msg.ID, msg.Params)
+		return
+	}
+	k.handleResponse(msg.ID, msg.Result)
+}
+
+func (k *Kimi) closeReady() {
+	select {
+	case <-k.readyCh:
+	default:
+		close(k.readyCh)
+	}
+}
+
+func (k *Kimi) handleResponse(id json.RawMessage, result json.RawMessage) {
+	var rid int
+	if err := json.Unmarshal(id, &rid); err != nil {
+		return
+	}
+	var res struct {
+		SessionID  string `json:"sessionId"`
+		StopReason string `json:"stopReason"`
+	}
+	_ = json.Unmarshal(result, &res)
+	switch rid {
+	case 1:
+		// initialize response; session/new follows immediately.
+		_ = k.request("session/new", map[string]any{
+			"cwd":        k.cwd,
+			"mcpServers": []any{},
+		})
+	case 2:
+		k.mu.Lock()
+		k.sessionID = res.SessionID
+		k.mu.Unlock()
+		if res.SessionID == "" {
+			k.mu.Lock()
+			k.initError = fmt.Errorf("kimi session/new returned no sessionId")
+			k.mu.Unlock()
+		}
+		k.closeReady()
+	default:
+		// A session/prompt response ends the current turn.
+		k.flushMessage()
+		status := protocol.StatusDone
+		if res.StopReason == "error" || res.StopReason == "max_turns" {
+			status = protocol.StatusError
+		}
+		_ = k.emit(protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: status})
+	}
+}
+
+func (k *Kimi) handleNotification(method string, id json.RawMessage, params json.RawMessage) {
+	switch method {
+	case "session/update":
+		k.handleSessionUpdate(params)
+	case "session/request_permission":
+		k.handlePermissionRequest(id, params)
+	default:
+		log.Printf("kimi[%s] unhandled ACP notification %s", k.id, method)
+	}
+}
+
+func (k *Kimi) handleSessionUpdate(params json.RawMessage) {
+	var n struct {
+		SessionID string `json:"sessionId"`
+		Update    struct {
+			SessionUpdate string          `json:"sessionUpdate"`
+			Content       json.RawMessage `json:"content"`
+			ToolCall      json.RawMessage `json:"toolCall"`
+			Title         string          `json:"title"`
+		} `json:"update"`
+	}
+	if err := json.Unmarshal(params, &n); err != nil {
+		return
+	}
+	switch n.Update.SessionUpdate {
+	case "user_message_chunk":
+		var c struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if json.Unmarshal(n.Update.Content, &c) == nil && c.Type == "text" && c.Text != "" {
+			_ = k.emit(protocol.EventUserMessage, protocol.AgentMessagePayload{Text: c.Text})
+		}
+	case "agent_message_chunk":
+		var c struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if json.Unmarshal(n.Update.Content, &c) == nil && c.Type == "text" {
+			k.mu.Lock()
+			k.msgBuf.WriteString(c.Text)
+			k.msgActive = true
+			k.mu.Unlock()
+		}
+	case "tool_call":
+		k.handleToolCall(n.Update.ToolCall, "started")
+	case "tool_call_update":
+		k.handleToolCallUpdate(n.Update.ToolCall)
+	}
+}
+
+func (k *Kimi) handleToolCall(raw json.RawMessage, status string) {
+	var tc struct {
+		ToolCallID string          `json:"toolCallId"`
+		Title      string          `json:"title"`
+		Kind       string          `json:"kind"`
+		RawInput   json.RawMessage `json:"rawInput"`
+	}
+	if err := json.Unmarshal(raw, &tc); err != nil {
+		return
+	}
+	args := map[string]any{}
+	_ = json.Unmarshal(tc.RawInput, &args)
+	_ = k.emit(protocol.EventToolCall, protocol.ToolCallPayload{
+		Tool:    firstNonEmpty(tc.Title, tc.Kind),
+		Status:  status,
+		Summary: summarizeTool(tc.Title, args),
+		Args:    args,
+	})
+}
+
+func (k *Kimi) handleToolCallUpdate(raw json.RawMessage) {
+	var tc struct {
+		ToolCallID string          `json:"toolCallId"`
+		Status     string          `json:"status"`
+		Title      string          `json:"title"`
+		RawOutput  json.RawMessage `json:"rawOutput"`
+	}
+	if err := json.Unmarshal(raw, &tc); err != nil {
+		return
+	}
+	if tc.Status == "" {
+		return
+	}
+	status := "completed"
+	if strings.Contains(tc.Status, "fail") || strings.Contains(tc.Status, "error") {
+		status = "failed"
+	}
+	_ = k.emit(protocol.EventToolCall, protocol.ToolCallPayload{Tool: tc.Title, Status: status})
+}
+
+func (k *Kimi) handlePermissionRequest(id json.RawMessage, params json.RawMessage) {
+	var req struct {
+		SessionID string `json:"sessionId"`
+		ToolCall  struct {
+			ToolCallID string          `json:"toolCallId"`
+			Title      string          `json:"title"`
+			Kind       string          `json:"kind"`
+			RawInput   json.RawMessage `json:"rawInput"`
+		} `json:"toolCall"`
+		Options []struct {
+			OptionID string `json:"optionId"`
+			Name     string `json:"name"`
+			Kind     string `json:"kind"`
+		} `json:"options"`
+	}
+	if err := json.Unmarshal(params, &req); err != nil {
+		return
+	}
+	requestID := ""
+	if json.Unmarshal(id, &requestID) != nil {
+		var n int
+		if json.Unmarshal(id, &n) != nil {
+			return
+		}
+		requestID = strconv.Itoa(n)
+	}
+	options := map[string]string{}
+	optionNames := []string{}
+	for _, o := range req.Options {
+		options[o.OptionID] = o.Name
+		optionNames = append(optionNames, o.Name)
+	}
+	args := map[string]any{}
+	_ = json.Unmarshal(req.ToolCall.RawInput, &args)
+	k.mu.Lock()
+	k.pending[requestID] = pendingApproval{
+		sessionID: req.SessionID,
+		action:    firstNonEmpty(req.ToolCall.Title, req.ToolCall.Kind),
+		summary:   summarizeTool(req.ToolCall.Title, args),
+		options:   options,
+	}
+	k.mu.Unlock()
+	_ = k.emit(protocol.EventApprovalReq, protocol.ApprovalRequestPayload{
+		RequestID: requestID,
+		Action:    firstNonEmpty(req.ToolCall.Title, req.ToolCall.Kind),
+		Summary:   summarizeTool(req.ToolCall.Title, args),
+		Options:   optionNames,
+		Args:      args,
+	})
+}
+
+func (k *Kimi) flushMessage() {
+	k.mu.Lock()
+	if !k.msgActive {
+		k.mu.Unlock()
+		return
+	}
+	text := k.msgBuf.String()
+	k.msgBuf.Reset()
+	k.msgActive = false
+	k.mu.Unlock()
+	if strings.TrimSpace(text) != "" {
+		_ = k.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: text})
+	}
+}
+
+func (k *Kimi) emit(typ string, payload any) error {
+	ev, err := protocol.NewEvent(k.id, typ, payload)
+	if err != nil {
+		return err
+	}
+	select {
+	case k.events <- ev:
+		return nil
+	case <-k.stopCh:
+		return nil
+	default:
+		return nil
+	}
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func summarizeTool(title string, args map[string]any) string {
+	if title != "" {
+		return title
+	}
+	if cmd, ok := args["command"].(string); ok {
+		return cmd
+	}
+	if p, ok := args["filePath"].(string); ok {
+		return "file: " + p
+	}
+	if p, ok := args["file_path"].(string); ok {
+		return "file: " + p
+	}
+	return ""
+}

--- a/apps/daemon/internal/kimi/kimi_test.go
+++ b/apps/daemon/internal/kimi/kimi_test.go
@@ -1,0 +1,116 @@
+package kimi
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
+	"github.com/riffpad/riffpad/packages/protocol"
+)
+
+type fakeWriteCloser struct {
+	bytes.Buffer
+}
+
+func (f *fakeWriteCloser) Close() error { return nil }
+
+func nextEvent(t *testing.T, c *Kimi) protocol.Event {
+	t.Helper()
+	select {
+	case ev := <-c.Events():
+		return ev
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+		return protocol.Event{}
+	}
+}
+
+func TestInitializeAndSessionNew(t *testing.T) {
+	k := New(adapter.CreateRequest{ID: "s1", Cwd: "/tmp/proj"})
+	k.handleLine([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"agentInfo":{"name":"Kimi Code CLI","version":"x"}}}`))
+	k.handleLine([]byte(`{"jsonrpc":"2.0","id":2,"result":{"sessionId":"session_abc","configOptions":[]}}`))
+	select {
+	case <-k.readyCh:
+	case <-time.After(time.Second):
+		t.Fatal("expected ready after session/new")
+	}
+	if k.sessionID != "session_abc" {
+		t.Fatalf("unexpected session id %q", k.sessionID)
+	}
+}
+
+func TestAgentMessageChunksAggregated(t *testing.T) {
+	k := New(adapter.CreateRequest{ID: "s1"})
+	k.handleLine([]byte(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hel"}}}}`))
+	k.handleLine([]byte(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"lo"}}}}`))
+	k.handleLine([]byte(`{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn"}}`))
+	ev := nextEvent(t, k)
+	if ev.Type != protocol.EventAgentMessage {
+		t.Fatalf("expected agent_message, got %s", ev.Type)
+	}
+	var p protocol.AgentMessagePayload
+	if err := ev.DecodePayload(&p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Text != "Hello" {
+		t.Fatalf("expected aggregated text %q, got %q", "Hello", p.Text)
+	}
+	ev = nextEvent(t, k)
+	if ev.Type != protocol.EventAgentStatus {
+		t.Fatalf("expected agent_status, got %s", ev.Type)
+	}
+}
+
+func TestToolCallEvents(t *testing.T) {
+	k := New(adapter.CreateRequest{ID: "s1"})
+	k.handleLine([]byte(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"tool_call","toolCall":{"toolCallId":"t1","title":"Run command","kind":"shell","status":"running","rawInput":{"command":"ls"}}}}}`))
+	k.handleLine([]byte(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"tool_call_update","toolCall":{"toolCallId":"t1","title":"Run command","status":"completed","rawOutput":"src"}}}}`))
+	ev := nextEvent(t, k)
+	if ev.Type != protocol.EventToolCall {
+		t.Fatalf("expected tool_call, got %s", ev.Type)
+	}
+	var p protocol.ToolCallPayload
+	if err := ev.DecodePayload(&p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Tool != "Run command" || p.Status != "started" {
+		t.Fatalf("unexpected tool call: %+v", p)
+	}
+	ev = nextEvent(t, k)
+	if err := ev.DecodePayload(&p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Status != "completed" {
+		t.Fatalf("expected completed, got %s", p.Status)
+	}
+}
+
+func TestPermissionRequestAndApproval(t *testing.T) {
+	k := New(adapter.CreateRequest{ID: "s1"})
+	fw := &fakeWriteCloser{}
+	k.stdin = fw
+	k.handleLine([]byte(`{"jsonrpc":"2.0","id":"perm_1","method":"session/request_permission","params":{"sessionId":"s1","toolCall":{"toolCallId":"t1","title":"Write file","kind":"write","rawInput":{"filePath":"/tmp/x"}},"options":[{"optionId":"allow","name":"Allow","kind":"allow_once"},{"optionId":"reject","name":"Reject","kind":"reject_once"}]}}`))
+	ev := nextEvent(t, k)
+	if ev.Type != protocol.EventApprovalReq {
+		t.Fatalf("expected approval_request, got %s", ev.Type)
+	}
+	var p protocol.ApprovalRequestPayload
+	if err := ev.DecodePayload(&p); err != nil {
+		t.Fatal(err)
+	}
+	if p.RequestID != "perm_1" || p.Action != "Write file" {
+		t.Fatalf("unexpected approval: %+v", p)
+	}
+	if err := k.SendApproval("perm_1", "approve"); err != nil {
+		t.Fatal(err)
+	}
+	out := fw.String()
+	if !strings.Contains(out, `"optionId":"allow"`) || !strings.Contains(out, `"outcome":"selected"`) {
+		t.Fatalf("unexpected approval response: %s", out)
+	}
+	if err := k.SendApproval("perm_1", "approve"); err == nil {
+		t.Fatal("expected error for already-resolved approval")
+	}
+}

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -212,7 +212,7 @@
 | M3.4 | 局域网直连 / WebRTC（relay 退化信令） | `[ ]` | 局域网内无中继可用 | — |
 | M3.5 | Windows daemon | `[ ]` | 安装包 + 自启动 | — |
 | M3.6 | 团队版（多人共享设备/会话） | `[ ]` | 权限模型可用 | — |
-| M3.7 | 无 tmux 注入：Kimi ACP / Codex app-server / Claude host 控制协议 | `[ ]` | 调研完成（见 agent-injection-research.md），三个通道均已实测可行；实现按 Kimi → Codex → Claude 排序 | #52 |
+| M3.7 | 无 tmux 注入：Kimi ACP / Codex app-server / Claude host 控制协议 | `[x]` | 三个适配器已实现并真机实测（回复/事件流/审批协议均通）：`riffpad run --cli kimi/codex/claude` | #55 #52 |
 
 ---
 

--- a/packages/webui/app.js
+++ b/packages/webui/app.js
@@ -146,12 +146,14 @@ async function createSession(ev) {
     body: JSON.stringify({
       name: $("s-name").value,
       prompt: $("s-prompt").value,
+      cli: $("s-cli").value,
       cwd: $("s-cwd").value
     })
   });
   const data = await res.json();
   if (!res.ok) throw new Error(data.error || "启动失败");
   $("s-name").value = ""; $("s-prompt").value = ""; $("s-cwd").value = "";
+  $("s-cli").value = "claude";
   await refreshSessions();
   openDetail(data.id, data.name);
 }

--- a/packages/webui/index.html
+++ b/packages/webui/index.html
@@ -45,7 +45,14 @@
           <input id="s-prompt" placeholder="初始指令（可选）">
         </div>
         <div class="row">
+          <select id="s-cli">
+            <option value="claude">Claude Code</option>
+            <option value="kimi">Kimi Code</option>
+            <option value="codex">Codex</option>
+          </select>
           <input id="s-cwd" placeholder="工作目录（默认 daemon 当前目录）">
+        </div>
+        <div class="row">
           <button type="submit">启动会话</button>
         </div>
       </form>


### PR DESCRIPTION
## 背景
基于 #52 调研结论实现无 tmux 指令注入适配器（#55）。

## 改动
- **Claude Code（改造）**：包装模式从 `-p`（单轮、权限自动拒绝）改为 host 控制协议——去掉 `-p`，spawn 后发送 `control_request/initialize`（2.1.x camelCase `matchers`/`hookCallbackIds` 新格式），支持多轮注入；UserPromptSubmit hook 回调自动应答；turn 的 result 不再误报会话结束
- **Kimi Code（新增）**：ACP client 适配器（spawn `kimi acp`），initialize → session/new → session/prompt；聚合 `agent_message_chunk` 为完整消息；`session/request_permission` 映射审批卡片，approve/reject 回写选项
- **Codex（新增）**：app-server JSON-RPC 适配器（spawn `codex app-server --listen stdio://`），thread/start + turn/start/turn/steer；agentMessage delta 聚合；命令/文件/权限审批（`item/*/requestApproval`）映射审批卡片
- **注册与 UI**：DefaultFactory 支持 `kimi`/`codex`，`riffpad run --cli` 可选，网页创建会话增加 CLI 下拉框
- **测试**：三包单测覆盖初始化、消息聚合、工具事件、审批响应；全量 go build/test 通过

## 真机验证（本机）
- kimi：`Reply with exactly: OK` → agent_message OK / done（约 4s）
- codex：同上 → OK / done（约 25s，走 deepseek provider）
- claude：同上 → OK / done（host 控制协议，含 initialize 与 hook 应答）

## 验证步骤
1. `cd apps/daemon && go build ./... && go test ./...`
2. 重启本地 daemon（`riffpad daemon restart`）后：`riffpad run --cli kimi --prompt 'hi' --cwd <dir>`，网页打开会话查看
3. 同法 `--cli codex` / `--cli claude`

Closes #55