### PR TITLE
feat(cli): lazy daemon autostart + systemd setup (#57)

### DIFF
--- a/apps/daemon/cmd/riffpad/main.go
+++ b/apps/daemon/cmd/riffpad/main.go
@@ -52,19 +52,21 @@ func main() {
 	case "status":
 		err = statusCmd(base)
 	case "pair":
-		err = pairCmd(base)
+		err = withDaemon(func() error { return pairCmd(base) }, base, dataDir)
 	case "sessions":
-		err = sessionsCmd(base)
+		err = withDaemon(func() error { return sessionsCmd(base) }, base, dataDir)
 	case "run":
-		err = runCmd(os.Args[2:], base)
+		err = withDaemon(func() error { return runCmd(os.Args[2:], base) }, base, dataDir)
 	case "logs":
 		err = logsCmd(dataDir)
 	case "attach":
-		err = attachCmd(base)
+		err = withDaemon(func() error { return attachCmd(base) }, base, dataDir)
 	case "detach":
 		err = detachCmd()
 	case "relay":
 		err = relayCmd(os.Args[2:], dataDir)
+	case "setup":
+		err = setupCmd(os.Args[2:], dataDir)
 	case "version":
 		fmt.Println("riffpad", version)
 	case "help", "-h", "--help":
@@ -93,6 +95,7 @@ Usage:
   riffpad detach                remove injected hooks
   riffpad relay login           log in to the relay (--url wss://… --username …)
   riffpad relay logout          clear the saved relay token
+  riffpad setup                 install daemon auto-start (Linux systemd user service)
   riffpad logs                  tail daemon logs
   riffpad version`)
 }
@@ -146,6 +149,106 @@ func daemonStart(base, dataDir string) error {
 		}
 	}
 	return fmt.Errorf("daemon did not become reachable; check %s", filepath.Join(logDir, "daemon.out.log"))
+}
+
+// startDaemonFn is indirection so tests can observe/emulate lazy starts.
+var startDaemonFn = daemonStart
+
+// withDaemon ensures the daemon is running before executing an operation that
+// needs it. Only reachable checks and daemon start are guarded by a file lock,
+// so concurrent riffpad invocations start at most one daemon.
+func withDaemon(fn func() error, base, dataDir string) error {
+	if err := ensureDaemon(base, dataDir); err != nil {
+		return err
+	}
+	return fn()
+}
+
+func ensureDaemon(base, dataDir string) error {
+	if reachable(base) {
+		return nil
+	}
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		return err
+	}
+	lockPath := filepath.Join(dataDir, "daemon.lock")
+	lf, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("open daemon lock: %w", err)
+	}
+	defer lf.Close()
+	if err := syscall.Flock(int(lf.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("lock daemon start: %w", err)
+	}
+	defer syscall.Flock(int(lf.Fd()), syscall.LOCK_UN)
+	// Another process may have started the daemon while we waited for the lock.
+	if reachable(base) {
+		return nil
+	}
+	if err := startDaemonFn(base, dataDir); err != nil {
+		return err
+	}
+	return nil
+}
+
+// setupCmd installs (or removes) a Linux systemd user service so the daemon
+// starts at login and restarts after crashes.
+func setupCmd(args []string, dataDir string) error {
+	fs := flag.NewFlagSet("setup", flag.ExitOnError)
+	remove := fs.Bool("remove", false, "stop and remove the systemd user service")
+	_ = fs.Parse(args)
+	if runtime.GOOS != "linux" {
+		return fmt.Errorf("setup currently supports Linux systemd only")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	unitDir := filepath.Join(home, ".config", "systemd", "user")
+	unitPath := filepath.Join(unitDir, "riffpad.service")
+	if *remove {
+		_ = exec.Command("systemctl", "--user", "disable", "--now", "riffpad.service").Run()
+		if err := os.Remove(unitPath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		fmt.Println("已移除 riffpad systemd user 服务。")
+		return nil
+	}
+	bin, err := findRiffpadd()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(unitDir, 0o700); err != nil {
+		return err
+	}
+	execStart := bin
+	if strings.Contains(bin, " ") {
+		execStart = `"` + bin + `"`
+	}
+	unit := fmt.Sprintf(`[Unit]
+Description=Riffpad daemon (AI agent remote control)
+After=network-online.target
+
+[Service]
+ExecStart=%s --data-dir %s
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=default.target
+`, execStart, dataDir)
+	if err := os.WriteFile(unitPath, []byte(unit), 0o600); err != nil {
+		return err
+	}
+	if out, err := exec.Command("systemctl", "--user", "daemon-reload").CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl daemon-reload: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("systemctl", "--user", "enable", "--now", "riffpad.service").CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl enable riffpad: %v\n%s", err, out)
+	}
+	fmt.Printf("已安装并启用 %s\n", unitPath)
+	fmt.Println("daemon 将随登录自启，崩溃后自动重启；以后可直接运行 riffpad run/attach/pair。")
+	return nil
 }
 
 func daemonStop(base string) error {

--- a/apps/daemon/cmd/riffpad/main_test.go
+++ b/apps/daemon/cmd/riffpad/main_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func fakeDaemon(t *testing.T, ready *atomic.Bool) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/status" {
+			http.NotFound(w, r)
+			return
+		}
+		if ready.Load() {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestEnsureDaemonSkipsWhenReachable(t *testing.T) {
+	ready := &atomic.Bool{}
+	ready.Store(true)
+	srv := fakeDaemon(t, ready)
+	calls := 0
+	startDaemonFn = func(string, string) error { calls++; return nil }
+	defer func() { startDaemonFn = daemonStart }()
+
+	if err := ensureDaemon(srv.URL, t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected no daemon start when reachable, got %d", calls)
+	}
+}
+
+func TestEnsureDaemonStartsLazily(t *testing.T) {
+	ready := &atomic.Bool{}
+	srv := fakeDaemon(t, ready)
+	calls := 0
+	startDaemonFn = func(base, dataDir string) error {
+		calls++
+		if base != srv.URL {
+			t.Fatalf("unexpected base %q", base)
+		}
+		ready.Store(true)
+		return nil
+	}
+	defer func() { startDaemonFn = daemonStart }()
+
+	if err := ensureDaemon(srv.URL, t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected one daemon start, got %d", calls)
+	}
+}
+
+func TestEnsureDaemonConcurrentSingleStart(t *testing.T) {
+	ready := &atomic.Bool{}
+	srv := fakeDaemon(t, ready)
+	var mu sync.Mutex
+	calls := 0
+	startDaemonFn = func(string, string) error {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		time.Sleep(150 * time.Millisecond) // simulate slow startup
+		ready.Store(true)
+		return nil
+	}
+	defer func() { startDaemonFn = daemonStart }()
+
+	dataDir := t.TempDir()
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := ensureDaemon(srv.URL, dataDir); err != nil {
+				t.Errorf("ensureDaemon: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if calls != 1 {
+		t.Fatalf("expected exactly one daemon start under concurrency, got %d", calls)
+	}
+}

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -213,6 +213,7 @@
 | M3.5 | Windows daemon | `[ ]` | 安装包 + 自启动 | — |
 | M3.6 | 团队版（多人共享设备/会话） | `[ ]` | 权限模型可用 | — |
 | M3.7 | 无 tmux 注入：Kimi ACP / Codex app-server / Claude host 控制协议 | `[x]` | 三个适配器已实现并真机实测（回复/事件流/审批协议均通）：`riffpad run --cli kimi/codex/claude` | #55 #52 |
+| M3.8 | daemon 无感化启动：CLI 懒启动 + Linux systemd 自启 | `[x]` | `run/sessions/pair/attach` 自动拉起 daemon（文件锁防双实例）；`riffpad setup` 安装 systemd user service，`--remove` 卸载 | #57 |
 
 ---
 


### PR DESCRIPTION
## 背景
所有需要 daemon 的操作（run/sessions/pair/attach）以前必须手动 `riffpad daemon start`，与 docker 的体验不符（#57）。

## 改动
- `run` / `sessions` / `pair` / `attach` 自动探测 daemon，不可达时自动拉起（复用 daemonStart：detached + Setsid + pid + 就绪轮询）
- 文件锁（`daemon.lock` + flock）保证并发命令只启动一个 daemon；等待锁后二次探测避免竞态
- `status` 保持只报告不自动启动（保留探测语义）；`daemon stop` 不自动启动
- 新增 `riffpad setup`：生成并启用 Linux systemd user service（登录自启、Restart=on-failure）；`riffpad setup --remove` 卸载
- 单元测试覆盖：可达不启动、不可达启动一次、并发只启动一次

## 验证
- 空数据目录直接 `riffpad sessions` → 自动输出 `daemon started at ...` 并返回会话列表
- 再次 `sessions` 不重复启动；`daemon stop` 后再次 stop 报 not running（不反自启）

## 验证步骤
1. `cd apps/daemon && go build ./... && go test ./...`
2. `RIFFPAD_DIR=$(mktemp -d) RIFFPAD_URL=http://127.0.0.1:8788 ./riffpad sessions`（无需先 start）
3. 可选：`./riffpad setup` 安装 systemd 自启，`./riffpad setup --remove` 卸载

Closes #57