### PR TITLE
ci: Go tests + client-beta checks + Playwright UI smoke (M1.15) (#91)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,86 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Typecheck client-beta
+        run: pnpm --filter client-beta typecheck
+
+      - name: Build client-beta
+        run: pnpm --filter client-beta build
+
       - name: Lint landing
         run: pnpm --filter landing lint
 
       - name: Build landing
         run: pnpm --filter landing build
+
+  go:
+    name: Go tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: |
+            apps/daemon/go.sum
+            apps/relay/go.sum
+            packages/protocol/go.sum
+
+      - name: Test daemon
+        working-directory: apps/daemon
+        run: go test ./...
+
+      - name: Test relay
+        working-directory: apps/relay
+        run: go test ./...
+
+      - name: Test protocol
+        working-directory: packages/protocol
+        run: go test ./...
+
+  e2e:
+    name: Web UI smoke (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build client-beta (embedded into daemon)
+        run: pnpm --filter client-beta build
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: apps/daemon/go.sum
+
+      - name: Build daemon
+        working-directory: apps/daemon
+        run: go build -o bin/riffpad ./cmd/riffpad
+
+      - name: Install Playwright browsers
+        working-directory: apps/client-beta
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run UI smoke tests
+        working-directory: apps/client-beta
+        env:
+          RIFFPAD_DAEMON: ${{ github.workspace }}/apps/daemon/bin/riffpad
+        run: pnpm test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ __pycache__/
 .DS_Store
 .vercel
 .env*
+apps/client-beta/test-results/
+apps/client-beta/playwright-report/

--- a/apps/client-beta/e2e/ui.spec.ts
+++ b/apps/client-beta/e2e/ui.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+test("app loads and shows pairing view for an unpaired device", async ({ page }) => {
+  await page.goto("/");
+  await expect(page).toHaveTitle(/Riffpad/);
+  await expect(page.locator("text=配对设备")).toBeVisible();
+  await expect(page.locator("input[placeholder='配对码']")).toBeVisible();
+});
+
+test("homepage shows online status", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("#conn")).toContainText("服务在线");
+});

--- a/apps/client-beta/package.json
+++ b/apps/client-beta/package.json
@@ -7,13 +7,15 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/apps/client-beta/playwright.config.ts
+++ b/apps/client-beta/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "@playwright/test";
+
+// UI smoke tests against a real local daemon (separate data dir + port).
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 60_000,
+  use: {
+    baseURL: "http://127.0.0.1:8792",
+  },
+  webServer: {
+    command:
+      "bash -c 'mkdir -p /tmp/riffpad-pw && printf \"{\\\"port\\\":8792}\" > /tmp/riffpad-pw/config.json && ${RIFFPAD_DAEMON:-$HOME/.local/bin/riffpad} _daemon --data-dir /tmp/riffpad-pw'",
+    url: "http://127.0.0.1:8792/api/status",
+    reuseExistingServer: false,
+    timeout: 30_000,
+  },
+});

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -84,7 +84,7 @@
 
 ### M0 已知边界（2026-08 整理后）
 
-- 会话在内存中，daemon 重启即丢（M1.4 恢复未完成）
+- 会话状态与历史已加密持久化；daemon 重启后 Codex 会话自动重连（TUI 无感），Kimi/Claude 恢复为只读（历史可回看，agent 需手动重连）
 - 控制只有 stop；pause/resume 未实现
 - 审批只支持同意/拒绝，条件编辑字段预留未用
 - Claude **host 托管模式**（`riffpad run --cli claude`）注入与事件已通，但工具权限审批仍被 CLI 自动拒绝（`--permission-prompt-tool` 已移除）——审批继续走附着模式 hooks 或预设 `--permission-mode`
@@ -105,7 +105,7 @@
 | M1.1 | Claude Code 适配器：host 控制协议（托管）+ 附着 hooks（attach） | `[x]` | 多轮注入、事件流、attach 审批闭环；2.1.220 实测 | #55 |
 | M1.2 | Codex 适配器：`codex app-server`（thread/turn/steer + requestApproval） | `[x]` | 注入、流式事件、命令/文件/权限审批映射；真机实测 | #55 |
 | M1.3 | Kimi Code 适配器：ACP client（`kimi acp`） | `[x]` | session/prompt、session/update、request_permission 全协议内；真机实测 | #55 |
-| M1.4 | 会话管理：多会话 + daemon 重启恢复 | `[~]` | 多会话并行已支持；重启恢复未做 | — |
+| M1.4 | 会话管理：多会话 + daemon 重启恢复 | `[x]` | 多会话并行；状态/历史加密持久化（AES-GCM）；重启后 Codex 自动重连（TUI 无感），Kimi/Claude 只读恢复；`riffpad update` 自动重启并恢复 | #86 #87 #88 #89 |
 | M1.5 | 断线重连 + 本地回放 | `[~]` | daemon/relay 断线重连已做（重连后重播会话）；手机端缺口补齐未做 | — |
 | M1.6 | 设备管理：多手机、撤销、一键熔断 | `[~]` | 多设备已支持；撤销/熔断未做 | — |
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
         specifier: ^19.1.0
         version: 19.2.8(react@19.2.8)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@types/react':
         specifier: ^19.1.8
         version: 19.2.18
@@ -37,7 +40,7 @@ importers:
     dependencies:
       next:
         specifier: 14.2.35
-        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@playwright/test@1.62.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -77,7 +80,7 @@ importers:
     dependencies:
       next:
         specifier: 14.2.35
-        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@playwright/test@1.62.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -486,6 +489,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1346,6 +1354,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1858,6 +1871,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2661,6 +2684,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -3669,6 +3696,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4052,7 +4082,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(@playwright/test@1.62.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -4073,6 +4103,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.33
       '@next/swc-win32-ia32-msvc': 14.2.33
       '@next/swc-win32-x64-msvc': 14.2.33
+      '@playwright/test': 1.62.1
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -4186,6 +4217,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## M1.15：测试与 CI

**CI 增加三个 job**
1. frontend：原 landing lint/build + client-beta typecheck/build
2. go：daemon / relay / protocol 全量 go test
3. e2e：build client-beta + daemon → Playwright 起真实本地 daemon → UI 冒烟（页面加载、配对视图、在线状态）

**覆盖说明**
- 审批闭环 / E2EE 信封 / 断线重连：由现有 Go 测试覆盖（daemon server_test、protocol crypto_test、relay hub_test）
- 真实 CLI 全链路（kimi/codex）：保留 scripts/e2e-acceptance.mjs 作为发布前验收脚本（依赖真实额度，不入 CI）
- 本地验证：三模块 go test 全绿；Playwright 2/2 通过

Closes #91