### PR TITLE
ci: pin RSA host fingerprint for drone-ssh deploy (#112)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,5 +129,5 @@ jobs:
           username: riffpad-deploy
           key: ${{ secrets.RACKNERD_DEPLOY_KEY }}
           port: 22
-          fingerprint: SHA256:xlQdeF605d0a+zM6/IVazenOHuCLEHQNxfT0VXJycnY
+          fingerprint: SHA256:pBp+dwvplwm+FG38+E5nJrBjIsFdui5lilwJkTV3C+Y
           script: /usr/local/bin/riffpad-deploy.sh


### PR DESCRIPTION
Closes #112

drone-ssh 走 Go SSH 客户端，协商到的是 RSA host key；把 deploy job 的 fingerprint 换成 RSA（pBp+...）。