### PR TITLE
release: bump version to 0.2.0 (#144)

### DIFF
--- a/apps/daemon/cmd/riffpad/main.go
+++ b/apps/daemon/cmd/riffpad/main.go
@@ -34,7 +34,7 @@ import (
 	"github.com/riffpad/riffpad/apps/daemon/internal/logging"
 )
 
-const version = "0.1.0-m0"
+const version = "0.2.0"
 
 const updateRepo = "riffpad/riffpad"
 

--- a/apps/relay/internal/hub/hub.go
+++ b/apps/relay/internal/hub/hub.go
@@ -20,7 +20,7 @@ import (
 	"github.com/riffpad/riffpad/packages/webui"
 )
 
-const version = "0.1.0-m1"
+const version = "0.2.0"
 
 func envOr(key, def string) string {
 	if v := os.Getenv(key); v != "" {

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -183,7 +183,7 @@
 | M3.2 | tmux / PTY 兜底（L3）正式实现 | `[ ]` | 任意 CLI 可监控 | — |
 | M3.3 | 自部署中继 | `[ ]` | 一键部署文档 + 镜像 | — |
 | M3.4 | 局域网直连 / WebRTC（relay 退化信令） | `[ ]` | 局域网内无中继可用 | — |
-| M3.5 | Windows daemon | `[ ]` | 安装包 + 自启动 | — |
+| M3.5 | Windows daemon | `[~]` | v0.2 发布后立即做：syscall 兼容（codex Kill、daemon Flock 跨平台）、install.ps1、开机自启、release 矩阵增加 windows amd64/arm64 | — |
 | M3.6 | 团队版（多人共享设备/会话） | `[ ]` | 权限模型可用 | — |
 | M3.7 | 无 tmux 注入：Kimi ACP / Codex app-server / Claude host 控制协议 | `[x]` | 三适配器实现并真机实测；`riffpad run --cli kimi/codex/claude` | #55 #52 |
 | M3.8 | daemon 无感化启动：CLI 懒启动 + Linux systemd 自启 | `[x]` | 自动拉起（文件锁防双实例）；`riffpad setup` 安装/卸载 | #57 |


### PR DESCRIPTION
## 改动
- CLI/relay 版本号 0.2.0
- dev-plan M3.5（Windows daemon）标为进行中：v0.2 发布后立即做（syscall 兼容、install.ps1、自启、release 加 windows 矩阵）