### PR TITLE
docs(dev-plan): containerized deploy, sqlite->postgres, auth roadmap

### DIFF
--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -186,7 +186,9 @@
 | M3.11 | CLI 命令完善：`login/logout` + `update` 自更新 | `[x]` | 旧命令保留别名；update 校验/备份/原子替换 | #64 #65 |
 | M3.12 | CLI 多语种（i18n） | `[x]` | zh/en 语言包；`--lang` > 环境变量 > 英文兜底 | #67 |
 | M3.13 | 第三方登录：Google / GitHub / Email（OAuth + 邮箱验证码） | `[ ]` | 与现有 username/password 账号体系统一；OAuth 回调、绑定与迁移；Email 验证码防滥用（暂缓实现） | — |
-| M3.14 | 托管模式无感化：`riffpad run` 后电脑终端照常显示/操作 CLI TUI，手机同步遥控 | `[ ]` | Claude：daemon PTY + hooks 收编；Codex：`--remote` 共享 app-server；Kimi：后续；Ctrl-C 退出即退出，持久会话由用户 tmux（docs 强烈推荐） | — |
+| M3.14 | 托管模式无感化：`riffpad run` 后电脑终端照常显示/操作 CLI TUI，手机同步遥控 | `[~]` | Codex：`--remote` 共享 app-server 已完成（#74 #79）；Claude：daemon PTY + hooks 收编；Kimi：后续；Ctrl-C 退出即退出，持久会话由用户 tmux（docs 强烈推荐） | #74 #79 |
+| M3.15 | 容器化部署：relay + Postgres 容器化（完善 infra/docker-compose + Dockerfile + nginx/TLS/证书入栈） | `[ ]` | 一键 compose up 即可上线；数据卷备份/恢复文档；与裸机部署可切换（暂缓，当前裸机 systemd 稳定） | — |
+| M3.16 | 元数据存储 SQLite → Postgres 迁移 | `[ ]` | GORM 已支持 DATABASE_URL；迁移脚本 + 数据导出/校验；生产切换后回滚方案（暂缓，单机规模 SQLite 够用） | — |
 
 ---
 


### PR DESCRIPTION
按当前部署现状补充 dev plan：

- **M3.14** 标为进行中：Codex 无感托管已完成（#74 #79），Claude/Kimi 待做
- **M3.15** 新增：容器化部署（完善 infra/docker-compose + Dockerfile + nginx/TLS 入栈），暂缓，当前裸机 systemd 稳定
- **M3.16** 新增：SQLite → Postgres 迁移（GORM 已支持 DATABASE_URL），暂缓
- M3.13（Google/GitHub/Email 登录）已有，保留