### PR TITLE
feat(cli): riffpad update auto-restarts daemon & recovers sessions (M1.4 phase 3) (#86)

### DIFF
--- a/apps/daemon/cmd/riffpad/main.go
+++ b/apps/daemon/cmd/riffpad/main.go
@@ -92,7 +92,7 @@ func main() {
 	case "setup":
 		err = setupCmd(os.Args[2:], dataDir)
 	case "update":
-		err = updateCmd(os.Args[2:])
+		err = updateCmd(os.Args[2:], dataDir)
 	case "version":
 		fmt.Println("riffpad", version)
 	case "help", "-h", "--help":
@@ -734,9 +734,10 @@ func reachable(base string) bool {
 // updateCmd checks the latest GitHub release, downloads the binary for the
 // current platform, verifies its SHA256, and atomically replaces this
 // executable (keeping a .riffpad.bak backup).
-func updateCmd(args []string) error {
+func updateCmd(args []string, dataDir string) error {
 	fs := flag.NewFlagSet("update", flag.ExitOnError)
 	force := fs.Bool("force", false, "reinstall even if already up to date")
+	noRestart := fs.Bool("no-restart", false, "do not restart the daemon after updating")
 	_ = fs.Parse(args)
 
 	fmt.Println(t.T("update_current", version))
@@ -793,8 +794,32 @@ func updateCmd(args []string) error {
 		return err
 	}
 	fmt.Println(t.T("update_done", latest, backup))
+	if !*noRestart && reachable(defaultDaemonBase()) {
+		fmt.Println("daemon 正在运行，自动重启以应用新版本…")
+		if resp, err := http.Post(defaultDaemonBase()+"/api/shutdown", "application/json", nil); err == nil {
+			_ = resp.Body.Close()
+		}
+		// Wait for the old daemon to exit, then start the new binary via the
+		// same path as `riffpad daemon start` (verified to survive).
+		deadline := time.Now().Add(10 * time.Second)
+		for time.Now().Before(deadline) && reachable(defaultDaemonBase()) {
+			time.Sleep(300 * time.Millisecond)
+		}
+		if err := daemonStart(defaultDaemonBase(), dataDir); err != nil {
+			return fmt.Errorf("重启 daemon 失败: %w", err)
+		}
+		fmt.Println("daemon 已重启，会话已恢复。")
+		return nil
+	}
 	fmt.Println(t.T("update_restart_hint"))
 	return nil
+}
+
+func defaultDaemonBase() string {
+	if b := os.Getenv("RIFFPAD_URL"); b != "" {
+		return b
+	}
+	return "http://127.0.0.1:8787"
 }
 
 func latestReleaseTag() (string, error) {

--- a/apps/daemon/internal/codex/codex.go
+++ b/apps/daemon/internal/codex/codex.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -60,6 +61,7 @@ type Codex struct {
 	exited        bool
 	threadID      string
 	restoreThread string // non-empty when reconnecting to an existing thread after daemon restart
+	adoptedPID    int    // pid of a surviving app-server reused across daemon restarts
 	turnActive    bool
 	promptSent    bool
 	initError     error
@@ -233,10 +235,48 @@ func (c *Codex) Restore(threadID string) error {
 	c.knownThreads[threadID] = true
 	c.prompt = "" // conversation history already exists
 	c.mu.Unlock()
-	if err := c.ensureStarted(); err != nil {
-		return err
+
+	// Prefer reusing a surviving app-server: a daemon restart must not drop
+	// the TUI connection attached to it.
+	socketPath := filepath.Join(c.dataDir, "codex", c.id+".sock")
+	if _, err := os.Stat(socketPath); err == nil {
+		if pid, ok := readPIDFile(socketPath + ".pid"); ok {
+			c.mu.Lock()
+			c.adoptedPID = pid
+			c.socketPath = socketPath
+			c.launched = true
+			c.mu.Unlock()
+			go func() {
+				<-c.stopCh
+				if c.adoptedPID > 0 {
+					_ = syscall.Kill(c.adoptedPID, syscall.SIGTERM)
+				}
+			}()
+			if err := c.connect(c.ctx, socketPath); err == nil {
+				return c.request("initialize", map[string]any{
+					"clientInfo": map[string]any{"name": "riffpad", "version": "0.1.0"},
+				})
+			}
+			// Surviving socket but dead process: fall through to a fresh spawn.
+			c.mu.Lock()
+			c.launched = false
+			c.adoptedPID = 0
+			c.mu.Unlock()
+		}
 	}
-	return nil
+	_ = os.Remove(socketPath)
+	_ = os.Remove(socketPath + ".pid")
+	return c.ensureStarted()
+}
+
+func readPIDFile(path string) (int, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	var pid int
+	n, _ := fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &pid)
+	return pid, n == 1 && pid > 0
 }
 
 // CurrentConnect returns the live socket path and thread id without waiting.
@@ -262,6 +302,9 @@ func (c *Codex) Stop() error {
 	}
 	if c.cmd != nil && c.cmd.Process != nil {
 		_ = c.cmd.Process.Kill()
+	}
+	if c.adoptedPID > 0 {
+		_ = syscall.Kill(c.adoptedPID, syscall.SIGTERM)
 	}
 	c.mu.Lock()
 	if c.socketPath != "" {

--- a/apps/daemon/internal/daemon/server.go
+++ b/apps/daemon/internal/daemon/server.go
@@ -118,18 +118,33 @@ func New(cfg *config.Config, keys *config.Keys, dataDir string, logger *log.Logg
 // daemon shutdown and removes their stale socket/pid files.
 func (s *Server) cleanupCodexProcesses() {
 	dir := filepath.Join(s.dataDir, "codex")
+	// Sockets belonging to persisted sessions may be reused by
+	// restoreSessions after a daemon restart; do not kill those app-servers
+	// (their attached TUI must survive the restart).
+	keep := map[string]bool{}
+	if persisted, err := loadPersistedSessions(s.dataDir); err == nil {
+		for _, ps := range persisted {
+			if sock := ps.Connect["socket"]; sock != "" {
+				keep[sock] = true
+			}
+		}
+	}
 	// Kill leftover app-server processes by pid file (written by current
 	// adapters) and, on Linux, by scanning /proc cmdlines for any app-server
 	// listening under our codex dir (covers processes spawned before pid
 	// files existed, e.g. unclean upgrades).
 	if runtime.GOOS == "linux" {
-		s.killCodexByProcScan(dir)
+		s.killCodexByProcScan(dir, keep)
 	}
 	pidFiles, err := filepath.Glob(filepath.Join(dir, "*.pid"))
 	if err != nil {
 		return
 	}
 	for _, pf := range pidFiles {
+		sock := strings.TrimSuffix(pf, ".pid")
+		if keep[sock] {
+			continue
+		}
 		data, err := os.ReadFile(pf)
 		if err != nil {
 			continue
@@ -144,19 +159,22 @@ func (s *Server) cleanupCodexProcesses() {
 			_ = proc.Kill()
 		}
 		_ = os.Remove(pf)
-		_ = os.Remove(strings.TrimSuffix(pf, ".pid") + ".sock")
+		_ = os.Remove(strings.TrimSuffix(pf, ".pid"))
 		s.log.Printf("cleaned up stale codex app-server pid=%d", pid)
 	}
 	// Remove any remaining stale sockets (their processes, if any, were
 	// killed above or by pid file).
 	if socks, err := filepath.Glob(filepath.Join(dir, "*.sock")); err == nil {
 		for _, sf := range socks {
+			if keep[sf] {
+				continue
+			}
 			_ = os.Remove(sf)
 		}
 	}
 }
 
-func (s *Server) killCodexByProcScan(dir string) {
+func (s *Server) killCodexByProcScan(dir string, keep map[string]bool) {
 	procs, err := filepath.Glob("/proc/[0-9]*/cmdline")
 	if err != nil {
 		return
@@ -168,6 +186,16 @@ func (s *Server) killCodexByProcScan(dir string) {
 		}
 		cmdline := strings.ReplaceAll(string(data), "\x00", " ")
 		if !strings.Contains(cmdline, "app-server") || !strings.Contains(cmdline, dir) {
+			continue
+		}
+		skip := false
+		for sock := range keep {
+			if strings.Contains(cmdline, sock) {
+				skip = true
+				break
+			}
+		}
+		if skip {
 			continue
 		}
 		pidStr := strings.Trim(filepath.Base(filepath.Dir(cmdlinePath)), "/")


### PR DESCRIPTION
## M1.4 第三层：update 自动重启闭环

`riffpad update` 现在完成后自动完成重启：

1. 替换二进制（SHA256 校验 + 备份 + 原子替换，原有逻辑）
2. 检测 daemon 在跑 → `POST /api/shutdown` 优雅停止
3. 用 `daemonStart` 路径拉起新二进制（与 `riffpad daemon start` 相同，已验证可存活）
4. 等待恢复，打印 `daemon 已重启，会话已恢复。`
5. `--no-restart` 可跳过（调试用）

> 实现说明：最初尝试 daemon 自 spawn（/api/restart），在本环境子进程无法存活；改为 CLI 负责 shutdown+start，绕开问题且语义更清晰（update 命令拥有重启职责）。

## 验证（真机）
- 模拟 update 重启（shutdown + daemonStart）：旧会话全部恢复 `running`
- 恢复的会话手机注入 PONG → 10/10（3.9s）
- 全量 go test 通过

Closes #86