### PR TITLE
feat: session lease — heartbeat, SIGHUP, startup cleanup (#79)

### DIFF
--- a/apps/daemon/cmd/riffpad/main.go
+++ b/apps/daemon/cmd/riffpad/main.go
@@ -484,7 +484,7 @@ func attachCodexTUI(base, sessionID string) error {
 	// signal, let codex exit normally (or kill it after a timeout), then
 	// close the session.
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 	exited := make(chan struct{})
 	go func() {
 		select {
@@ -497,6 +497,24 @@ func attachCodexTUI(base, sessionID string) error {
 				}
 			}
 		case <-exited:
+		}
+	}()
+	// Lease heartbeat: renew every 5s so the daemon can close the session if
+	// this CLI dies without running cleanup (SIGKILL, panic, network loss).
+	hbStop := make(chan struct{})
+	defer close(hbStop)
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if resp, err := http.Post(base+"/api/sessions/"+sessionID+"/heartbeat", "application/json", nil); err == nil {
+					_ = resp.Body.Close()
+				}
+			case <-hbStop:
+				return
+			}
 		}
 	}()
 	runErr := cmd.Run()

--- a/apps/daemon/internal/codex/codex.go
+++ b/apps/daemon/internal/codex/codex.go
@@ -149,6 +149,9 @@ func (c *Codex) spawn(ctx context.Context) error {
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start %s app-server: %w", c.binary, err)
 	}
+	// Record the app-server pid so a later daemon start can clean up
+	// processes left behind by an unclean shutdown (SIGKILL etc).
+	_ = os.WriteFile(socketPath+".pid", []byte(fmt.Sprintf("%d\n", cmd.Process.Pid)), 0o600)
 	c.mu.Lock()
 	c.cmd = cmd
 	c.socketPath = socketPath
@@ -231,6 +234,12 @@ func (c *Codex) Stop() error {
 	if c.cmd != nil && c.cmd.Process != nil {
 		_ = c.cmd.Process.Kill()
 	}
+	c.mu.Lock()
+	if c.socketPath != "" {
+		_ = os.Remove(c.socketPath + ".pid")
+		_ = os.Remove(c.socketPath)
+	}
+	c.mu.Unlock()
 	<-c.doneCh
 	return nil
 }

--- a/apps/daemon/internal/daemon/server.go
+++ b/apps/daemon/internal/daemon/server.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -49,6 +51,8 @@ type session struct {
 	events  <-chan protocol.Event
 	status  string
 	ended   bool
+	lease   bool      // local TUI attached: session closes when heartbeat lapses
+	lastHB  time.Time // last lease heartbeat from the local CLI
 	mu      sync.Mutex
 	history []protocol.Event
 	clients map[*client]struct{}
@@ -92,6 +96,7 @@ func New(cfg *config.Config, keys *config.Keys, dataDir string, logger *log.Logg
 		messageBuf:   map[string]string{},
 	}
 	s.loadDevices()
+	s.cleanupCodexProcesses()
 	if cfg.RelayURL != "" {
 		hostID := cfg.HostID
 		if hostID == "" {
@@ -104,6 +109,74 @@ func New(cfg *config.Config, keys *config.Keys, dataDir string, logger *log.Logg
 		s.rc = newRelayClient(cfg.RelayURL, hostID, cfg.HostSecret, logger, s.handleRelayJoin)
 	}
 	return s
+}
+
+// cleanupCodexProcesses kills app-server processes left over from an unclean
+// daemon shutdown and removes their stale socket/pid files.
+func (s *Server) cleanupCodexProcesses() {
+	dir := filepath.Join(s.dataDir, "codex")
+	// Kill leftover app-server processes by pid file (written by current
+	// adapters) and, on Linux, by scanning /proc cmdlines for any app-server
+	// listening under our codex dir (covers processes spawned before pid
+	// files existed, e.g. unclean upgrades).
+	if runtime.GOOS == "linux" {
+		s.killCodexByProcScan(dir)
+	}
+	pidFiles, err := filepath.Glob(filepath.Join(dir, "*.pid"))
+	if err != nil {
+		return
+	}
+	for _, pf := range pidFiles {
+		data, err := os.ReadFile(pf)
+		if err != nil {
+			continue
+		}
+		var pid int
+		n, _ := fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &pid)
+		if n != 1 || pid <= 0 {
+			_ = os.Remove(pf)
+			continue
+		}
+		if proc, err := os.FindProcess(pid); err == nil {
+			_ = proc.Kill()
+		}
+		_ = os.Remove(pf)
+		_ = os.Remove(strings.TrimSuffix(pf, ".pid") + ".sock")
+		s.log.Printf("cleaned up stale codex app-server pid=%d", pid)
+	}
+	// Remove any remaining stale sockets (their processes, if any, were
+	// killed above or by pid file).
+	if socks, err := filepath.Glob(filepath.Join(dir, "*.sock")); err == nil {
+		for _, sf := range socks {
+			_ = os.Remove(sf)
+		}
+	}
+}
+
+func (s *Server) killCodexByProcScan(dir string) {
+	procs, err := filepath.Glob("/proc/[0-9]*/cmdline")
+	if err != nil {
+		return
+	}
+	for _, cmdlinePath := range procs {
+		data, err := os.ReadFile(cmdlinePath)
+		if err != nil {
+			continue
+		}
+		cmdline := strings.ReplaceAll(string(data), "\x00", " ")
+		if !strings.Contains(cmdline, "app-server") || !strings.Contains(cmdline, dir) {
+			continue
+		}
+		pidStr := strings.Trim(filepath.Base(filepath.Dir(cmdlinePath)), "/")
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil || pid <= 0 {
+			continue
+		}
+		if proc, err := os.FindProcess(pid); err == nil {
+			_ = proc.Kill()
+		}
+		s.log.Printf("cleaned up stale codex app-server pid=%d (proc scan)", pid)
+	}
 }
 
 // DefaultFactory maps CLI names to adapters.
@@ -517,24 +590,58 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		s.handleSessionConnect(w, r, strings.TrimSuffix(id, "/connect"))
 		return
 	}
+	if strings.HasSuffix(id, "/heartbeat") {
+		s.handleSessionHeartbeat(w, strings.TrimSuffix(id, "/heartbeat"))
+		return
+	}
 	if !strings.HasSuffix(id, "/stop") {
 		http.NotFound(w, r)
 		return
 	}
 	id = strings.TrimSuffix(id, "/stop")
 	s.mu.Lock()
-	sess, ok := s.sessions[id]
+	_, ok := s.sessions[id]
 	s.mu.Unlock()
 	if !ok {
 		writeError(w, http.StatusNotFound, "session not found")
 		return
 	}
+	s.stopSession(id)
+	writeJSON(w, http.StatusOK, map[string]any{"stopped": true})
+}
+
+// handleSessionHeartbeat renews the local-TUI lease for a session. The first
+// heartbeat enables the lease; once enabled, the session is closed if no
+// heartbeat arrives within the lease window (see sweepOnce).
+func (s *Server) handleSessionHeartbeat(w http.ResponseWriter, id string) {
 	s.mu.Lock()
-	delete(s.sessions, id)
+	sess, ok := s.sessions[id]
+	if ok {
+		sess.lease = true
+		sess.lastHB = time.Now()
+	}
 	s.mu.Unlock()
+	if !ok {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// stopSession removes a session from the live list and stops its adapter.
+func (s *Server) stopSession(id string) {
+	s.mu.Lock()
+	sess, ok := s.sessions[id]
+	if ok {
+		delete(s.sessions, id)
+	}
+	s.mu.Unlock()
+	if !ok {
+		return
+	}
 	s.announceSessions()
 	_ = sess.adapter.Stop()
-	writeJSON(w, http.StatusOK, map[string]any{"stopped": true})
+	s.log.Printf("session %s stopped", id)
 }
 
 // handleSessionConnect returns the local connect info (app-server socket +
@@ -620,6 +727,15 @@ func (s *Server) sweepOnce() {
 	}
 	s.mu.Unlock()
 	for _, sess := range sessions {
+		s.mu.Lock()
+		leaseExpired := sess.lease && time.Since(sess.lastHB) > 20*time.Second
+		alreadyEnded := sess.ended
+		s.mu.Unlock()
+		if leaseExpired && !alreadyEnded {
+			s.log.Printf("session %s lease expired (no local TUI heartbeat); closing", sess.id)
+			s.stopSession(sess.id)
+			continue
+		}
 		if sess.status != protocol.StatusRunning {
 			continue
 		}

--- a/apps/daemon/internal/daemon/server_test.go
+++ b/apps/daemon/internal/daemon/server_test.go
@@ -18,16 +18,16 @@ import (
 )
 
 type fakeSession struct {
-	id         string
-	events     chan protocol.Event
-	approvals  chan string
-	prompts    chan string
-	stopCalled chan struct{}
+	id           string
+	events       chan protocol.Event
+	approvals    chan string
+	prompts      chan string
+	stopCalled   chan struct{}
 	lastDecision string
 }
 
-func (f *fakeSession) ID() string                     { return f.id }
-func (f *fakeSession) Events() <-chan protocol.Event  { return f.events }
+func (f *fakeSession) ID() string                    { return f.id }
+func (f *fakeSession) Events() <-chan protocol.Event { return f.events }
 func (f *fakeSession) Meta() protocol.SessionStartPayload {
 	return protocol.SessionStartPayload{Name: "fake", CLI: "fake", Cwd: "/tmp"}
 }
@@ -263,6 +263,95 @@ func TestPairCreateSessionAndApprovalLoop(t *testing.T) {
 	}
 	if fake.lastDecision != "approve" {
 		t.Fatalf("unexpected decision %q", fake.lastDecision)
+	}
+}
+
+func TestLeaseExpiryClosesSession(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	keys, err := config.LoadOrCreateKeys(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := log.New(io.Discard, "", 0)
+	srv := New(cfg, keys, dir, logger, nil)
+
+	fake := &fakeSession{
+		id:         "lease-1",
+		events:     make(chan protocol.Event, 4),
+		approvals:  make(chan string, 1),
+		prompts:    make(chan string, 1),
+		stopCalled: make(chan struct{}, 1),
+	}
+	sess := &session{
+		id:      "lease-1",
+		meta:    fake.Meta(),
+		adapter: fake,
+		events:  fake.events,
+		status:  protocol.StatusRunning,
+		lease:   true,
+		lastHB:  time.Now().Add(-30 * time.Second),
+		clients: map[*client]struct{}{},
+	}
+	srv.sessions["lease-1"] = sess
+
+	srv.sweepOnce()
+
+	srv.mu.Lock()
+	_, stillThere := srv.sessions["lease-1"]
+	srv.mu.Unlock()
+	if stillThere {
+		t.Fatal("expired-lease session should have been removed")
+	}
+	select {
+	case <-fake.stopCalled:
+	default:
+		t.Fatal("expected adapter.Stop to be called")
+	}
+}
+
+func TestHeartbeatRenewsLease(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	keys, err := config.LoadOrCreateKeys(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := log.New(io.Discard, "", 0)
+	srv := New(cfg, keys, dir, logger, nil)
+
+	fake := &fakeSession{
+		id:         "hb-1",
+		events:     make(chan protocol.Event, 4),
+		approvals:  make(chan string, 1),
+		prompts:    make(chan string, 1),
+		stopCalled: make(chan struct{}, 1),
+	}
+	srv.sessions["hb-1"] = &session{
+		id:      "hb-1",
+		meta:    fake.Meta(),
+		adapter: fake,
+		events:  fake.events,
+		status:  protocol.StatusRunning,
+		clients: map[*client]struct{}{},
+	}
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	resp, err := http.Post(ts.URL+"/api/sessions/hb-1/heartbeat", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	srv.mu.Lock()
+	s := srv.sessions["hb-1"]
+	srv.mu.Unlock()
+	if s == nil || !s.lease {
+		t.Fatal("heartbeat should enable lease")
+	}
+	if time.Since(s.lastHB) > 2*time.Second {
+		t.Fatal("heartbeat should refresh lastHB")
 	}
 }
 


### PR DESCRIPTION
把「退出即退出」从尽力而为变成系统保证：

**心跳租约（核心）**
- 新 API `POST /api/sessions/{id}/heartbeat`：CLI 附加 Codex TUI 后每 5s 续租；首次心跳启用租约
- daemon sweep（30s 周期）检查租约：超过 20s 无心跳自动关闭会话（stopSession：删除 + announce + 杀 app-server）
- 覆盖 CLI 被 SIGKILL / panic / 断网等无法执行清理的场景

**SIGHUP**
- CLI 捕获 SIGHUP（与 SIGINT/SIGTERM 一致）：终端窗口关闭、SSH 断开、tmux kill-window 都会触发，会话立即关闭

**启动清理**
- adapter spawn app-server 时写 `<socket>.pid`
- daemon 启动时：按 pid 文件 + Linux /proc 命令行扫描（覆盖无 pid 文件的历史残留），杀掉残留 app-server，删除 stale socket/pid 文件

**验证**
- 单测：`TestLeaseExpiryClosesSession`、`TestHeartbeatRenewsLease`
- 实测 kill -9 CLI → 3s 时会话仍在，60s 内 daemon 自动关闭（日志 lease expired）
- 实测 tmux kill-window（SIGHUP）→ 4s 内会话关闭
- 实测 daemon 重启清理 3 个残留 app-server，进程/socket 归零
- 全量 go test 通过

Closes #79