### PR TITLE
fix(ci): e2e pairing input selector — stable id/class, zh locale (#109)

### DIFF
--- a/apps/client-beta/e2e/ui.spec.ts
+++ b/apps/client-beta/e2e/ui.spec.ts
@@ -4,7 +4,7 @@ test("app loads and shows pairing view for an unpaired device", async ({ page })
   await page.goto("/");
   await expect(page).toHaveTitle(/Riffpad/);
   await expect(page.locator("text=配对设备")).toBeVisible();
-  await expect(page.locator("input[placeholder='配对码']")).toBeVisible();
+  await expect(page.locator("#pair-view input.pair-input")).toBeVisible();
 });
 
 test("homepage shows online status", async ({ page }) => {

--- a/apps/client-beta/e2e/ui.spec.ts
+++ b/apps/client-beta/e2e/ui.spec.ts
@@ -4,7 +4,7 @@ test("app loads and shows pairing view for an unpaired device", async ({ page })
   await page.goto("/");
   await expect(page).toHaveTitle(/Riffpad/);
   await expect(page.locator("text=配对设备")).toBeVisible();
-  await expect(page.locator("#pair-view input.pair-input")).toBeVisible();
+  await expect(page.locator("#pair-view input")).toBeVisible();
 });
 
 test("homepage shows online status", async ({ page }) => {

--- a/apps/client-beta/playwright.config.ts
+++ b/apps/client-beta/playwright.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   timeout: 60_000,
   use: {
     baseURL: "http://127.0.0.1:8792",
+    locale: "zh-CN",
   },
   webServer: {
     command:


### PR DESCRIPTION
Closes #109

## 问题
M1.17 起配对输入框 placeholder 已是「例如：A1B2C3」，但 e2e 仍在找 placeholder=配对码；之前 main push 未触发 CI（GitHub Actions 事件），所以没暴露。

## 改动
- ui.spec.ts 改用稳定选择器 #pair-view input（兼容当前 main 旧 UI 与 PR #107 新 UI）
- playwright.config 固定 locale zh-CN，让新 UI 的 i18n 文案确定性

## 验证
- [x] 本地 e2e 通过（当前 main 旧 UI）