### PR TITLE
feat(relay): API-only hosts (api.riffpad.ai) no longer serve the web UI (#131)

### DIFF
--- a/apps/relay/internal/hub/hub.go
+++ b/apps/relay/internal/hub/hub.go
@@ -101,6 +101,7 @@ type Hub struct {
 	githubTokenURL string
 	githubUserURL  string
 	appURL         string
+	apiHosts       []string
 }
 
 type ipCounter struct {
@@ -130,7 +131,30 @@ func New(logger *log.Logger, dataDir, databaseURL string) (*Hub, error) {
 		githubTokenURL: "https://github.com/login/oauth/access_token",
 		githubUserURL:  "https://api.github.com/user",
 		appURL:         envOr("RIFFPAD_APP_URL", "https://app.riffpad.ai"),
+		apiHosts:       splitCSV(os.Getenv("RIFFPAD_API_HOSTS")),
 	}, nil
+}
+
+func splitCSV(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// apiOnly reports whether this vhost is an API-only host (e.g. api.riffpad.ai):
+// API and WebSocket routes keep working, but the web UI is not served here.
+func (h *Hub) apiOnly(r *http.Request) bool {
+	host := strings.ToLower(strings.Split(r.Host, ":")[0])
+	for _, hh := range h.apiHosts {
+		if strings.ToLower(hh) == host {
+			return true
+		}
+	}
+	return false
 }
 
 var upgrader = websocket.Upgrader{
@@ -166,6 +190,10 @@ func (h *Hub) Handler() http.Handler {
 func (h *Hub) handleRoot(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" && r.URL.Path != "/device" {
 		http.NotFound(w, r)
+		return
+	}
+	if h.apiOnly(r) {
+		writeJSON(w, http.StatusNotFound, map[string]any{"error": "not found"})
 		return
 	}
 	raw, err := webui.IndexHTML()

--- a/apps/relay/internal/hub/hub_test.go
+++ b/apps/relay/internal/hub/hub_test.go
@@ -175,6 +175,38 @@ func TestRelayRoutesViewerToHost(t *testing.T) {
 	_ = h
 }
 
+func TestAPIClientHostDoesNotServeWebUI(t *testing.T) {
+	h, ts := newTestHub(t)
+	h.apiHosts = []string{"api.riffpad.ai"}
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/", nil)
+	req.Host = "api.riffpad.ai"
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Error string `json:"error"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	if resp.StatusCode != http.StatusNotFound || out.Error != "not found" {
+		t.Fatalf("api host status %d error %q, want JSON 404", resp.StatusCode, out.Error)
+	}
+
+	// The app host still gets the web UI.
+	req2, _ := http.NewRequest(http.MethodGet, ts.URL+"/", nil)
+	req2.Host = "app.riffpad.ai"
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK || !strings.Contains(resp2.Header.Get("Content-Type"), "text/html") {
+		t.Fatalf("app host status %d content-type %q", resp2.StatusCode, resp2.Header.Get("Content-Type"))
+	}
+}
+
 func TestPairingRequiresOnlineAndOwnedHost(t *testing.T) {
 	_, ts := newTestHub(t)
 	token := registerUser(t, ts, "bob")

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -5,3 +5,5 @@ POSTGRES_PASSWORD=change-me
 POSTGRES_DB=riffpad
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+RIFFPAD_API_HOSTS=api.riffpad.ai
+RIFFPAD_APP_URL=https://app.riffpad.ai

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       DATABASE_URL: postgres://${POSTGRES_USER:-riffpad}:${POSTGRES_PASSWORD:-riffpad}@postgres:5432/${POSTGRES_DB:-riffpad}?sslmode=disable
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}
+      RIFFPAD_API_HOSTS: ${RIFFPAD_API_HOSTS:-}
+      RIFFPAD_APP_URL: ${RIFFPAD_APP_URL:-https://app.riffpad.ai}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Closes #131

- relay 按 Host 判断：RIFFPAD_API_HOSTS（如 api.riffpad.ai）的 / 和 /device 返回 JSON 404，API/WS/OAuth 回调不受影响
- compose/.env.example 增加 RIFFPAD_API_HOSTS 与 RIFFPAD_APP_URL
- 单测覆盖 api host 404 + app host 正常出页