### PR TITLE
feat(codex): auto-follow TUI /resume — daemon manages the session the user is looking at (#82)

### DIFF
--- a/apps/daemon/internal/codex/codex.go
+++ b/apps/daemon/internal/codex/codex.go
@@ -66,6 +66,7 @@ type Codex struct {
 	pendingRes    map[int]chan json.RawMessage
 	pending       map[string]pendingApproval
 	messages      map[string]*strings.Builder
+	knownThreads  map[string]bool
 }
 
 // New creates a Codex app-server session adapter.
@@ -89,6 +90,7 @@ func New(req adapter.CreateRequest) *Codex {
 		pendingRes:    make(map[int]chan json.RawMessage),
 		pending:       make(map[string]pendingApproval),
 		messages:      make(map[string]*strings.Builder),
+		knownThreads:  make(map[string]bool),
 	}
 }
 
@@ -531,8 +533,12 @@ func (c *Codex) handleResponse(id json.RawMessage, result json.RawMessage) {
 				if _, err := c.requestSync("thread/name/set", map[string]any{"threadId": tid, "name": name}, 5*time.Second); err != nil {
 					log.Printf("codex[%s] thread/name/set: %v", c.id, err)
 				}
+				c.mu.Lock()
+				c.knownThreads[tid] = true
+				c.mu.Unlock()
 			}
 			c.closeReady()
+			go c.followLoop()
 		}()
 	default:
 		var res struct {
@@ -666,6 +672,83 @@ func (c *Codex) handleAgentDelta(params json.RawMessage) {
 		b.WriteString(n.Delta)
 	}
 	c.mu.Unlock()
+}
+
+// followLoop periodically checks which threads are loaded in the app-server.
+// If the user switches focus inside the TUI (e.g. `/resume` to a historical
+// session), a new thread appears that we did not create; we follow it so the
+// daemon keeps managing exactly the session the user is looking at.
+func (c *Codex) followLoop() {
+	ticker := time.NewTicker(3 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.stopCh:
+			return
+		case <-ticker.C:
+			c.followOnce()
+		}
+	}
+}
+
+func (c *Codex) followOnce() {
+	res, err := c.requestSync("thread/loaded/list", map[string]any{}, 5*time.Second)
+	if err != nil {
+		return
+	}
+	var list struct {
+		Data []string `json:"data"`
+	}
+	if err := json.Unmarshal(res, &list); err != nil {
+		return
+	}
+	c.mu.Lock()
+	known := make(map[string]bool, len(c.knownThreads))
+	for k := range c.knownThreads {
+		known[k] = true
+	}
+	c.mu.Unlock()
+	for _, tid := range list.Data {
+		if tid == "" || known[tid] {
+			continue
+		}
+		c.followThread(tid)
+		return // handle one switch per tick
+	}
+}
+
+// followThread resumes a newly-loaded thread (the TUI switched to it),
+// subscribes, and moves the daemon's focus to it.
+func (c *Codex) followThread(tid string) {
+	r, err := c.requestSync("thread/resume", map[string]any{"threadId": tid}, 5*time.Second)
+	if err != nil {
+		log.Printf("codex[%s] follow resume %s: %v", c.id, tid, err)
+		return
+	}
+	var thr struct {
+		Thread struct {
+			ID  string `json:"id"`
+			Cwd string `json:"cwd,omitempty"`
+		} `json:"thread"`
+	}
+	_ = json.Unmarshal(r, &thr)
+	c.mu.Lock()
+	c.threadID = tid
+	c.knownThreads[tid] = true
+	c.turnActive = false
+	if thr.Thread.Cwd != "" {
+		c.cwd = thr.Thread.Cwd
+	}
+	c.mu.Unlock()
+	short := tid
+	if len(short) > 8 {
+		short = short[:8]
+	}
+	_ = c.emit(protocol.EventNotify, protocol.NotifyPayload{
+		Level:   "info",
+		Message: "会话焦点已切换到 " + short + "（TUI 内 /resume）",
+	})
+	log.Printf("codex[%s] followed TUI to thread %s", c.id, tid)
 }
 
 func (c *Codex) handleTurnCompleted(params json.RawMessage) {


### PR DESCRIPTION
## 背景
用户在 TUI 内 `/resume` 历史会话后，daemon 仍停在旧 thread，电脑与手机各管各的（分叉）。调研确认：`thread/resume` 是绑定在调用连接上的有状态操作，不向其他连接广播；但 `thread/loaded/list` 能反映加载集合。

## 实现（自动跟随为第一公民）
- daemon 每 3s 轮询 `thread/loaded/list`
- 发现集合中出现未知新 thread（用户 TUI /resume 加载的历史会话）→ 判定焦点切换
- 对新 thread 执行 `thread/resume`（订阅 + 元数据），更新 adapter threadID / cwd，重置 turn 状态
- 发 `notify` 事件（手机端可见“会话焦点已切换”）
- 每次 tick 只处理一个切换，避免抖动

## 验证（真机）
- daemon 轮询正常；模拟 TUI resume 历史 thread B 后，3 秒内日志 `followed TUI to thread B`
- 手机经 relay 发 PONG → 注入到 B（B 的订阅客户端收到完整 delta + PONG + turn/completed）而非旧 thread A
- 全量 go test 通过

Closes #82