### PR TITLE
feat: Windows daemon support — cross-compile, install.ps1, autostart, release matrix + CI guard (M3.5) (#147)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
         working-directory: packages/protocol
         run: go test ./...
 
+      - name: Cross-compile guard (windows/darwin)
+        working-directory: apps/daemon
+        run: |
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build ./...
+          CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build ./...
+
   e2e:
     name: Web UI smoke (Playwright)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,13 +44,15 @@ jobs:
         working-directory: apps/daemon
         run: |
           mkdir -p dist
-          for target in "linux amd64" "linux arm64" "darwin amd64" "darwin arm64"; do
+          for target in "linux amd64" "linux arm64" "darwin amd64" "darwin arm64" "windows amd64" "windows arm64"; do
             set -- $target
             os=$1
             arch=$2
+            ext=""
+            if [ "$os" = "windows" ]; then ext=".exe"; fi
             CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" \
               go build -trimpath -ldflags "-s -w" \
-              -o "dist/riffpad-$os-$arch" ./cmd/riffpad
+              -o "dist/riffpad-$os-$arch$ext" ./cmd/riffpad
           done
           (cd dist && sha256sum riffpad-* > sha256sums.txt)
 

--- a/apps/daemon/cmd/riffpad/lock_unix.go
+++ b/apps/daemon/cmd/riffpad/lock_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+}
+
+func unlockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/apps/daemon/cmd/riffpad/lock_windows.go
+++ b/apps/daemon/cmd/riffpad/lock_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFile(f *os.File) error {
+	ol := new(windows.Overlapped)
+	return windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0, 1, 0, ol,
+	)
+}
+
+func unlockFile(f *os.File) error {
+	ol := new(windows.Overlapped)
+	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, ol)
+}

--- a/apps/daemon/cmd/riffpad/main.go
+++ b/apps/daemon/cmd/riffpad/main.go
@@ -223,9 +223,7 @@ func daemonStart(base, dataDir string) error {
 	cmd := exec.Command(exe, "_daemon", "--data-dir", dataDir)
 	cmd.Stdout = out
 	cmd.Stderr = out
-	if runtime.GOOS != "windows" {
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-	}
+	cmd.SysProcAttr = daemonProcAttr()
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start daemon: %w", err)
 	}
@@ -266,10 +264,10 @@ func ensureDaemon(base, dataDir string) error {
 		return fmt.Errorf("open daemon lock: %w", err)
 	}
 	defer lf.Close()
-	if err := syscall.Flock(int(lf.Fd()), syscall.LOCK_EX); err != nil {
+	if err := lockFile(lf); err != nil {
 		return fmt.Errorf("lock daemon start: %w", err)
 	}
-	defer syscall.Flock(int(lf.Fd()), syscall.LOCK_UN)
+	defer func() { _ = unlockFile(lf) }()
 	// Another process may have started the daemon while we waited for the lock.
 	if reachable(base) {
 		return nil
@@ -284,10 +282,13 @@ func ensureDaemon(base, dataDir string) error {
 // starts at login and restarts after crashes.
 func setupCmd(args []string, dataDir string) error {
 	fs := flag.NewFlagSet("setup", flag.ExitOnError)
-	remove := fs.Bool("remove", false, "stop and remove the systemd user service")
+	remove := fs.Bool("remove", false, "stop and remove the autostart entry")
 	_ = fs.Parse(args)
+	if runtime.GOOS == "windows" {
+		return setupWindowsTask(*remove, dataDir)
+	}
 	if runtime.GOOS != "linux" {
-		return fmt.Errorf("setup currently supports Linux systemd only")
+		return fmt.Errorf("setup currently supports Linux systemd / Windows Task Scheduler only")
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -336,6 +337,31 @@ WantedBy=default.target
 		return fmt.Errorf("systemctl enable riffpad: %v\n%s", err, out)
 	}
 	fmt.Println(t.T("setup_installed", unitPath))
+	fmt.Println(t.T("setup_done"))
+	return nil
+}
+
+// setupWindowsTask registers (or removes) a scheduled task that starts the
+// daemon at logon.
+func setupWindowsTask(remove bool, dataDir string) error {
+	if remove {
+		out, err := exec.Command("schtasks", "/Delete", "/TN", "RiffpadDaemon", "/F").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("schtasks delete: %v\n%s", err, out)
+		}
+		fmt.Println(t.T("setup_removed"))
+		return nil
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	tr := fmt.Sprintf(`"%s" _daemon --data-dir "%s"`, exe, dataDir)
+	out, err := exec.Command("schtasks", "/Create", "/TN", "RiffpadDaemon", "/TR", tr, "/SC", "ONLOGON", "/RL", "LIMITED", "/F").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("schtasks create: %v\n%s", err, out)
+	}
+	fmt.Println(t.T("setup_installed", "RiffpadDaemon"))
 	fmt.Println(t.T("setup_done"))
 	return nil
 }

--- a/apps/daemon/cmd/riffpad/procattr_unix.go
+++ b/apps/daemon/cmd/riffpad/procattr_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+import "syscall"
+
+func daemonProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}

--- a/apps/daemon/cmd/riffpad/procattr_windows.go
+++ b/apps/daemon/cmd/riffpad/procattr_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "syscall"
+
+func daemonProcAttr() *syscall.SysProcAttr {
+	return nil
+}

--- a/apps/daemon/go.mod
+++ b/apps/daemon/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/mdp/qrterminal/v3 v3.0.0
 	github.com/riffpad/riffpad/packages/protocol v0.0.0
 	github.com/riffpad/riffpad/packages/webui v0.0.0
+	golang.org/x/sys v0.42.0
 	golang.org/x/term v0.41.0
 )
 
 require (
 	golang.org/x/crypto v0.49.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	rsc.io/qr v0.2.0 // indirect
 )
 

--- a/apps/daemon/internal/codex/codex.go
+++ b/apps/daemon/internal/codex/codex.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -249,7 +248,7 @@ func (c *Codex) Restore(threadID string) error {
 			go func() {
 				<-c.stopCh
 				if c.adoptedPID > 0 {
-					_ = syscall.Kill(c.adoptedPID, syscall.SIGTERM)
+					killProcess(c.adoptedPID)
 				}
 			}()
 			if err := c.connect(c.ctx, socketPath); err == nil {
@@ -304,7 +303,7 @@ func (c *Codex) Stop() error {
 		_ = c.cmd.Process.Kill()
 	}
 	if c.adoptedPID > 0 {
-		_ = syscall.Kill(c.adoptedPID, syscall.SIGTERM)
+		killProcess(c.adoptedPID)
 	}
 	c.mu.Lock()
 	if c.socketPath != "" {
@@ -314,6 +313,17 @@ func (c *Codex) Stop() error {
 	c.mu.Unlock()
 	<-c.doneCh
 	return nil
+}
+
+// killProcess terminates a process on any platform (SIGKILL on Unix,
+// TerminateProcess on Windows).
+func killProcess(pid int) {
+	if pid <= 0 {
+		return
+	}
+	if p, err := os.FindProcess(pid); err == nil {
+		_ = p.Kill()
+	}
 }
 
 // Alive reports whether the app-server process is running.

--- a/apps/landing/components/InstallCommand.tsx
+++ b/apps/landing/components/InstallCommand.tsx
@@ -5,6 +5,7 @@ import { useLanguage } from "./LanguageProvider";
 
 const COMMANDS = {
   unix: "curl -fsSL https://riffpad.ai/install.sh | sh",
+  windows: "irm https://riffpad.ai/install.ps1 | iex",
 } as const;
 
 type Platform = keyof typeof COMMANDS;
@@ -26,6 +27,7 @@ export function InstallCommand() {
 
   const tabs: { id: Platform; label: string }[] = [
     { id: "unix", label: t.install.unix },
+    { id: "windows", label: t.install.windows },
   ];
 
   return (

--- a/apps/landing/lib/i18n.ts
+++ b/apps/landing/lib/i18n.ts
@@ -12,6 +12,7 @@ const en = {
   },
   install: {
     unix: "macOS / Linux",
+    windows: "Windows",
     copy: "copy",
     copied: "copied ✓",
   },
@@ -224,6 +225,7 @@ const zh: typeof en = {
   },
   install: {
     unix: "macOS / Linux",
+    windows: "Windows",
     copy: "复制",
     copied: "已复制 ✓",
   },

--- a/apps/landing/public/install.ps1
+++ b/apps/landing/public/install.ps1
@@ -1,0 +1,27 @@
+$ErrorActionPreference = "Stop"
+
+$installDir = Join-Path $env:LOCALAPPDATA "riffpad"
+$exe = Join-Path $installDir "riffpad.exe"
+
+Write-Host "Installing Riffpad to $installDir ..."
+New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+
+$release = Invoke-RestMethod "https://api.github.com/repos/riffpad/riffpad/releases/latest"
+$asset = $release.assets | Where-Object { $_.name -eq "riffpad-windows-amd64.exe" }
+if (-not $asset) {
+  throw "Latest release has no riffpad-windows-amd64.exe asset"
+}
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $exe
+
+# Add the install dir to the user PATH if missing.
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($userPath -notlike "*$installDir*") {
+  [Environment]::SetEnvironmentVariable("Path", "$userPath;$installDir", "User")
+  Write-Host "Added $installDir to your user PATH (reopen the terminal to use riffpad)."
+}
+
+# Autostart the daemon at logon via a hidden scheduled task.
+schtasks /Create /TN "RiffpadDaemon" /TR "\"$exe\" _daemon" /SC ONLOGON /RL LIMITED /F | Out-Null
+
+Write-Host ""
+Write-Host "Done. Run 'riffpad version' in a new terminal."

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -183,7 +183,7 @@
 | M3.2 | tmux / PTY 兜底（L3）正式实现 | `[ ]` | 任意 CLI 可监控 | — |
 | M3.3 | 自部署中继 | `[ ]` | 一键部署文档 + 镜像 | — |
 | M3.4 | 局域网直连 / WebRTC（relay 退化信令） | `[ ]` | 局域网内无中继可用 | — |
-| M3.5 | Windows daemon | `[~]` | v0.2 发布后立即做：syscall 兼容（codex Kill、daemon Flock 跨平台）、install.ps1、开机自启、release 矩阵增加 windows amd64/arm64 | — |
+| M3.5 | Windows daemon | `[x]` | 交叉编译通过（codex Kill、daemon Flock、Setsid 拆 build tag）；CI 增加 windows/darwin 编译守卫；scripts/install.ps1 + schtasks 开机自启；release 矩阵含 windows amd64/arm64（随下个 release 发布） | #147 |
 | M3.6 | 团队版（多人共享设备/会话） | `[ ]` | 权限模型可用 | — |
 | M3.7 | 无 tmux 注入：Kimi ACP / Codex app-server / Claude host 控制协议 | `[x]` | 三适配器实现并真机实测；`riffpad run --cli kimi/codex/claude` | #55 #52 |
 | M3.8 | daemon 无感化启动：CLI 懒启动 + Linux systemd 自启 | `[x]` | 自动拉起（文件锁防双实例）；`riffpad setup` 安装/卸载 | #57 |

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,27 @@
+$ErrorActionPreference = "Stop"
+
+$installDir = Join-Path $env:LOCALAPPDATA "riffpad"
+$exe = Join-Path $installDir "riffpad.exe"
+
+Write-Host "Installing Riffpad to $installDir ..."
+New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+
+$release = Invoke-RestMethod "https://api.github.com/repos/riffpad/riffpad/releases/latest"
+$asset = $release.assets | Where-Object { $_.name -eq "riffpad-windows-amd64.exe" }
+if (-not $asset) {
+  throw "Latest release has no riffpad-windows-amd64.exe asset"
+}
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $exe
+
+# Add the install dir to the user PATH if missing.
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($userPath -notlike "*$installDir*") {
+  [Environment]::SetEnvironmentVariable("Path", "$userPath;$installDir", "User")
+  Write-Host "Added $installDir to your user PATH (reopen the terminal to use riffpad)."
+}
+
+# Autostart the daemon at logon via a hidden scheduled task.
+schtasks /Create /TN "RiffpadDaemon" /TR "\"$exe\" _daemon" /SC ONLOGON /RL LIMITED /F | Out-Null
+
+Write-Host ""
+Write-Host "Done. Run 'riffpad version' in a new terminal."


### PR DESCRIPTION
Closes #147

## 改动
- codex：syscall.Kill → os.Process.Kill（跨平台）
- daemon 锁：Flock 拆 lock_unix/lock_windows（x/sys LockFileEx）
- daemon 启动 Setsid 拆 procattr_unix/windows
- GOOS=windows/darwin 全量编译通过（amd64+arm64）
- CI：go job 增加 windows/darwin 交叉编译守卫（防止回归破坏闭环）
- release 矩阵增加 windows amd64/arm64（.exe）
- scripts/install.ps1：下载最新 release、加入用户 PATH、schtasks 开机自启 daemon；同步到 landing public
- landing 恢复 Windows 安装 tab（irm https://riffpad.ai/install.ps1 | iex）
- dev-plan M3.5 标记完成（windows 二进制随下个 release 发布）

## 回归验证
- [x] go test（daemon/relay/protocol）、client typecheck/test（4）/build、Playwright e2e 4/4、landing lint/build
- [x] linux/darwin/windows × amd64/arm64 交叉编译