### PR TITLE
fix(codex): sync user messages (TUI input) to client (#84)

### DIFF
--- a/apps/daemon/internal/codex/codex.go
+++ b/apps/daemon/internal/codex/codex.go
@@ -615,6 +615,7 @@ func (c *Codex) handleItemCompleted(params json.RawMessage) {
 			Type     string          `json:"type"`
 			Command  string          `json:"command"`
 			Changes  json.RawMessage `json:"changes"`
+			Content  json.RawMessage `json:"content"`
 			Tool     string          `json:"tool"`
 			Server   string          `json:"server"`
 			Status   string          `json:"status"`
@@ -635,6 +636,10 @@ func (c *Codex) handleItemCompleted(params json.RawMessage) {
 		c.mu.Unlock()
 		if ok && strings.TrimSpace(b.String()) != "" {
 			_ = c.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: b.String()})
+		}
+	case "userMessage":
+		if text := userMessageText(n.Item.Content); text != "" {
+			_ = c.emit(protocol.EventUserMessage, protocol.AgentMessagePayload{Text: text})
 		}
 	case "commandExecution":
 		status := "completed"
@@ -877,6 +882,24 @@ func fileChangePaths(raw json.RawMessage) []string {
 		}
 	}
 	return out
+}
+
+// userMessageText extracts the text of a userMessage item's content blocks.
+func userMessageText(raw json.RawMessage) string {
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, blk := range blocks {
+		if blk.Type == "text" {
+			b.WriteString(blk.Text)
+		}
+	}
+	return strings.TrimSpace(b.String())
 }
 
 func firstNonEmpty(vals ...string) string {

--- a/apps/daemon/internal/codex/codex_test.go
+++ b/apps/daemon/internal/codex/codex_test.go
@@ -77,6 +77,22 @@ func TestTurnCompletedStatus(t *testing.T) {
 	}
 }
 
+func TestUserMessageEmitted(t *testing.T) {
+	c := New(adapter.CreateRequest{ID: "s1"})
+	c.handleLine([]byte(`{"method":"item/completed","params":{"item":{"id":"u1","type":"userMessage","content":[{"type":"text","text":"hello from tui"}]}}}`))
+	ev := nextEvent(t, c)
+	if ev.Type != protocol.EventUserMessage {
+		t.Fatalf("expected user_message, got %s", ev.Type)
+	}
+	var p protocol.AgentMessagePayload
+	if err := ev.DecodePayload(&p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Text != "hello from tui" {
+		t.Fatalf("expected text %q, got %q", "hello from tui", p.Text)
+	}
+}
+
 func TestCommandApproval(t *testing.T) {
 	c := New(adapter.CreateRequest{ID: "s1"})
 	fw := &fakeWriteCloser{}


### PR DESCRIPTION
## 问题
用户在 Codex TUI 里输入的消息没有出现在手机端（只有 agent 回复），导致会话上下文不完整。Kimi 适配器已支持 `user_message`，Codex 适配器缺失 `userMessage` item 处理。

## 修复
- `handleItemCompleted` 增加 `userMessage` 分支：解析 content text 块，emit `EventUserMessage`
- 新增 `userMessageText` 辅助函数 + 单元测试

## 验证（真机）
- 模拟 TUI 输入发 turn 后，手机端 viewer 收到：`session_start → user_message "Reply with exactly: OK" → agent_message OK → done`
- 全量 go test 通过

Closes #84