### PR TITLE
feat(cli): riffpad login/logout as primary commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__/
 .env
 *.log
 .DS_Store
+.vercel
+.env*

--- a/apps/daemon/cmd/riffpad/main.go
+++ b/apps/daemon/cmd/riffpad/main.go
@@ -72,6 +72,10 @@ func main() {
 		err = withDaemon(func() error { return attachCmd(base) }, base, dataDir)
 	case "detach":
 		err = detachCmd()
+	case "login":
+		err = loginCmd(os.Args[2:], dataDir)
+	case "logout":
+		err = logoutCmd(dataDir)
 	case "relay":
 		err = relayCmd(os.Args[2:], dataDir)
 	case "setup":
@@ -153,8 +157,9 @@ Usage:
   riffpad run [--name N] [--prompt P] [--cwd D] [--cli claude|kimi|codex]
   riffpad attach                inject Claude Code hooks so the daemon captures your own CLI session
   riffpad detach                remove injected hooks
-  riffpad relay login           log in to the relay (--url wss://… --username …)
-  riffpad relay logout          clear the saved relay token
+  riffpad login [--url wss://… --username …]
+                                log in to Riffpad cloud (relay)
+  riffpad logout                clear the saved login token
   riffpad setup                 install daemon auto-start (Linux systemd user service)
   riffpad logs                  tail daemon logs
   riffpad version`)
@@ -508,6 +513,27 @@ func defaultDaemonPort(base string) int {
 		}
 	}
 	return 8787
+}
+
+// loginCmd logs into the Riffpad relay and stores the token in the daemon
+// config. `riffpad relay login` is kept as an alias.
+func loginCmd(args []string, dataDir string) error {
+	return relayCmd(args, dataDir)
+}
+
+// logoutCmd clears the stored relay token. `riffpad relay logout` is kept as
+// an alias.
+func logoutCmd(dataDir string) error {
+	cfg, err := config.Load(dataDir)
+	if err != nil {
+		return err
+	}
+	cfg.RelayToken = ""
+	if err := config.Save(dataDir, cfg); err != nil {
+		return err
+	}
+	fmt.Println("已退出登录。")
+	return nil
 }
 
 func relayCmd(args []string, dataDir string) error {

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -149,7 +149,7 @@
 | # | 任务 | 状态 | 验收标准 | Issue |
 |---|---|---|---|---|
 | M1.6 | WebSocket Hub + 房间路由 + 心跳重连 | `[x]` | Host/Viewer 路由、join/leave、会话同步（本地 E2E 验证通过） | — |
-| M1.7 | 用户 auth + 配对 API + per-host 注册密钥 | `[x]` | 用户注册/登录/登出/me；host/device 绑定 owner；daemon `riffpad relay login` | — |
+| M1.7 | 用户 auth + 配对 API + per-host 注册密钥 | `[x]` | 用户注册/登录/登出/me；host/device 绑定 owner；daemon `riffpad login` | — |
 | M1.8 | 元数据存储（SQLite，GORM；可换 Postgres） | `[x]` | users/hosts/devices/sessions 落库；relay 重启不丢 | — |
 | M1.9 | 部署：VPS + nginx + TLS + 健康检查 | `[x]` | relay 已上线 https://api.riffpad.ai（Let's Encrypt 自动续期）；systemd 托管 | — |
 


### PR DESCRIPTION
把 `riffpad relay login/logout` 简化为 `riffpad login/logout`：

- 用户心智里没有 relay，只有 Riffpad 账号登录，与网页端登录/注册一致
- `relay login/logout` 保留为兼容别名，不出现在 help
- usage/dev-plan 同步更新

验证：`go build ./...`、`go test ./cmd/riffpad/`、`riffpad --help` 显示新命令。