### PR TITLE
fix(docs): enable cleanUrls for Vercel static export (#132)

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -6,6 +6,7 @@ export default defineConfig({
   title: "Riffpad",
   description: "AI coding agent 的口袋遥控器",
   base: "/docs/",
+  cleanUrls: true,
   // Build straight into the landing app so riffpad.ai/docs is served by the
   // same Vercel deployment.
   outDir: resolve(import.meta.dirname, "../../landing/public/docs"),


### PR DESCRIPTION
Closes #132

Vercel clean URLs 下 .html 链接 404；VitePress cleanUrls:true 后站内链接不再带 .html。