### PR TITLE
fix(landing): 移动端适配 — 修复整页溢出与架构图裁剪 (#137)

### DIFF
--- a/apps/landing/DESIGN.md
+++ b/apps/landing/DESIGN.md
@@ -316,4 +316,6 @@ bracket-wrapped controls (`[button]`) anywhere. If an SVG is truly needed
 | <768px | Single column; hero display 28px; bento stacks 1×1; nav collapses |
 
 Touch targets ≥ 44px; focus rings visible in accent color; no horizontal
-scroll.
+scroll. (The architecture diagram is the one exception: it keeps its 960px
+canvas and scrolls horizontally *inside its own frame* below 768px — the page
+itself never scrolls sideways.)

--- a/apps/landing/components/Architecture.tsx
+++ b/apps/landing/components/Architecture.tsx
@@ -128,7 +128,7 @@ export function Architecture() {
   return (
     <section
       id="architecture"
-      className="mx-auto max-w-frame scroll-mt-20 px-4 py-24 sm:px-6 sm:py-32"
+      className="mx-auto max-w-frame scroll-mt-20 px-4 py-12 sm:px-6 sm:py-16 lg:py-32"
     >
       <div className="mx-auto max-w-content">
         <span className="label">{`// ${a.label}`}</span>
@@ -137,123 +137,125 @@ export function Architecture() {
         </h2>
         <p className="mt-3 text-base text-body">{a.description}</p>
 
-        <div className="relative mt-12 overflow-hidden border border-hairline">
-          <div className="arch-grid absolute inset-0" aria-hidden="true" />
-          <svg
-            viewBox="0 80 960 220"
-            className="relative h-auto w-full min-w-[680px]"
-            role="img"
-            aria-label={a.title}
-          >
-            <title>{a.title}</title>
+        <div className="mt-12 overflow-x-auto border border-hairline">
+          <div className="relative min-w-[680px]">
+            <div className="arch-grid absolute inset-0" aria-hidden="true" />
+            <svg
+              viewBox="0 80 960 220"
+              className="relative h-auto w-full"
+              role="img"
+              aria-label={a.title}
+            >
+              <title>{a.title}</title>
 
-            {/* flow lanes */}
-            {EVENT_PATHS.map((p) => (
-              <path
-                key={p.id}
-                id={p.id}
-                d={p.d}
-                fill="none"
-                stroke="var(--accent)"
-                strokeOpacity={0.5}
-                strokeWidth={1.5}
-                strokeDasharray="6 6"
-                className="flow-dash-line"
-              />
-            ))}
-            {COMMAND_PATHS.map((p) => (
-              <path
-                key={p.id}
-                id={p.id}
-                d={p.d}
-                fill="none"
-                stroke="rgb(var(--info))"
-                strokeOpacity={0.5}
-                strokeWidth={1.5}
-                strokeDasharray="6 6"
-                className="flow-dash-line"
-              />
-            ))}
-
-            {/* daemon ↔ CLI links */}
-            {CLI_CHIPS.map((c) => (
-              <path
-                key={c.link}
-                d={c.link}
-                fill="none"
-                stroke="var(--hairline-strong)"
-                strokeWidth={1}
-                strokeDasharray="6 6"
-                className="flow-dash-line"
-              />
-            ))}
-
-            {/* nodes */}
-            <Node x={80} title={a.clientTitle} caption={a.clientCaption} />
-            <Node x={400} title={a.relayTitle} caption={a.relayCaption} />
-            <Node x={720} title={a.hostTitle} caption={a.hostCaption} />
-
-            {/* CLI chips with brand icons */}
-            {CLI_CHIPS.map((c, i) => (
-              <g key={c.x}>
-                <title>{BRAND_ICONS[i].title}</title>
-                <rect
-                  x={c.x}
-                  y={236}
-                  width={44}
-                  height={44}
-                  fill="var(--surface)"
-                  stroke="var(--hairline)"
-                />
+              {/* flow lanes */}
+              {EVENT_PATHS.map((p) => (
                 <path
-                  d={BRAND_ICONS[i].path}
-                  transform={`translate(${c.x + 12} 248) scale(0.8333)`}
-                  fill="var(--ink)"
+                  key={p.id}
+                  id={p.id}
+                  d={p.d}
+                  fill="none"
+                  stroke="var(--accent)"
+                  strokeOpacity={0.5}
+                  strokeWidth={1.5}
+                  strokeDasharray="6 6"
+                  className="flow-dash-line"
                 />
-              </g>
-            ))}
-
-            {/* more CLIs */}
-            <text x={896} y={263} fontSize={10} fill="var(--mute)">
-              {a.moreClis}
-            </text>
-
-            {/* flow labels */}
-            <FlowLabel x={320} y={114}>
-              {a.flowEvents}
-            </FlowLabel>
-            <FlowLabel x={320} y={188}>
-              {a.flowCommands}
-            </FlowLabel>
-            <FlowLabel x={640} y={114}>
-              {a.flowEvents}
-            </FlowLabel>
-            <FlowLabel x={640} y={188}>
-              {a.flowCommands}
-            </FlowLabel>
-
-            {/* travelling packets */}
-            {EVENT_PATHS.map((p) =>
-              ["0s", "-2s"].map((begin) => (
-                <Packet
-                  key={`${p.id}-${begin}`}
-                  pathId={p.id}
-                  color="var(--accent)"
-                  begin={begin}
+              ))}
+              {COMMAND_PATHS.map((p) => (
+                <path
+                  key={p.id}
+                  id={p.id}
+                  d={p.d}
+                  fill="none"
+                  stroke="rgb(var(--info))"
+                  strokeOpacity={0.5}
+                  strokeWidth={1.5}
+                  strokeDasharray="6 6"
+                  className="flow-dash-line"
                 />
-              )),
-            )}
-            {COMMAND_PATHS.map((p) =>
-              ["-1s", "-3s"].map((begin) => (
-                <Packet
-                  key={`${p.id}-${begin}`}
-                  pathId={p.id}
-                  color="rgb(var(--info))"
-                  begin={begin}
+              ))}
+
+              {/* daemon ↔ CLI links */}
+              {CLI_CHIPS.map((c) => (
+                <path
+                  key={c.link}
+                  d={c.link}
+                  fill="none"
+                  stroke="var(--hairline-strong)"
+                  strokeWidth={1}
+                  strokeDasharray="6 6"
+                  className="flow-dash-line"
                 />
-              )),
-            )}
-          </svg>
+              ))}
+
+              {/* nodes */}
+              <Node x={80} title={a.clientTitle} caption={a.clientCaption} />
+              <Node x={400} title={a.relayTitle} caption={a.relayCaption} />
+              <Node x={720} title={a.hostTitle} caption={a.hostCaption} />
+
+              {/* CLI chips with brand icons */}
+              {CLI_CHIPS.map((c, i) => (
+                <g key={c.x}>
+                  <title>{BRAND_ICONS[i].title}</title>
+                  <rect
+                    x={c.x}
+                    y={236}
+                    width={44}
+                    height={44}
+                    fill="var(--surface)"
+                    stroke="var(--hairline)"
+                  />
+                  <path
+                    d={BRAND_ICONS[i].path}
+                    transform={`translate(${c.x + 12} 248) scale(0.8333)`}
+                    fill="var(--ink)"
+                  />
+                </g>
+              ))}
+
+              {/* more CLIs */}
+              <text x={896} y={263} fontSize={10} fill="var(--mute)">
+                {a.moreClis}
+              </text>
+
+              {/* flow labels */}
+              <FlowLabel x={320} y={114}>
+                {a.flowEvents}
+              </FlowLabel>
+              <FlowLabel x={320} y={188}>
+                {a.flowCommands}
+              </FlowLabel>
+              <FlowLabel x={640} y={114}>
+                {a.flowEvents}
+              </FlowLabel>
+              <FlowLabel x={640} y={188}>
+                {a.flowCommands}
+              </FlowLabel>
+
+              {/* travelling packets */}
+              {EVENT_PATHS.map((p) =>
+                ["0s", "-2s"].map((begin) => (
+                  <Packet
+                    key={`${p.id}-${begin}`}
+                    pathId={p.id}
+                    color="var(--accent)"
+                    begin={begin}
+                  />
+                )),
+              )}
+              {COMMAND_PATHS.map((p) =>
+                ["-1s", "-3s"].map((begin) => (
+                  <Packet
+                    key={`${p.id}-${begin}`}
+                    pathId={p.id}
+                    color="rgb(var(--info))"
+                    begin={begin}
+                  />
+                )),
+              )}
+            </svg>
+          </div>
         </div>
       </div>
     </section>

--- a/apps/landing/components/CTA.tsx
+++ b/apps/landing/components/CTA.tsx
@@ -6,7 +6,7 @@ export function CTA() {
   const { t } = useLanguage();
 
   return (
-    <section className="mx-auto max-w-frame px-4 py-24 text-center sm:px-6 sm:py-32">
+    <section className="mx-auto max-w-frame px-4 py-12 text-center sm:px-6 sm:py-16 lg:py-32">
       <h2 className="mx-auto max-w-content text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
         {t.cta.title}
       </h2>

--- a/apps/landing/components/FAQ.tsx
+++ b/apps/landing/components/FAQ.tsx
@@ -10,7 +10,7 @@ export function FAQ() {
   return (
     <section
       id="faq"
-      className="mx-auto max-w-frame scroll-mt-20 px-4 py-24 sm:px-6 sm:py-32"
+      className="mx-auto max-w-frame scroll-mt-20 px-4 py-12 sm:px-6 sm:py-16 lg:py-32"
     >
       <div className="mx-auto max-w-content">
         <span className="label">{`// ${t.faq.label}`}</span>

--- a/apps/landing/components/Hero.tsx
+++ b/apps/landing/components/Hero.tsx
@@ -10,7 +10,7 @@ export function Hero() {
   return (
     <section
       id="top"
-      className="mx-auto max-w-frame scroll-mt-20 px-4 pb-20 pt-14 sm:px-6 sm:pb-28 sm:pt-20"
+      className="mx-auto max-w-frame scroll-mt-20 px-4 pb-12 pt-10 sm:px-6 sm:pb-28 sm:pt-20"
     >
       <div className="mx-auto max-w-content text-center">
         <h1 className="text-balance text-[28px] font-bold leading-[1.15] tracking-[-0.02em] sm:text-[40px]">

--- a/apps/landing/components/HowItWorks.tsx
+++ b/apps/landing/components/HowItWorks.tsx
@@ -81,7 +81,7 @@ export function HowItWorks() {
   return (
     <section
       id="how"
-      className="mx-auto max-w-frame scroll-mt-20 px-4 py-24 sm:px-6 sm:py-32"
+      className="mx-auto max-w-frame scroll-mt-20 px-4 py-12 sm:px-6 sm:py-16 lg:py-32"
     >
       <div className="mx-auto max-w-content">
         <span className="label">{`// ${t.how.label}`}</span>

--- a/apps/landing/components/InstallCommand.tsx
+++ b/apps/landing/components/InstallCommand.tsx
@@ -60,7 +60,9 @@ export function InstallCommand() {
           onClick={copy}
           className="flex w-full cursor-pointer items-center justify-center px-4 py-4"
         >
-          <code className="whitespace-nowrap text-sm">{COMMANDS[platform]}</code>
+          <code className="break-all text-[13px] sm:text-sm">
+            {COMMANDS[platform]}
+          </code>
         </button>
       </div>
     </div>

--- a/apps/landing/components/Security.tsx
+++ b/apps/landing/components/Security.tsx
@@ -95,7 +95,7 @@ function PlaintextCard({ label, lines }: { label: string; lines: string[] }) {
 function CipherFlow({ t }: { t: Messages }) {
   const f = t.security.flow;
   return (
-    <div className="py-2">
+    <div className="min-w-0 py-2">
       <PlaintextCard label={f.daemonLabel} lines={f.plainLines} />
 
       <FlowGate label={f.encryptLabel} locked />
@@ -137,11 +137,11 @@ export function Security() {
   return (
     <section
       id="security"
-      className="mx-auto max-w-frame scroll-mt-20 px-4 py-24 sm:px-6 sm:py-32"
+      className="mx-auto max-w-frame scroll-mt-20 px-4 py-12 sm:px-6 sm:py-16 lg:py-32"
     >
       <div className="mx-auto max-w-content">
         <div className="grid items-start gap-10 lg:grid-cols-2">
-          <div>
+          <div className="min-w-0">
             <span className="label">{`// ${t.security.label}`}</span>
             <h2 className="mt-6 text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
               {t.security.title}


### PR DESCRIPTION
Closes #137

## 问题

桌面端表现正常，但移动端整页被撑到 ~2300px 宽，布局视口被迫放大，页面缩小模糊；架构图右侧（daemon / CLI 部分）被直接裁剪不可见。

## 改动

- **Security（根因）**：密文流 `.cipher-stream` 是 `w-max` 的 2200px 宽元素，grid item 的 automatic minimum size 不允许其收缩，导致整个 section 溢出。两个 grid 子项加 `min-w-0` 修复。
- **Architecture**：架构图改为在其自身图框内横向滚动（`overflow-x-auto` + 内层 `min-w-[680px]`），页面本身不横向滚动；DESIGN.md §9 补充说明此例外。
- **InstallCommand**：`whitespace-nowrap` → `break-all`，curl 命令在 ≤375px 屏自动换行而非溢出卡片。
- **间距**：按 DESIGN.md §9 收敛为 `py-12`（mobile）/ `sm:py-16`（tablet）/ `lg:py-32`（桌面不变）；Hero 同步收紧。

## 验证

1. `pnpm --filter landing build` 与 `next lint` 均通过。
2. 静态导出后用 Playwright（Chromium headless shell）实测 375px / 360px / 390px（中文）三个移动视口：`document.documentElement.scrollWidth === window.innerWidth`，页面零横向滚动。
3. 全页截图逐区检查：Hero、安装命令换行、终端/手机 mockup、架构图（图框内可滑动、文字可读）、密文流正确裁剪在虚线框内，中英文排版均正常。
4. 桌面 1280px 截图回归检查，布局无变化。

复现方式：`pnpm --filter landing build` 后用任意静态服务器托管 `apps/landing/out`，以 ≤390px 视口访问。