### PR TITLE
fix(docs): light-mode code block readability + hairline polish (#140)

### DIFF
--- a/apps/docs/.vitepress/theme/custom.css
+++ b/apps/docs/.vitepress/theme/custom.css
@@ -26,7 +26,7 @@
   --vp-c-gutter: rgba(25, 25, 23, 0.1);
   --vp-c-mute: rgba(25, 25, 23, 0.6);
   --vp-code-bg: #f2f1ec;
-  --vp-code-block-bg: #121214;
+  --vp-code-block-bg: #f2f1ec;
   --vp-code-color: #191917;
   --vp-button-brand-bg: #1a7f37;
   --vp-button-brand-hover-bg: #146c2e;
@@ -59,4 +59,21 @@
   --vp-button-brand-text: #191917;
   --vp-custom-block-tip-border: #7ee787;
   --vp-custom-block-tip-text: #7ee787;
+}
+
+/* Code blocks: square, hairline border, theme-aware background. */
+.vp-doc div[class*="language-"] {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 0;
+  margin: 16px 0;
+}
+.vp-doc div[class*="language-"] .shiki,
+.vp-doc div[class*="language-"] pre {
+  background: transparent !important;
+}
+.vp-doc :not(pre) > code {
+  border: 1px solid var(--vp-c-divider);
+  padding: 1px 6px;
+  background-color: var(--vp-code-bg);
+  color: var(--vp-code-color);
 }


### PR DESCRIPTION
Closes #140

- 浅色模式代码块改为浅底深字（原为深底深字不可读），深色保持终端深色
- 代码块加 hairline 边框、方角、清除 shiki 自带背景；行内 code 同样主题化