### PR TITLE
fix(daemon): deterministic session status in create response (#110)

### DIFF
--- a/apps/daemon/internal/daemon/server.go
+++ b/apps/daemon/internal/daemon/server.go
@@ -647,6 +647,17 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 	if err == nil {
 		s.pumpEvent(sess, startEv)
 	}
+	// Respond with the initial status before starting the adapter, so the
+	// create response is deterministic (e.g. waiting_input for an empty
+	// prompt) instead of racing with the first agent status event.
+	writeJSON(w, http.StatusOK, map[string]any{
+		"id":     id,
+		"name":   req.Name,
+		"cli":    req.CLI,
+		"cwd":    req.Cwd,
+		"status": sess.status,
+		"url":    fmt.Sprintf("http://127.0.0.1:%d/?session=%s", s.cfg.Port, id),
+	})
 	go func() {
 		if err := sessAdapter.Start(context.Background()); err != nil {
 			s.log.Printf("session %s start error: %v", id, err)
@@ -656,14 +667,6 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 	go s.pump(sess)
-	writeJSON(w, http.StatusOK, map[string]any{
-		"id":     id,
-		"name":   req.Name,
-		"cli":    req.CLI,
-		"cwd":    req.Cwd,
-		"status": sess.status,
-		"url":    fmt.Sprintf("http://127.0.0.1:%d/?session=%s", s.cfg.Port, id),
-	})
 }
 
 func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Closes #110

## 问题
createSession 先启动 adapter goroutine 再写响应；fake agent 秒发 running 事件时，响应里的 status 变成 running，导致 TestPairCreateSessionAndApprovalLoop 偶发失败。

## 改动
- 将 adapter Start / pump goroutine 移到写响应之后，创建响应始终返回初始状态（空 prompt = waiting_input）

## 验证
- [x] 该测试 -count=5 连续通过
- [x] apps/daemon go test ./... 全绿