### PR TITLE
ci: auto-deploy relay to racknerd on main push (CD) (#108)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,19 @@ jobs:
         env:
           RIFFPAD_DAEMON: ${{ github.workspace }}/apps/daemon/bin/riffpad
         run: pnpm test:e2e
+
+  deploy:
+    name: Deploy relay (CD)
+    needs: [frontend, go, e2e]
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: 23.254.185.39
+          username: riffpad-deploy
+          key: ${{ secrets.RACKNERD_DEPLOY_KEY }}
+          port: 22
+          fingerprint: SHA256:xlQdeF605d0a+zM6/IVazenOHuCLEHQNxfT0VXJycnY
+          script: /usr/local/bin/riffpad-deploy.sh

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -192,6 +192,7 @@
 | M3.14 | 托管模式无感化：`riffpad run` 后电脑终端照常显示/操作 CLI TUI，手机同步遥控 | `[~]` | Codex：`--remote` 共享 app-server 已完成（#74 #79）；Claude：daemon PTY + hooks 收编；Kimi：后续；Ctrl-C 退出即退出，持久会话由用户 tmux（docs 强烈推荐） | #74 #79 |
 | M3.15 | 容器化部署：relay + Postgres 容器化 | `[x]` | 已随 M1.18 完成：relay 仅监听 127.0.0.1:9090、Postgres 17、healthcheck/restart、nginx/certbot 留宿主；生产运行中 | — |
 | M3.16 | 元数据存储 SQLite → Postgres 迁移 | `[x]` | 已随 M1.18 完成：`apps/relay/cmd/migrate-sqlite` 逐表迁移 + 行数校验，生产已切换 Postgres | — |
+| M3.17 | CI/CD：main push → 自动部署 relay（GitHub Actions + SSH 受限部署密钥） | `[~]` | CI 三 job 通过后自动执行 `/usr/local/bin/riffpad-deploy.sh`（git pull --ff-only + compose up -d --build + 健康检查）；部署密钥仅能执行固定脚本 | #108 |
 
 ---
 


### PR DESCRIPTION
Closes #108

## 改动
- ci.yml 新增 deploy job：main push（或手动触发）且 frontend/go/e2e 全部通过后，SSH 到 racknerd 执行 /usr/local/bin/riffpad-deploy.sh
- 部署脚本：git pull --ff-only → docker compose up -d --build relay → 健康检查 /api/status，失败则 workflow 失败、旧容器不受影响
- 服务器新增最小权限部署账号 riffpad-deploy：docker 组、SSH 公钥强制 command= 只能运行部署脚本（无 PTY/转发）
- 部署密钥存于 GitHub Actions secret RACKNERD_DEPLOY_KEY
- docs/dev-plan 新增 M3.17

## 验证
- [x] 服务器脚本手动触发：deploy ok（relay 重建 + 健康检查通过）
- [x] 部署密钥 forced command 已生效（本地测试无法获得 shell）
- [ ] 合并后观察 GitHub Actions 自动部署（本 PR 合入 main 即触发）