### PR TITLE
feat(install): single-binary riffpad + one-line install via riffpad.ai (#62)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build release binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install frontend deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build web client (embedded into binaries)
+        run: pnpm --filter client-beta build
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: apps/daemon/go.sum
+
+      - name: Cross-compile riffpad
+        working-directory: apps/daemon
+        run: |
+          mkdir -p dist
+          for target in "linux amd64" "linux arm64" "darwin amd64" "darwin arm64"; do
+            set -- $target
+            os=$1
+            arch=$2
+            CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" \
+              go build -trimpath -ldflags "-s -w" \
+              -o "dist/riffpad-$os-$arch" ./cmd/riffpad
+          done
+          (cd dist && sha256sum riffpad-* > sha256sums.txt)
+
+      - name: Upload binaries
+        uses: softprops/action-gh-release@v2
+        with:
+          files: apps/daemon/dist/*
+          generate_release_notes: true

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,12 @@ build-daemon:
 
 # Build and install riffpad/riffpadd to $(PREFIX) (default ~/.local/bin) so they
 # are available on PATH from any directory. Existing files are overwritten.
+# Build and install the single riffpad binary (CLI + daemon) to $(PREFIX)
+# (default ~/.local/bin) so it is available on PATH from any directory.
 install-daemon: build-daemon
 	mkdir -p $(PREFIX)
 	cp -f apps/daemon/bin/riffpad $(PREFIX)/riffpad
-	cp -f apps/daemon/bin/riffpadd $(PREFIX)/riffpadd
-	@echo "installed: $(PREFIX)/riffpad $(PREFIX)/riffpadd"
+	@echo "installed: $(PREFIX)/riffpad"
 
 install-relay:
 	cd apps/relay && mkdir -p bin && go build -o bin/relay .

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ curl -fsSL https://riffpad.ai/install.sh | sh
 **Windows PowerShell**
 
 ```powershell
-irm https://riffpad.ai/install.ps1 | iex
+# Coming soon — build from source for now.
 ```
 
 Then start the daemon and attach to your CLI:

--- a/apps/daemon/cmd/riffpad/main.go
+++ b/apps/daemon/cmd/riffpad/main.go
@@ -1,15 +1,20 @@
-// Command riffpad is the user-facing CLI controlling the local riffpadd daemon.
+// Command riffpad is the single Riffpad binary: user-facing CLI plus the
+// hidden `_daemon` subcommand that runs the background daemon.
 package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -21,6 +26,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/riffpad/riffpad/apps/daemon/internal/config"
+	"github.com/riffpad/riffpad/apps/daemon/internal/daemon"
 	"github.com/riffpad/riffpad/apps/daemon/internal/logging"
 )
 
@@ -30,6 +36,9 @@ func main() {
 	if len(os.Args) < 2 {
 		usage()
 		os.Exit(2)
+	}
+	if os.Args[1] == "_daemon" {
+		os.Exit(runDaemon(os.Args[2:]))
 	}
 	base := os.Getenv("RIFFPAD_URL")
 	if base == "" {
@@ -81,11 +90,62 @@ func main() {
 	}
 }
 
+// runDaemon is the hidden `riffpad _daemon` entry point used by daemon start
+// and systemd. Keeping the daemon inside the same binary makes installation a
+// single-file affair.
+func runDaemon(args []string) int {
+	fs := flag.NewFlagSet("_daemon", flag.ExitOnError)
+	dataDir := fs.String("data-dir", "", "daemon data directory (default ~/.config/riffpad)")
+	_ = fs.Parse(args)
+	dir := *dataDir
+	if dir == "" {
+		var err error
+		dir, err = config.DefaultDataDir()
+		if err != nil {
+			log.Printf("resolve data dir: %v", err)
+			return 1
+		}
+	}
+	logger, closer, err := logging.New(dir)
+	if err != nil {
+		log.Printf("init logging: %v", err)
+		return 1
+	}
+	defer closer.Close()
+
+	cfg, err := config.Load(dir)
+	if err != nil {
+		logger.Fatalf("load config: %v", err)
+	}
+	keys, err := config.LoadOrCreateKeys(dir)
+	if err != nil {
+		logger.Fatalf("load keys: %v", err)
+	}
+	srv := daemon.New(cfg, keys, dir, logger, daemon.DefaultFactory())
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	go func() {
+		if err := srv.Start(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Fatalf("server: %v", err)
+		}
+		stop()
+	}()
+	<-ctx.Done()
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		logger.Printf("shutdown: %v", err)
+	}
+	logger.Printf("daemon stopped")
+	return 0
+}
+
 func usage() {
 	fmt.Fprintln(os.Stderr, `riffpad — AI agent remote control (M0)
 
 Usage:
-  riffpad daemon start          start the background daemon (riffpadd)
+  riffpad daemon start          start the background daemon (same binary)
   riffpad daemon stop           stop the daemon
   riffpad status                show daemon status
   riffpad pair                  print a pairing code and QR
@@ -118,7 +178,7 @@ func daemonStart(base, dataDir string) error {
 	if reachable(base) {
 		return fmt.Errorf("daemon already running at %s", base)
 	}
-	bin, err := findRiffpadd()
+	exe, err := os.Executable()
 	if err != nil {
 		return err
 	}
@@ -131,14 +191,14 @@ func daemonStart(base, dataDir string) error {
 		return err
 	}
 	defer out.Close()
-	cmd := exec.Command(bin, "--data-dir", dataDir)
+	cmd := exec.Command(exe, "_daemon", "--data-dir", dataDir)
 	cmd.Stdout = out
 	cmd.Stderr = out
 	if runtime.GOOS != "windows" {
 		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	}
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("start riffpadd: %w", err)
+		return fmt.Errorf("start daemon: %w", err)
 	}
 	_ = os.WriteFile(filepath.Join(dataDir, "daemon.pid"), []byte(fmt.Sprintf("%d\n", cmd.Process.Pid)), 0o600)
 	for i := 0; i < 20; i++ {
@@ -214,23 +274,23 @@ func setupCmd(args []string, dataDir string) error {
 		fmt.Println("已移除 riffpad systemd user 服务。")
 		return nil
 	}
-	bin, err := findRiffpadd()
+	exe, err := os.Executable()
 	if err != nil {
 		return err
 	}
 	if err := os.MkdirAll(unitDir, 0o700); err != nil {
 		return err
 	}
-	execStart := bin
-	if strings.Contains(bin, " ") {
-		execStart = `"` + bin + `"`
+	execStart := exe
+	if strings.Contains(exe, " ") {
+		execStart = `"` + exe + `"`
 	}
 	unit := fmt.Sprintf(`[Unit]
 Description=Riffpad daemon (AI agent remote control)
 After=network-online.target
 
 [Service]
-ExecStart=%s --data-dir %s
+ExecStart=%s _daemon --data-dir %s
 Restart=on-failure
 RestartSec=2
 
@@ -516,20 +576,6 @@ func relayCmd(args []string, dataDir string) error {
 	default:
 		return fmt.Errorf("usage: riffpad relay login|logout")
 	}
-}
-
-func findRiffpadd() (string, error) {
-	exe, err := os.Executable()
-	if err == nil {
-		candidate := filepath.Join(filepath.Dir(exe), "riffpadd")
-		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
-			return candidate, nil
-		}
-	}
-	if p, err := exec.LookPath("riffpadd"); err == nil {
-		return p, nil
-	}
-	return "", fmt.Errorf("riffpadd binary not found next to riffpad or on PATH")
 }
 
 func reachable(base string) bool {

--- a/apps/landing/public/install.sh
+++ b/apps/landing/public/install.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+#
+# Riffpad installer — downloads the single riffpad binary from GitHub
+# Releases and installs it to ~/.local/bin (override with RIFFPAD_PREFIX).
+#
+# The copy served at https://riffpad.ai/install.sh lives in
+# apps/landing/public/install.sh — keep it in sync when editing this file.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/riffpad/riffpad/main/scripts/install.sh | sh
+#
+# Overrides:
+#   RIFFPAD_VERSION   release tag to install (default: latest)
+#   RIFFPAD_PREFIX    install directory (default: ~/.local/bin)
+#   RIFFPAD_DOWNLOAD_URL  direct binary URL (for testing/mirrors)
+#   RIFFPAD_SUMS_URL      checksums URL when RIFFPAD_DOWNLOAD_URL is set
+set -eu
+
+REPO="riffpad/riffpad"
+VERSION="${RIFFPAD_VERSION:-latest}"
+PREFIX="${RIFFPAD_PREFIX:-$HOME/.local/bin}"
+
+case "$(uname -s)" in
+  Linux) OS="linux" ;;
+  Darwin) OS="darwin" ;;
+  *)
+    echo "riffpad: unsupported OS: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64) ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *)
+    echo "riffpad: unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+ASSET="riffpad-${OS}-${ARCH}"
+if [ -n "${RIFFPAD_DOWNLOAD_URL:-}" ]; then
+  URL="$RIFFPAD_DOWNLOAD_URL"
+  SUMS_URL="${RIFFPAD_SUMS_URL:-}"
+elif [ "$VERSION" = "latest" ]; then
+  URL="https://github.com/$REPO/releases/latest/download/$ASSET"
+  SUMS_URL="https://github.com/$REPO/releases/latest/download/sha256sums.txt"
+else
+  URL="https://github.com/$REPO/releases/download/$VERSION/$ASSET"
+  SUMS_URL="https://github.com/$REPO/releases/download/$VERSION/sha256sums.txt"
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+echo "riffpad: downloading $URL"
+curl -fsSL "$URL" -o "$tmp/$ASSET"
+
+if [ -n "$SUMS_URL" ]; then
+  echo "riffpad: verifying checksum"
+  curl -fsSL "$SUMS_URL" -o "$tmp/sha256sums.txt"
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$tmp" && grep " $ASSET$" sha256sums.txt | sha256sum -c - >/dev/null)
+  elif command -v shasum >/dev/null 2>&1; then
+    (cd "$tmp" && grep " $ASSET$" sha256sums.txt | shasum -a 256 -c - >/dev/null)
+  else
+    echo "riffpad: warning: no sha256sum/shasum found, skipping verification" >&2
+  fi
+fi
+
+chmod 0755 "$tmp/$ASSET"
+mkdir -p "$PREFIX"
+install -m 0755 "$tmp/$ASSET" "$PREFIX/riffpad"
+
+echo "riffpad: installed $PREFIX/riffpad ($OS/$ARCH, $VERSION)"
+case ":${PATH:-}:" in
+  *":$PREFIX:"*) ;;
+  *) echo "riffpad: note: $PREFIX is not on PATH — add it or run: export PATH=\"$PREFIX:\$PATH\"" ;;
+esac

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -215,6 +215,7 @@
 | M3.7 | 无 tmux 注入：Kimi ACP / Codex app-server / Claude host 控制协议 | `[x]` | 三个适配器已实现并真机实测（回复/事件流/审批协议均通）：`riffpad run --cli kimi/codex/claude` | #55 #52 |
 | M3.8 | daemon 无感化启动：CLI 懒启动 + Linux systemd 自启 | `[x]` | `run/sessions/pair/attach` 自动拉起 daemon（文件锁防双实例）；`riffpad setup` 安装 systemd user service，`--remove` 卸载 | #57 |
 | M3.9 | Web 客户端 React 重写（apps/client-beta）+ app.riffpad.ai 上线 | `[x]` | Vite+React+TS；daemon/relay 内嵌同一产物；app.riffpad.ai HTTPS 已部署 | #59 |
+| M3.10 | 单二进制 + 一键安装：`riffpad _daemon` 内嵌、`scripts/install.sh`、GitHub Releases 工作流 | `[x]` | `riffpad` 一个二进制承载 CLI+daemon；curl 管道安装带 SHA256 校验；tag v* 自动交叉编译 linux/darwin amd64/arm64 | #62 |
 
 ---
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+#
+# Riffpad installer — downloads the single riffpad binary from GitHub
+# Releases and installs it to ~/.local/bin (override with RIFFPAD_PREFIX).
+#
+# The copy served at https://riffpad.ai/install.sh lives in
+# apps/landing/public/install.sh — keep it in sync when editing this file.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/riffpad/riffpad/main/scripts/install.sh | sh
+#
+# Overrides:
+#   RIFFPAD_VERSION   release tag to install (default: latest)
+#   RIFFPAD_PREFIX    install directory (default: ~/.local/bin)
+#   RIFFPAD_DOWNLOAD_URL  direct binary URL (for testing/mirrors)
+#   RIFFPAD_SUMS_URL      checksums URL when RIFFPAD_DOWNLOAD_URL is set
+set -eu
+
+REPO="riffpad/riffpad"
+VERSION="${RIFFPAD_VERSION:-latest}"
+PREFIX="${RIFFPAD_PREFIX:-$HOME/.local/bin}"
+
+case "$(uname -s)" in
+  Linux) OS="linux" ;;
+  Darwin) OS="darwin" ;;
+  *)
+    echo "riffpad: unsupported OS: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64) ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *)
+    echo "riffpad: unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+ASSET="riffpad-${OS}-${ARCH}"
+if [ -n "${RIFFPAD_DOWNLOAD_URL:-}" ]; then
+  URL="$RIFFPAD_DOWNLOAD_URL"
+  SUMS_URL="${RIFFPAD_SUMS_URL:-}"
+elif [ "$VERSION" = "latest" ]; then
+  URL="https://github.com/$REPO/releases/latest/download/$ASSET"
+  SUMS_URL="https://github.com/$REPO/releases/latest/download/sha256sums.txt"
+else
+  URL="https://github.com/$REPO/releases/download/$VERSION/$ASSET"
+  SUMS_URL="https://github.com/$REPO/releases/download/$VERSION/sha256sums.txt"
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+echo "riffpad: downloading $URL"
+curl -fsSL "$URL" -o "$tmp/$ASSET"
+
+if [ -n "$SUMS_URL" ]; then
+  echo "riffpad: verifying checksum"
+  curl -fsSL "$SUMS_URL" -o "$tmp/sha256sums.txt"
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$tmp" && grep " $ASSET$" sha256sums.txt | sha256sum -c - >/dev/null)
+  elif command -v shasum >/dev/null 2>&1; then
+    (cd "$tmp" && grep " $ASSET$" sha256sums.txt | shasum -a 256 -c - >/dev/null)
+  else
+    echo "riffpad: warning: no sha256sum/shasum found, skipping verification" >&2
+  fi
+fi
+
+chmod 0755 "$tmp/$ASSET"
+mkdir -p "$PREFIX"
+install -m 0755 "$tmp/$ASSET" "$PREFIX/riffpad"
+
+echo "riffpad: installed $PREFIX/riffpad ($OS/$ARCH, $VERSION)"
+case ":${PATH:-}:" in
+  *":$PREFIX:"*) ;;
+  *) echo "riffpad: note: $PREFIX is not on PATH — add it or run: export PATH=\"$PREFIX:\$PATH\"" ;;
+esac


### PR DESCRIPTION
## 背景
一键安装：发布物只有一个二进制，`curl -fsSL https://riffpad.ai/install.sh | sh` 即可安装（#62）。

## 改动
- **单二进制**：`riffpad` 内置隐藏 `_daemon` 子命令（原 riffpadd main 移入）；`daemon start`/懒启动/systemd 直接 re-exec 自身，不再依赖独立 riffpadd
- **scripts/install.sh**：POSIX sh，检测 linux/darwin × amd64/arm64，从 GitHub Releases 下载 `riffpad-<os>-<arch>`，SHA256 校验（sha256sums.txt），安装到 `~/.local/bin`（`RIFFPAD_PREFIX`/`RIFFPAD_VERSION`/`RIFFPAD_DOWNLOAD_URL` 可覆盖）
- **安装入口**：landing 托管 `apps/landing/public/install.sh`，`https://riffpad.ai/install.sh` 即可用（脚本头部注明与 scripts/install.sh 同步）
- **.github/workflows/release.yml**：tag `v*` 或手动触发 → pnpm build client-beta → 交叉编译 linux/darwin amd64/arm64 → 上传 Release（含 sha256sums.txt）
- Makefile install-daemon 只装 riffpad；README Quickstart 改回 `riffpad.ai/install.sh`；dev-plan M3.10

## 验证
- 单二进制：`riffpad sessions` 自动 re-exec `riffpad _daemon` 启动成功、`daemon stop` 正常（隔离端口实测）
- install.sh：本地 HTTP 模拟下载 + SHA256 校验 + 安装，`riffpad version` 可运行
- 全量 go build/test 通过

## 使用
```bash
curl -fsSL https://riffpad.ai/install.sh | sh
riffpad daemon start   # 或直接 riffpad run，懒启动
```

Closes #62