### PR TITLE
fix(codex): no-prompt TUI attach — persist rollout via thread/name/set (#74)

### DIFF
--- a/apps/daemon/internal/codex/codex.go
+++ b/apps/daemon/internal/codex/codex.go
@@ -506,7 +506,25 @@ func (c *Codex) handleResponse(id json.RawMessage, result json.RawMessage) {
 			c.initError = fmt.Errorf("thread/start returned no thread id")
 		}
 		c.mu.Unlock()
-		c.closeReady()
+		// A fresh thread has no persisted rollout yet, so `codex resume` (the
+		// local TUI bootstrap) would fail with "no rollout found". Setting a
+		// name persists the rollout at zero cost; only then mark ready so the
+		// CLI can attach the TUI.
+		go func() {
+			c.mu.Lock()
+			tid := c.threadID
+			c.mu.Unlock()
+			if tid != "" {
+				name := c.name
+				if name == "" {
+					name = "riffpad"
+				}
+				if _, err := c.requestSync("thread/name/set", map[string]any{"threadId": tid, "name": name}, 5*time.Second); err != nil {
+					log.Printf("codex[%s] thread/name/set: %v", c.id, err)
+				}
+			}
+			c.closeReady()
+		}()
 	default:
 		var res struct {
 			Turn struct {

--- a/scripts/e2e-acceptance.mjs
+++ b/scripts/e2e-acceptance.mjs
@@ -286,7 +286,9 @@ while (!sessionKey && !wsError && Date.now() < helloDeadline) {
 check("7 viewer WS connected (E2EE)", wsConnected && !!sessionKey, wsError || "");
 if (!wsConnected || !sessionKey) process.exit(7);
 
-// 8. wait for initial agent reply (or existing history when reusing a session)
+// 8. wait for initial agent reply (or existing history when reusing a
+// session; sessions created without an initial prompt have no reply yet, so
+// treat that as SKIP rather than FAIL)
 const deadline = Date.now() + TIMEOUT_MS;
 let gotReply = false;
 while (Date.now() < deadline && !gotReply) {
@@ -294,7 +296,11 @@ while (Date.now() < deadline && !gotReply) {
   if (!gotReply) await sleep(1000);
 }
 const replyText = events.find((e) => e.type === "agent_message")?.payload?.text || "";
-check("8 agent reply visible to viewer", gotReply, replyText.slice(0, 60));
+if (!gotReply && EXISTING_SESSION) {
+  console.log("SKIP  8 agent reply visible to viewer — session has no initial prompt history");
+} else {
+  check("8 agent reply visible to viewer", gotReply, replyText.slice(0, 60));
+}
 if (!gotReply) {
   console.log("  events seen:", events.map((e) => `${e.type}:${e.payload?.status || e.payload?.text?.slice(0, 20) || ""}`).join(" | "));
 }
@@ -326,7 +332,9 @@ while (Date.now() < pongDeadline && !gotPong) {
 check("10 agent replied to viewer prompt", gotPong, "reply contains PONG");
 
 ws.close();
-await jfetch(`${DAEMON}/api/sessions/${sid}/stop`, { method: "POST" });
+if (!EXISTING_SESSION) {
+  await jfetch(`${DAEMON}/api/sessions/${sid}/stop`, { method: "POST" });
+}
 
 const passed = checks.filter((c) => c.ok).length;
 console.log(`\n${passed}/${checks.length} checks passed in ${((Date.now() - started) / 1000).toFixed(1)}s`);


### PR DESCRIPTION
人肉验收发现：`riffpad run --cli codex`（不带 --prompt）时 TUI 启动失败：

```
Error: Failed to resume session ... thread/resume failed: no rollout found for thread id ... (code -32600)
```

根因：daemon 创建的新 thread 还没有持久化 rollout 文件（首次 turn 才会写入），而 `codex resume --remote` 的 TUI bootstrap 必须从 rollout 恢复，找不到就退出。

修复：thread/start 完成后、开放 connect 之前，调用 `thread/name/set`（零成本）触发 rollout 落盘（实测 thread/name/set 后文件立即创建、resume 成功），再标记 ready 让 CLI 附加 TUI。

顺带修了验收脚本：
- 复用已有会话（--session）时不再在结尾 stop 会话（否则第二次复用失败）
- 无初始 prompt 的会话将 check 8 标记为 SKIP 而不是 FAIL

验证：
- 无 prompt：`riffpad run --cli codex` → TUI 正常打开，无 resume 错误
- 手机注入 PONG → TUI 实时显示、viewer 收到回复
- 带 prompt 会话两轮 e2e 均 10/10（4.8s / 5.4s）