### PR TITLE
feat(cli): i18n — --lang override, env detection, en fallback (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ claude
 
 Open `http://127.0.0.1:8787`, pair your phone, and approve from anywhere.
 
+The CLI speaks English and Chinese. It detects your locale from
+`LC_ALL`/`LC_MESSAGES`/`LANG`; override it anytime with
+`riffpad --lang zh` or `riffpad --lang en`. Unsupported locales fall back to
+English.
+
 ## How it works
 
 ```

--- a/apps/daemon/cmd/riffpad/main.go
+++ b/apps/daemon/cmd/riffpad/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/riffpad/riffpad/apps/daemon/internal/config"
 	"github.com/riffpad/riffpad/apps/daemon/internal/daemon"
+	"github.com/riffpad/riffpad/apps/daemon/internal/i18n"
 	"github.com/riffpad/riffpad/apps/daemon/internal/logging"
 )
 
@@ -36,7 +37,13 @@ const version = "0.1.0-m0"
 
 const updateRepo = "riffpad/riffpad"
 
+// t is the active language bundle, initialized in main from --lang / env.
+var t = i18n.New(i18n.DefaultLang)
+
 func main() {
+	langFlag, args := extractLangFlag(os.Args[1:])
+	t = i18n.New(i18n.Detect(langFlag))
+	os.Args = append([]string{os.Args[0]}, args...)
 	if len(os.Args) < 2 {
 		usage()
 		os.Exit(2)
@@ -52,7 +59,7 @@ func main() {
 	if dataDir == "" {
 		d, err := config.DefaultDataDir()
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "resolve data dir:", err)
+			fmt.Fprintln(os.Stderr, t.T("resolve_data_dir", err))
 			os.Exit(1)
 		}
 		dataDir = d
@@ -152,29 +159,34 @@ func runDaemon(args []string) int {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, `riffpad — AI agent remote control (M0)
+	fmt.Fprintln(os.Stderr, t.T("usage"))
+}
 
-Usage:
-  riffpad daemon start          start the background daemon (same binary)
-  riffpad daemon stop           stop the daemon
-  riffpad status                show daemon status
-  riffpad pair                  print a pairing code and QR
-  riffpad sessions              list sessions
-  riffpad run [--name N] [--prompt P] [--cwd D] [--cli claude|kimi|codex]
-  riffpad attach                inject Claude Code hooks so the daemon captures your own CLI session
-  riffpad detach                remove injected hooks
-  riffpad login [--url wss://… --username …]
-                                log in to Riffpad cloud (relay)
-  riffpad logout                clear the saved login token
-  riffpad setup                 install daemon auto-start (Linux systemd user service)
-  riffpad update                check for updates and replace this binary
-  riffpad logs                  tail daemon logs
-  riffpad version`)
+// extractLangFlag pulls a global --lang/-lang value out of args so it works
+// before any subcommand, regardless of position.
+func extractLangFlag(args []string) (lang string, rest []string) {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--lang" || a == "-lang":
+			if i+1 < len(args) {
+				lang = args[i+1]
+				i++
+			}
+		case strings.HasPrefix(a, "--lang="):
+			lang = strings.TrimPrefix(a, "--lang=")
+		case strings.HasPrefix(a, "-lang="):
+			lang = strings.TrimPrefix(a, "-lang=")
+		default:
+			rest = append(rest, a)
+		}
+	}
+	return lang, rest
 }
 
 func daemonCmd(args []string, base, dataDir string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: riffpad daemon start|stop")
+		return fmt.Errorf("%s", t.T("usage_daemon"))
 	}
 	switch args[0] {
 	case "start":
@@ -182,13 +194,13 @@ func daemonCmd(args []string, base, dataDir string) error {
 	case "stop":
 		return daemonStop(base)
 	default:
-		return fmt.Errorf("usage: riffpad daemon start|stop")
+		return fmt.Errorf("%s", t.T("usage_daemon"))
 	}
 }
 
 func daemonStart(base, dataDir string) error {
 	if reachable(base) {
-		return fmt.Errorf("daemon already running at %s", base)
+		return fmt.Errorf("%s", t.T("daemon_already_running", base))
 	}
 	exe, err := os.Executable()
 	if err != nil {
@@ -216,11 +228,11 @@ func daemonStart(base, dataDir string) error {
 	for i := 0; i < 20; i++ {
 		time.Sleep(100 * time.Millisecond)
 		if reachable(base) {
-			fmt.Println("daemon started at", base)
+			fmt.Println(t.T("daemon_started", base))
 			return nil
 		}
 	}
-	return fmt.Errorf("daemon did not become reachable; check %s", filepath.Join(logDir, "daemon.out.log"))
+	return fmt.Errorf("%s", t.T("daemon_start_wait_failed", filepath.Join(logDir, "daemon.out.log")))
 }
 
 // startDaemonFn is indirection so tests can observe/emulate lazy starts.
@@ -283,7 +295,7 @@ func setupCmd(args []string, dataDir string) error {
 		if err := os.Remove(unitPath); err != nil && !os.IsNotExist(err) {
 			return err
 		}
-		fmt.Println("已移除 riffpad systemd user 服务。")
+		fmt.Println(t.T("setup_removed"))
 		return nil
 	}
 	exe, err := os.Executable()
@@ -318,14 +330,14 @@ WantedBy=default.target
 	if out, err := exec.Command("systemctl", "--user", "enable", "--now", "riffpad.service").CombinedOutput(); err != nil {
 		return fmt.Errorf("systemctl enable riffpad: %v\n%s", err, out)
 	}
-	fmt.Printf("已安装并启用 %s\n", unitPath)
-	fmt.Println("daemon 将随登录自启，崩溃后自动重启；以后可直接运行 riffpad run/attach/pair。")
+	fmt.Println(t.T("setup_installed", unitPath))
+	fmt.Println(t.T("setup_done"))
 	return nil
 }
 
 func daemonStop(base string) error {
 	if !reachable(base) {
-		return fmt.Errorf("daemon is not running")
+		return fmt.Errorf("%s", t.T("daemon_not_running"))
 	}
 	resp, err := http.Post(base+"/api/shutdown", "application/json", nil)
 	if err != nil {
@@ -336,17 +348,17 @@ func daemonStop(base string) error {
 	for i := 0; i < 20; i++ {
 		time.Sleep(100 * time.Millisecond)
 		if !reachable(base) {
-			fmt.Println("daemon stopped")
+			fmt.Println(t.T("daemon_stopped"))
 			return nil
 		}
 	}
-	return fmt.Errorf("daemon did not stop")
+	return fmt.Errorf("%s", t.T("daemon_did_not_stop"))
 }
 
 func statusCmd(base string) error {
 	resp, err := http.Get(base + "/api/status")
 	if err != nil {
-		return fmt.Errorf("daemon not reachable at %s: %w", base, err)
+		return fmt.Errorf("%s: %w", t.T("daemon_not_reachable", base), err)
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
@@ -361,7 +373,7 @@ func statusCmd(base string) error {
 func pairCmd(base string) error {
 	resp, err := http.Post(base+"/api/pairings", "application/json", nil)
 	if err != nil {
-		return fmt.Errorf("daemon not reachable at %s: %w", base, err)
+		return fmt.Errorf("%s: %w", t.T("daemon_not_reachable", base), err)
 	}
 	defer resp.Body.Close()
 	var data struct {
@@ -371,7 +383,7 @@ func pairCmd(base string) error {
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		return err
 	}
-	fmt.Printf("配对码：%s\n在手机/浏览器输入此配对码（或扫描二维码）\n", data.Code)
+	fmt.Println(t.T("pair_code", data.Code))
 	qrterminal.GenerateWithConfig(data.URL, qrterminal.Config{
 		Level:     qrterminal.L,
 		Writer:    os.Stdout,
@@ -385,7 +397,7 @@ func pairCmd(base string) error {
 func sessionsCmd(base string) error {
 	resp, err := http.Get(base + "/api/sessions")
 	if err != nil {
-		return fmt.Errorf("daemon not reachable at %s: %w", base, err)
+		return fmt.Errorf("%s: %w", t.T("daemon_not_reachable", base), err)
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
@@ -409,7 +421,7 @@ func runCmd(args []string, base string) error {
 	})
 	resp, err := http.Post(base+"/api/sessions", "application/json", bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("daemon not reachable at %s: %w", base, err)
+		return fmt.Errorf("%s: %w", t.T("daemon_not_reachable", base), err)
 	}
 	defer resp.Body.Close()
 	var data struct {
@@ -419,7 +431,7 @@ func runCmd(args []string, base string) error {
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		return err
 	}
-	fmt.Printf("session: %s\n打开 %s 查看\n", data.ID, data.URL)
+	fmt.Println(t.T("session_url", data.ID, data.URL))
 	return nil
 }
 
@@ -437,7 +449,7 @@ func logsCmd(dataDir string) error {
 // from the web UI / mobile.
 func attachCmd(base string) error {
 	if !reachable(base) {
-		return fmt.Errorf("daemon not reachable at %s (run: riffpad daemon start)", base)
+		return fmt.Errorf("%s", t.T("daemon_start_hint", base))
 	}
 	port := defaultDaemonPort(base)
 	home, err := os.UserHomeDir()
@@ -487,9 +499,9 @@ func attachCmd(base string) error {
 	if err := os.WriteFile(settingsPath, raw, 0o600); err != nil {
 		return err
 	}
-	fmt.Println("已注入 Claude Code hooks（备份在 settings.json.riffpad.bak）")
-	fmt.Println("现在正常打开你的 claude（建议放在 tmux 里），daemon 会自动捕捉会话与审批。")
-	fmt.Println("验证完运行: riffpad detach")
+	fmt.Println(t.T("attach_injected"))
+	fmt.Println(t.T("attach_next"))
+	fmt.Println(t.T("attach_verify"))
 	return nil
 }
 
@@ -509,7 +521,7 @@ func detachCmd() error {
 		return err
 	}
 	// Keep the backup file; user can remove it manually.
-	fmt.Println("已还原 Claude Code settings，hooks 已移除。")
+	fmt.Println(t.T("detach_restored"))
 	return nil
 }
 
@@ -539,7 +551,7 @@ func logoutCmd(dataDir string) error {
 	if err := config.Save(dataDir, cfg); err != nil {
 		return err
 	}
-	fmt.Println("已退出登录。")
+	fmt.Println(t.T("logout_done"))
 	return nil
 }
 
@@ -558,7 +570,7 @@ func relayCmd(args []string, dataDir string) error {
 		}
 		password := os.Getenv("RIFFPAD_RELAY_PASSWORD")
 		if password == "" {
-			fmt.Print("密码: ")
+			fmt.Print(t.T("login_password"))
 			b, err := term.ReadPassword(int(os.Stdin.Fd()))
 			if err != nil {
 				return err
@@ -572,7 +584,7 @@ func relayCmd(args []string, dataDir string) error {
 		body, _ := json.Marshal(map[string]string{"username": *username, "password": password})
 		resp, err := http.Post(httpURL+"/api/auth/login", "application/json", bytes.NewReader(body))
 		if err != nil {
-			return fmt.Errorf("登录失败: %w", err)
+			return fmt.Errorf("%s: %w", t.T("login_failed"), err)
 		}
 		defer resp.Body.Close()
 		var out struct {
@@ -582,7 +594,7 @@ func relayCmd(args []string, dataDir string) error {
 			return err
 		}
 		if out.Token == "" {
-			return fmt.Errorf("登录失败（状态 %d）", resp.StatusCode)
+			return fmt.Errorf("%s", t.T("login_failed_status", resp.StatusCode))
 		}
 		cfg, err := config.Load(dataDir)
 		if err != nil {
@@ -593,7 +605,7 @@ func relayCmd(args []string, dataDir string) error {
 		if err := config.Save(dataDir, cfg); err != nil {
 			return err
 		}
-		fmt.Printf("已登录 %s，token 已保存到配置。\n", *username)
+		fmt.Println(t.T("login_success", *username))
 		return nil
 	case "logout":
 		cfg, err := config.Load(dataDir)
@@ -604,7 +616,7 @@ func relayCmd(args []string, dataDir string) error {
 		if err := config.Save(dataDir, cfg); err != nil {
 			return err
 		}
-		fmt.Println("已退出登录。")
+		fmt.Println(t.T("logout_done"))
 		return nil
 	default:
 		return fmt.Errorf("usage: riffpad relay login|logout")
@@ -629,14 +641,14 @@ func updateCmd(args []string) error {
 	force := fs.Bool("force", false, "reinstall even if already up to date")
 	_ = fs.Parse(args)
 
-	fmt.Printf("当前版本: %s\n", version)
+	fmt.Println(t.T("update_current", version))
 	latest, err := latestReleaseTag()
 	if err != nil {
 		return err
 	}
-	fmt.Printf("最新版本: %s\n", latest)
+	fmt.Println(t.T("update_latest", latest))
 	if !*force && compareVersions(version, latest) >= 0 {
-		fmt.Println("已是最新版本。")
+		fmt.Println(t.T("update_up_to_date"))
 		return nil
 	}
 
@@ -646,7 +658,7 @@ func updateCmd(args []string) error {
 	}
 	asset := "riffpad-" + osName + "-" + arch
 	base := "https://github.com/" + updateRepo + "/releases/latest/download/"
-	fmt.Printf("下载 %s …\n", asset)
+	fmt.Println(t.T("update_downloading", asset))
 
 	exe, err := os.Executable()
 	if err != nil {
@@ -666,7 +678,7 @@ func updateCmd(args []string) error {
 		return err
 	}
 	if err := verifyChecksum(base+"sha256sums.txt", asset, tmpPath); err != nil {
-		fmt.Println("校验失败，已中止更新（原文件未改动）。")
+		fmt.Println(t.T("update_checksum_failed"))
 		return err
 	}
 	if err := os.Chmod(tmpPath, 0o755); err != nil {
@@ -675,15 +687,15 @@ func updateCmd(args []string) error {
 
 	backup := exe + ".riffpad.bak"
 	if err := copyFile(exe, backup); err != nil {
-		fmt.Println("备份失败，已中止更新:", err)
+		fmt.Println(t.T("update_backup_failed", err))
 		return err
 	}
 	if err := os.Rename(tmpPath, exe); err != nil {
-		fmt.Println("替换失败:", err)
+		fmt.Println(t.T("update_replace_failed", err))
 		return err
 	}
-	fmt.Printf("已更新到 %s（旧版本备份: %s）\n", latest, backup)
-	fmt.Println("如果 daemon 正在运行，请执行 `riffpad daemon stop && riffpad daemon start` 让新版本生效。")
+	fmt.Println(t.T("update_done", latest, backup))
+	fmt.Println(t.T("update_restart_hint"))
 	return nil
 }
 
@@ -694,7 +706,7 @@ func latestReleaseTag() (string, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("获取最新版本失败: %s", resp.Status)
+		return "", fmt.Errorf("%s", t.T("latest_release_failed", resp.Status))
 	}
 	var rel struct {
 		TagName string `json:"tag_name"`
@@ -703,7 +715,7 @@ func latestReleaseTag() (string, error) {
 		return "", err
 	}
 	if rel.TagName == "" {
-		return "", fmt.Errorf("release 缺少 tag_name")
+		return "", fmt.Errorf("%s", t.T("release_no_tag"))
 	}
 	return rel.TagName, nil
 }
@@ -711,7 +723,7 @@ func latestReleaseTag() (string, error) {
 func updatePlatform() (string, string, error) {
 	osName := strings.ToLower(runtime.GOOS)
 	if osName != "linux" && osName != "darwin" {
-		return "", "", fmt.Errorf("update 暂不支持 %s", runtime.GOOS)
+		return "", "", fmt.Errorf("%s", t.T("update_platform_unsupported", runtime.GOOS))
 	}
 	arch := runtime.GOARCH
 	if arch == "x86_64" {
@@ -721,7 +733,7 @@ func updatePlatform() (string, string, error) {
 		arch = "arm64"
 	}
 	if arch != "amd64" && arch != "arm64" {
-		return "", "", fmt.Errorf("update 暂不支持架构 %s", runtime.GOARCH)
+		return "", "", fmt.Errorf("%s", t.T("update_arch_unsupported", runtime.GOARCH))
 	}
 	return osName, arch, nil
 }
@@ -733,7 +745,7 @@ func downloadFile(url string, w io.Writer) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("下载 %s: %s", url, resp.Status)
+		return fmt.Errorf("%s", t.T("download_failed", url, resp.Status))
 	}
 	_, err = io.Copy(w, resp.Body)
 	return err
@@ -746,7 +758,7 @@ func verifyChecksum(sumsURL, asset, path string) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("获取校验和失败: %s", resp.Status)
+		return fmt.Errorf("%s", t.T("download_failed", sumsURL, resp.Status))
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -761,7 +773,7 @@ func verifyChecksum(sumsURL, asset, path string) error {
 		}
 	}
 	if want == "" {
-		return fmt.Errorf("校验和文件里没有 %s", asset)
+		return fmt.Errorf("%s", t.T("checksum_missing", asset))
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/apps/daemon/internal/i18n/i18n.go
+++ b/apps/daemon/internal/i18n/i18n.go
@@ -1,0 +1,98 @@
+// Package i18n provides lightweight localization for the riffpad CLI.
+//
+// Language selection order:
+//  1. --lang flag (highest priority)
+//  2. environment: LC_ALL > LC_MESSAGES > LANG
+//  3. default: en
+//
+// Unsupported languages fall back to English instead of erroring.
+package i18n
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// DefaultLang is the fallback language.
+const DefaultLang = "en"
+
+// Bundle translates message keys for a resolved language.
+type Bundle struct {
+	lang string
+}
+
+// New returns a bundle for lang (already resolved via Detect).
+func New(lang string) *Bundle {
+	return &Bundle{lang: lang}
+}
+
+// Lang returns the bundle's language code.
+func (b *Bundle) Lang() string {
+	if b == nil {
+		return DefaultLang
+	}
+	return b.lang
+}
+
+// T translates key, formatting with args.
+func (b *Bundle) T(key string, args ...any) string {
+	lang := DefaultLang
+	if b != nil && b.lang != "" {
+		lang = b.lang
+	}
+	table, ok := messages[lang]
+	if !ok {
+		table = messages[DefaultLang]
+	}
+	format, ok := table[key]
+	if !ok {
+		format = messages[DefaultLang][key]
+	}
+	if format == "" {
+		return key
+	}
+	if len(args) == 0 {
+		return format
+	}
+	return fmt.Sprintf(format, args...)
+}
+
+// Detect resolves the language code from an explicit flag value or the
+// environment. Returns a supported code ("zh" or "en"); unsupported values
+// fall back to DefaultLang.
+func Detect(langFlag string) string {
+	if langFlag != "" {
+		if l := resolve(langFlag); l != "" {
+			return l
+		}
+		return DefaultLang
+	}
+	for _, env := range []string{"LC_ALL", "LC_MESSAGES", "LANG"} {
+		v := os.Getenv(env)
+		if v == "" {
+			continue
+		}
+		if l := resolve(v); l != "" {
+			return l
+		}
+	}
+	return DefaultLang
+}
+
+// resolve normalizes a locale string ("zh_CN.UTF-8", "en_US", "fr", "C") to a
+// supported language code, or "" if unsupported.
+func resolve(raw string) string {
+	code := strings.ToLower(strings.TrimSpace(raw))
+	if i := strings.IndexAny(code, "._@"); i >= 0 {
+		code = code[:i]
+	}
+	switch code {
+	case "zh", "zh-hans", "zh-hant", "zh-cn", "zh-tw", "zh-sg", "zh-hk", "zh-mo":
+		return "zh"
+	case "en", "en-us", "en-gb":
+		return "en"
+	default:
+		return ""
+	}
+}

--- a/apps/daemon/internal/i18n/i18n_test.go
+++ b/apps/daemon/internal/i18n/i18n_test.go
@@ -1,0 +1,63 @@
+package i18n
+
+import "testing"
+
+func TestDetectFlagOverridesEnv(t *testing.T) {
+	t.Setenv("LANG", "zh_CN.UTF-8")
+	if got := Detect("en"); got != "en" {
+		t.Fatalf("flag should override env, got %q", got)
+	}
+	if got := Detect("fr"); got != "en" {
+		t.Fatalf("unsupported flag should fall back to en, got %q", got)
+	}
+}
+
+func TestDetectEnvPrecedence(t *testing.T) {
+	t.Setenv("LANG", "zh_CN.UTF-8")
+	t.Setenv("LC_MESSAGES", "en_US.UTF-8")
+	if got := Detect(""); got != "en" {
+		t.Fatalf("LC_MESSAGES should beat LANG, got %q", got)
+	}
+	t.Setenv("LC_ALL", "zh_TW.UTF-8")
+	if got := Detect(""); got != "zh" {
+		t.Fatalf("LC_ALL should beat LC_MESSAGES, got %q", got)
+	}
+}
+
+func TestDetectLocaleNormalization(t *testing.T) {
+	cases := map[string]string{
+		"":            "en",
+		"zh":          "zh",
+		"zh_CN.UTF-8": "zh",
+		"zh_TW":       "zh",
+		"en_US.UTF-8": "en",
+		"fr_FR.UTF-8": "en",
+		"de":          "en",
+		"C":           "en",
+		"POSIX":       "en",
+	}
+	for locale, want := range cases {
+		if got := Detect(locale); got != want {
+			t.Errorf("Detect(%q) = %q, want %q", locale, got, want)
+		}
+	}
+}
+
+func TestTranslate(t *testing.T) {
+	en := New("en")
+	zh := New("zh")
+	if got := en.T("daemon_started", "http://x"); got != "daemon started at http://x" {
+		t.Errorf("en daemon_started = %q", got)
+	}
+	if got := zh.T("daemon_started", "http://x"); got != "daemon 已在 http://x 启动" {
+		t.Errorf("zh daemon_started = %q", got)
+	}
+	// Missing key returns the key itself (never empty/garbled).
+	if got := zh.T("no_such_key"); got != "no_such_key" {
+		t.Errorf("missing key = %q", got)
+	}
+	// Fallback language table is used for missing translations.
+	if got := New("zz").T("pair_code", "abc"); got != "Pairing code: abc\nEnter it in the phone/browser (or scan the QR)" {
+		t.Errorf("fallback pair_code = %q", got)
+	}
+}

--- a/apps/daemon/internal/i18n/messages.go
+++ b/apps/daemon/internal/i18n/messages.go
@@ -1,0 +1,131 @@
+package i18n
+
+var messages = map[string]map[string]string{
+	"en": {
+		"usage": `riffpad — AI agent remote control
+
+Usage:
+  riffpad daemon start          start the background daemon (same binary)
+  riffpad daemon stop           stop the daemon
+  riffpad status                show daemon status
+  riffpad pair                  print a pairing code and QR
+  riffpad sessions              list sessions
+  riffpad run [--name N] [--prompt P] [--cwd D] [--cli claude|kimi|codex]
+  riffpad attach                inject Claude Code hooks so the daemon captures your own CLI session
+  riffpad detach                remove injected hooks
+  riffpad login [--url wss://… --username …]
+                                log in to Riffpad cloud (relay)
+  riffpad logout                clear the saved login token
+  riffpad setup                 install daemon auto-start (Linux systemd user service)
+  riffpad update                check for updates and replace this binary
+  riffpad logs                  tail daemon logs
+  riffpad version
+`,
+		"daemon_already_running":      "daemon already running at %s",
+		"daemon_started":              "daemon started at %s",
+		"daemon_not_reachable":        "daemon not reachable at %s",
+		"daemon_start_hint":           "daemon not reachable at %s (run: riffpad daemon start)",
+		"daemon_not_running":          "daemon is not running",
+		"daemon_stopped":              "daemon stopped",
+		"daemon_did_not_stop":         "daemon did not stop",
+		"daemon_start_wait_failed":    "daemon did not become reachable; check %s",
+		"session_url":                 "session: %s\nOpen %s to view",
+		"pair_code":                   "Pairing code: %s\nEnter it in the phone/browser (or scan the QR)",
+		"attach_injected":             "Injected Claude Code hooks (backup at settings.json.riffpad.bak)",
+		"attach_next":                 "Now open your claude normally (tmux recommended); the daemon captures the session and approvals.",
+		"attach_verify":               "When done, run: riffpad detach",
+		"detach_restored":             "Restored Claude Code settings; hooks removed.",
+		"login_password":              "Password: ",
+		"login_failed":                "login failed",
+		"login_failed_status":         "login failed (status %d)",
+		"login_success":               "Logged in as %s; token saved to config.",
+		"logout_done":                 "Logged out.",
+		"setup_removed":               "Removed riffpad systemd user service.",
+		"setup_installed":             "Installed and enabled %s",
+		"setup_done":                  "The daemon will start at login and restart after crashes; you can now run riffpad run/attach/pair directly.",
+		"update_current":              "Current version: %s",
+		"update_latest":               "Latest version: %s",
+		"update_up_to_date":           "Already up to date.",
+		"update_downloading":          "Downloading %s …",
+		"update_checksum_failed":      "Checksum verification failed; update aborted (original file unchanged).",
+		"update_backup_failed":        "Backup failed, update aborted: %v",
+		"update_replace_failed":       "Replace failed: %v",
+		"update_done":                 "Updated to %s (old binary backed up at %s)",
+		"update_restart_hint":         "If the daemon is running, run `riffpad daemon stop && riffpad daemon start` to apply the new version.",
+		"update_platform_unsupported": "update does not support %s yet",
+		"update_arch_unsupported":     "update does not support architecture %s yet",
+		"checksum_missing":            "checksum file has no entry for %s",
+		"download_failed":             "download %s: %s",
+		"latest_release_failed":       "failed to fetch latest release: %s",
+		"release_no_tag":              "release is missing tag_name",
+		"resolve_data_dir":            "resolve data dir: %v",
+		"unsupported_cli":             "unsupported cli %q",
+		"usage_daemon":                "usage: riffpad daemon start|stop",
+		"usage_login":                 "usage: riffpad login|logout",
+		"usage_run":                   "usage: riffpad run [--name N] [--prompt P] [--cwd D] [--cli claude|kimi|codex]",
+	},
+	"zh": {
+		"usage": `riffpad — AI agent 远程遥控
+
+用法：
+  riffpad daemon start          启动后台 daemon（同一二进制）
+  riffpad daemon stop           停止 daemon
+  riffpad status                查看 daemon 状态
+  riffpad pair                  打印配对码和二维码
+  riffpad sessions              列出会话
+  riffpad run [--name N] [--prompt P] [--cwd D] [--cli claude|kimi|codex]
+                                创建并启动会话
+  riffpad attach                注入 Claude Code hooks，让 daemon 捕获你自己启动的会话
+  riffpad detach                移除注入的 hooks
+  riffpad login [--url wss://… --username …]
+                                登录 Riffpad 云服务（relay）
+  riffpad logout                清除登录 token
+  riffpad setup                 安装 daemon 自启（Linux systemd user service）
+  riffpad update                检查更新并替换当前二进制
+  riffpad logs                  查看 daemon 日志
+  riffpad version
+`,
+		"daemon_already_running":      "daemon 已在 %s 运行",
+		"daemon_started":              "daemon 已在 %s 启动",
+		"daemon_not_reachable":        "无法连接 daemon：%s",
+		"daemon_start_hint":           "无法连接 daemon：%s（运行：riffpad daemon start）",
+		"daemon_not_running":          "daemon 未在运行",
+		"daemon_stopped":              "daemon 已停止",
+		"daemon_did_not_stop":         "daemon 未能停止",
+		"daemon_start_wait_failed":    "daemon 未能就绪；请检查 %s",
+		"session_url":                 "会话：%s\n打开 %s 查看",
+		"pair_code":                   "配对码：%s\n在手机/浏览器输入此配对码（或扫描二维码）",
+		"attach_injected":             "已注入 Claude Code hooks（备份在 settings.json.riffpad.bak）",
+		"attach_next":                 "现在正常打开你的 claude（建议放在 tmux 里），daemon 会自动捕捉会话与审批。",
+		"attach_verify":               "验证完运行: riffpad detach",
+		"detach_restored":             "已还原 Claude Code settings，hooks 已移除。",
+		"login_password":              "密码: ",
+		"login_failed":                "登录失败",
+		"login_failed_status":         "登录失败（状态 %d）",
+		"login_success":               "已登录 %s，token 已保存到配置。",
+		"logout_done":                 "已退出登录。",
+		"setup_removed":               "已移除 riffpad systemd user 服务。",
+		"setup_installed":             "已安装并启用 %s",
+		"setup_done":                  "daemon 将随登录自启，崩溃后自动重启；以后可直接运行 riffpad run/attach/pair。",
+		"update_current":              "当前版本: %s",
+		"update_latest":               "最新版本: %s",
+		"update_up_to_date":           "已是最新版本。",
+		"update_downloading":          "下载 %s …",
+		"update_checksum_failed":      "校验失败，已中止更新（原文件未改动）。",
+		"update_backup_failed":        "备份失败，已中止更新: %v",
+		"update_replace_failed":       "替换失败: %v",
+		"update_done":                 "已更新到 %s（旧版本备份: %s）",
+		"update_restart_hint":         "如果 daemon 正在运行，请执行 `riffpad daemon stop && riffpad daemon start` 让新版本生效。",
+		"update_platform_unsupported": "update 暂不支持 %s",
+		"update_arch_unsupported":     "update 暂不支持架构 %s",
+		"checksum_missing":            "校验和文件里没有 %s",
+		"download_failed":             "下载 %s: %s",
+		"latest_release_failed":       "获取最新版本失败: %s",
+		"release_no_tag":              "release 缺少 tag_name",
+		"resolve_data_dir":            "解析数据目录失败: %v",
+		"unsupported_cli":             "不支持的 CLI %q",
+		"usage_daemon":                "用法：riffpad daemon start|stop",
+		"usage_login":                 "用法：riffpad login|logout",
+		"usage_run":                   "用法：riffpad run [--name N] [--prompt P] [--cwd D] [--cli claude|kimi|codex]",
+	},
+}

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -217,6 +217,7 @@
 | M3.9 | Web 客户端 React 重写（apps/client-beta）+ app.riffpad.ai 上线 | `[x]` | Vite+React+TS；daemon/relay 内嵌同一产物；app.riffpad.ai HTTPS 已部署 | #59 |
 | M3.10 | 单二进制 + 一键安装：`riffpad _daemon` 内嵌、`scripts/install.sh`、GitHub Releases 工作流 | `[x]` | `riffpad` 一个二进制承载 CLI+daemon；curl 管道安装带 SHA256 校验；tag v* 自动交叉编译 linux/darwin amd64/arm64 | #62 |
 | M3.11 | CLI 命令完善：`login/logout` 主命令 + `riffpad update` 自更新 | `[x]` | `login/logout` 替代 relay 前缀（旧命令保留别名）；update 打印当前/最新版本、SHA256 校验、备份并原子替换自身 | #64 #65 |
+| M3.12 | CLI 多语种（i18n）：`--lang` 覆盖 + 环境变量检测 + 英文兜底 | `[x]` | zh/en 语言包；`--lang` > `LC_ALL`/`LC_MESSAGES`/`LANG` > 默认 en；fr 等未支持语言自动降级英文 | #67 |
 
 ---
 


### PR DESCRIPTION
## 改动
- 新增 `apps/daemon/internal/i18n`：轻量语言包（zh / en）
- 语言选择优先级：`--lang` 参数 > `LC_ALL` > `LC_MESSAGES` > `LANG` > 默认 en
- locale 归一化：`zh_CN.UTF-8`/`zh_TW`→zh，`en_US`→en，`fr_FR`/`de`/`C`/`POSIX`→自动降级 en（不报错、无乱码）
- `--lang` 是全局参数，任意位置可用（`riffpad --lang zh run ...` 或 `riffpad run --lang zh ...`）
- 覆盖全部用户可见输出：帮助、pair/run/attach/detach/login/logout/setup/update、主要错误信息
- README/dev-plan 同步

## 验证
- 单测：flag 覆盖 env、LC_ALL>LC_MESSAGES>LANG、locale 归一化与降级、翻译缺失回退 key
- 实测：`--lang zh` 中文帮助；`--lang en` 英文帮助；`LANG=fr_FR.UTF-8` 回退英文；`LANG=zh_CN` 下 update 输出中文
- 全量 go test 通过

Closes #67