### PR TITLE
docs: no-silent-hosting principle for riffpad run

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -6,6 +6,7 @@
 
 AI coding agent（Claude Code、Codex、DeepSeek CLI、Kimi CLI 等）会长时间自主工作，用户不该守在电脑前。Riffpad 提供：
 
+- **无感托管**：daemon 接管会话后，电脑终端照常显示并可操作 coding agent 的 TUI，用户感受不到差异；手机是离席时的镜像与遥控器
 - **监督**：手机上实时查看 agent 的进度、工具调用、文件变更
 - **审批**：agent 等待确认时推送通知，手机一键同意/拒绝/修改条件
 - **转向**：文字下达新指令，远程影响本地会话
@@ -25,6 +26,7 @@ AI coding agent（Claude Code、Codex、DeepSeek CLI、Kimi CLI 等）会长时�
 ### daemon（用户电脑）
 
 - 主路径：按 CLI 适配器订阅结构化事件（如 Claude Code 的 `stream-json`、Codex 的 JSON 输出），渲染为结构化事件
+- 托管模式：daemon 用 PTY/共享会话运行 CLI，并把 TUI 透传到当前终端（本地输入照常）；不同 CLI 的接入路径差异由适配器层吸收（Claude = PTY + hooks、Codex = `--remote` 共享 app-server、Kimi = 后续渲染）
 - 兜底路径：挂接 tmux 控制模式（`tmux -CC`）或 PTY，原始字节流供移动端 xterm.js 渲染
 - 设备配对：二维码扫码交换密钥，之后只接受已配对设备
 

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -186,6 +186,7 @@
 | M3.11 | CLI 命令完善：`login/logout` + `update` 自更新 | `[x]` | 旧命令保留别名；update 校验/备份/原子替换 | #64 #65 |
 | M3.12 | CLI 多语种（i18n） | `[x]` | zh/en 语言包；`--lang` > 环境变量 > 英文兜底 | #67 |
 | M3.13 | 第三方登录：Google / GitHub / Email（OAuth + 邮箱验证码） | `[ ]` | 与现有 username/password 账号体系统一；OAuth 回调、绑定与迁移；Email 验证码防滥用（暂缓实现） | — |
+| M3.14 | 托管模式无感化：`riffpad run` 后电脑终端照常显示/操作 CLI TUI，手机同步遥控 | `[ ]` | Claude：daemon PTY + hooks 收编；Codex：`--remote` 共享 app-server；Kimi：后续；Ctrl-C 退出即退出，持久会话由用户 tmux（docs 强烈推荐） | — |
 
 ---
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -31,6 +31,7 @@ AI coding CLI（Claude Code、Codex、DeepSeek CLI、Kimi CLI 等）已经从“
 Riffpad 不是一个新的 AI coding 工具，而是**已有 AI coding agent 的“手机遥控器 + 陪伴层”**：
 
 - **不替代**：agent 继续跑在用户自己的电脑上，用自己的 API key、自己的仓库、自己的工具链
+- **无感托管**：`riffpad run` 后终端体验与直接运行 CLI 完全一致——电脑始终是主屏，手机是镜像与遥控器；会话生命周期遵循用户自己的终端习惯（想持久化就用 tmux，不强加 detach 魔法）
 - **跨 CLI 通用**：Claude Code、Codex、DeepSeek CLI、Kimi CLI……一个 app 全管
 - **监督**：手机上实时查看进度、工具调用、文件变更
 - **审批**：agent 等待确认时推送通知，手机一键同意 / 拒绝 / 修改条件

--- a/docs/tsd.md
+++ b/docs/tsd.md
@@ -148,7 +148,7 @@ type Adapter interface {
 
 ### 5.3 两种运行模式
 
-- **包装模式**：`riffpad run -- claude` 或 `codex exec --json`，daemon 持有协议流，手机是主交互端；适合新会话
+- **包装模式（无感托管）**：`riffpad run --cli claude/codex/kimi`，daemon 持有会话并把 TUI 透传到当前终端，本地体验与直接运行一致；手机是离席时的遥控器
 - **附着模式**：用户照常启动 TUI（Claude Code 建议在 tmux 内），daemon 通过 L2 hooks 接收结构化事件与审批请求，审批由 hook 阻塞等待手机响应后返回 `permissionDecision`，指令注入走 tmux send-keys；Codex 可复用 `codex app-server`（实验性）让终端与手机共享同一会话（参考 codex-relay 的 `codex resume --remote unix://` 模式）
 - 所有适配器必须能降级到 L3；实验性接口需要 pin CLI 版本
 


### PR DESCRIPTION
把「无感托管」原则写进产品/技术文档：

- PRD 定位：`riffpad run` 后终端体验与直接运行 CLI 完全一致，电脑始终是主屏，手机是镜像与遥控器；不强制 detach 魔法，持久会话由用户自行 tmux
- design 总览：托管模式 TUI 透传（PTY/共享会话），各 CLI 路径差异由适配器层吸收（Claude=PTY+hooks、Codex=--remote、Kimi=后续）
- TSD 5.3：包装模式改为「无感托管」描述
- dev-plan：新增 M3.14（托管模式无感化）