### PR TITLE
fix(landing): avoid react 18/19 @types conflict

### DIFF
--- a/apps/landing/app/layout.tsx
+++ b/apps/landing/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+import type { ReactNode } from "react";
 import "./globals.css";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { LanguageProvider } from "@/components/LanguageProvider";
@@ -64,7 +65,7 @@ const themeScript = `
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>

--- a/apps/landing/components/DeviceMockup.tsx
+++ b/apps/landing/components/DeviceMockup.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
 import { useLanguage } from "./LanguageProvider";
 import type { Messages } from "@/lib/i18n";
 
@@ -220,7 +221,7 @@ function MacTerminal({
   typing: boolean;
   syncing: boolean;
   syncLabel: string;
-  scrollRef: React.RefObject<HTMLDivElement>;
+  scrollRef: RefObject<HTMLDivElement>;
 }) {
   return (
     <div className="w-full overflow-hidden rounded-[10px] border border-hairline bg-console text-on-console shadow-[0_18px_50px_-12px_rgba(0,0,0,0.28)]">
@@ -314,7 +315,7 @@ function PhoneApp({
   syncing: boolean;
   onSend: (preset: Preset) => void;
   onResolve: (verdict: Exclude<Approval, "pending">) => void;
-  scrollRef: React.RefObject<HTMLDivElement>;
+  scrollRef: RefObject<HTMLDivElement>;
 }) {
   return (
     <div className="w-full rounded-[40px] bg-[#1b1b19] p-[10px] shadow-[0_24px_60px_-20px_rgba(0,0,0,0.45)] ring-1 ring-black/60">


### PR DESCRIPTION
CI（Frontend lint & build）在 landing `next build` 的类型检查阶段失败：

```
./app/layout.tsx:76:29
Type error: Type 'React.ReactNode' is not assignable to type '@types/react@18.3.31...ReactNode'.
  Type 'bigint' is not assignable to type 'ReactNode'.
```

原因：工作区同时存在 React 18（landing）与 React 19（client-beta）两套 `@types/react`，TS 的全局 `React` 命名空间解析到了 19（其 ReactNode 含 bigint），而组件 props 的类型来自 18，导致不匹配。这是合并 #60（client-beta 引入 React 19）后 lockfile 重新生成暴露的问题。

修复：landing 中不再依赖全局 `React.ReactNode` / `React.RefObject`，改为显式 `import type { ReactNode, RefObject } from "react"`，让所有 React 类型都来自 landing 自己的 @types/react 18。

验证：`pnpm --filter landing build` 本机通过；`pnpm --filter client-beta typecheck && build` 通过。