### PR TITLE
feat(codex): auto-reconnect persisted sessions on daemon restart (M1.4 phase 2) (#86)

### DIFF
--- a/apps/daemon/internal/codex/codex.go
+++ b/apps/daemon/internal/codex/codex.go
@@ -59,6 +59,7 @@ type Codex struct {
 	launched      bool
 	exited        bool
 	threadID      string
+	restoreThread string // non-empty when reconnecting to an existing thread after daemon restart
 	turnActive    bool
 	promptSent    bool
 	initError     error
@@ -217,6 +218,32 @@ func (c *Codex) ConnectInfo() (socket string, threadID string, err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.socketPath, c.threadID, nil
+}
+
+// Restore reattaches this adapter to an existing thread (e.g. after a daemon
+// restart). The app-server is spawned again and the thread is resumed instead
+// of creating a new one.
+func (c *Codex) Restore(threadID string) error {
+	c.mu.Lock()
+	if c.ctx == nil {
+		c.ctx = context.Background()
+	}
+	c.threadID = threadID
+	c.restoreThread = threadID
+	c.knownThreads[threadID] = true
+	c.prompt = "" // conversation history already exists
+	c.mu.Unlock()
+	if err := c.ensureStarted(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// CurrentConnect returns the live socket path and thread id without waiting.
+func (c *Codex) CurrentConnect() (socket string, threadID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.socketPath, c.threadID
 }
 
 // Stop terminates the app-server.
@@ -503,7 +530,14 @@ func (c *Codex) handleResponse(id json.RawMessage, result json.RawMessage) {
 	case 1:
 		// initialize response; acknowledge then create the thread.
 		_ = c.writeJSON(map[string]any{"method": "initialized", "params": map[string]any{}})
-		_ = c.request("thread/start", map[string]any{"cwd": c.cwd})
+		c.mu.Lock()
+		restore := c.restoreThread
+		c.mu.Unlock()
+		if restore != "" {
+			_ = c.request("thread/resume", map[string]any{"threadId": restore})
+		} else {
+			_ = c.request("thread/start", map[string]any{"cwd": c.cwd})
+		}
 	case 2:
 		var res struct {
 			Thread struct {

--- a/apps/daemon/internal/daemon/persist.go
+++ b/apps/daemon/internal/daemon/persist.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
+	"github.com/riffpad/riffpad/apps/daemon/internal/codex"
 	"github.com/riffpad/riffpad/packages/protocol"
 )
 
@@ -206,27 +207,47 @@ func (s *Server) restoreSessions() {
 		if ps.Ended {
 			continue
 		}
-		events, err := loadSessionEvents(s.dataDir, ps.ID, key)
+		history, err := loadSessionEvents(s.dataDir, ps.ID, key)
 		if err != nil {
 			s.log.Printf("load events for %s: %v", ps.ID, err)
 			continue
 		}
-		adapter := &restoredAdapter{id: ps.ID}
+		var sessAdapter adapter.Session = &restoredAdapter{id: ps.ID}
+		events := sessAdapter.Events()
+		status := "restored"
+		if ps.CLI == "codex" && ps.Connect["threadId"] != "" {
+			// Phase 2: reattach the real Codex adapter to the persisted thread
+			// so the session becomes remotely controllable again.
+			ca := codex.New(adapter.CreateRequest{
+				ID: ps.ID, Name: ps.Name, CLI: "codex", Cwd: ps.Cwd, DataDir: s.dataDir,
+			})
+			if err := ca.Restore(ps.Connect["threadId"]); err != nil {
+				s.log.Printf("codex restore %s: %v; keeping read-only", ps.ID, err)
+			} else {
+				sessAdapter = ca
+				events = ca.Events()
+				status = protocol.StatusRunning
+			}
+		}
 		sess := &session{
 			id:      ps.ID,
 			meta:    protocol.SessionStartPayload{Name: ps.Name, CLI: ps.CLI, Cwd: ps.Cwd},
-			adapter: adapter,
-			events:  adapter.Events(),
-			status:  "restored",
+			adapter: sessAdapter,
+			events:  events,
+			status:  status,
 			ended:   false,
 			created: ps.CreatedAt,
-			history: events,
+			connect: ps.Connect,
+			history: history,
 			clients: map[*client]struct{}{},
 		}
 		s.mu.Lock()
 		s.sessions[ps.ID] = sess
 		s.mu.Unlock()
-		s.log.Printf("restored session %s (%s) with %d events", ps.ID, ps.CLI, len(events))
+		s.log.Printf("restored session %s (%s) with %d events", ps.ID, ps.CLI, len(history))
+		if status == protocol.StatusRunning {
+			go s.pump(sess)
+		}
 	}
 }
 
@@ -236,9 +257,19 @@ func (s *Server) persistEvent(sess *session, ev protocol.Event) {
 		return
 	}
 	_ = appendSessionEvent(s.dataDir, sess.id, key, ev)
+	// Keep meta (status + codex connect info) fresh on every event so a
+	// restart can reattach to the latest thread.
+	s.persistSession(sess)
 }
 
 func (s *Server) persistSession(sess *session) {
+	if ci, ok := sess.adapter.(interface {
+		CurrentConnect() (socket string, threadID string)
+	}); ok {
+		if sock, tid := ci.CurrentConnect(); sock != "" && tid != "" {
+			sess.connect = map[string]string{"socket": sock, "threadId": tid}
+		}
+	}
 	_ = persistSessionMeta(s.dataDir, &PersistedSession{
 		ID:        sess.id,
 		Name:      sess.meta.Name,
@@ -246,6 +277,7 @@ func (s *Server) persistSession(sess *session) {
 		Cwd:       sess.meta.Cwd,
 		Status:    sess.status,
 		Ended:     sess.ended,
+		Connect:   sess.connect,
 		CreatedAt: sess.created,
 		UpdatedAt: time.Now(),
 	})

--- a/apps/daemon/internal/daemon/server.go
+++ b/apps/daemon/internal/daemon/server.go
@@ -54,6 +54,7 @@ type session struct {
 	lease   bool      // local TUI attached: session closes when heartbeat lapses
 	lastHB  time.Time // last lease heartbeat from the local CLI
 	created time.Time
+	connect map[string]string // adapter connect info for restart recovery (e.g. codex socket/threadId)
 	mu      sync.Mutex
 	history []protocol.Event
 	clients map[*client]struct{}


### PR DESCRIPTION
## M1.4 第二层：Codex 会话重启后自动重连

- Codex adapter 新增 `Restore(threadID)`：重新 spawn app-server + `thread/resume`（不新建线程），会话从只读 restored 变为可遥控 running
- connect 信息（socket/threadId）在事件持久化时持续更新（`persistSession` 读取 `CurrentConnect`），重启时能定位到最新 thread
- restoreSessions：codex + 有 threadId 的会话走真实 adapter 恢复并启动事件泵；其他 CLI 保持只读 restored
- 修复：Restore 缺 ctx 导致恢复失败；恢复日志误打 channel len（应为历史条数）

## 验证（真机）
- codex 会话产生 5 条事件后重启 daemon → `restored session ... with 5 events`，状态 running（自动重连成功）
- viewer 完整回放历史：session_start → user_message → agent_message OK → done
- 重启后手机注入 PONG → 10/10（3.4s）
- 全量 go test 通过

Closes #86