### PR TITLE
docs: unify docs links to www.riffpad.ai/docs/guide/quickstart (#150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Watch, approve, and steer Claude Code, Codex, and other AI coding CLIs from your
 
 [![CI](https://github.com/riffpad/riffpad/actions/workflows/ci.yml/badge.svg)](https://github.com/riffpad/riffpad/actions/workflows/ci.yml)
 [![GitHub stars](https://img.shields.io/github/stars/riffpad/riffpad?style=flat&color=1a7f37)](https://github.com/riffpad/riffpad/stargazers)
-[![Docs](https://img.shields.io/badge/docs-riffpad.ai-1a7f37)](https://riffpad.ai/docs)
+[![Docs](https://img.shields.io/badge/docs-riffpad.ai-1a7f37)](https://www.riffpad.ai/docs/guide/quickstart)
 [![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/CDNFTg2QyM)
 
-[Website](https://riffpad.ai) · [Documentation](https://riffpad.ai/docs) · [Discord community](https://discord.gg/CDNFTg2QyM) · [App](https://app.riffpad.ai)
+[Website](https://riffpad.ai) · [Documentation](https://www.riffpad.ai/docs/guide/quickstart) · [Discord community](https://discord.gg/CDNFTg2QyM) · [App](https://app.riffpad.ai)
 
 </div>
 
@@ -88,4 +88,4 @@ Questions, ideas, or show-and-tell? Join us:
 
 - [Discord](https://discord.gg/CDNFTg2QyM) — the community hangout
 - [GitHub Issues](https://github.com/riffpad/riffpad/issues) — bugs and feature requests
-- [Documentation](https://riffpad.ai/docs) — install, pairing, security model
+- [Documentation](https://www.riffpad.ai/docs/guide/quickstart) — install, pairing, security model

--- a/apps/landing/components/Footer.tsx
+++ b/apps/landing/components/Footer.tsx
@@ -33,7 +33,7 @@ export function Footer() {
               {t.footer.github}
             </a>
             <a
-              href="/docs"
+              href="https://www.riffpad.ai/docs/guide/quickstart"
               className="transition-colors hover:text-ink"
             >
               {t.footer.docs}

--- a/apps/landing/components/Hero.tsx
+++ b/apps/landing/components/Hero.tsx
@@ -31,7 +31,7 @@ export function Hero() {
             {t.hero.ctaPrimary}
           </a>
           <a
-            href="/docs"
+            href="https://www.riffpad.ai/docs/guide/quickstart"
             className="btn btn-secondary w-full sm:w-auto"
           >
             {t.hero.ctaSecondary}


### PR DESCRIPTION
README 与 landing 的文档按钮统一直链到 www.riffpad.ai/docs/guide/quickstart，跳过域名重定向 + meta refresh 两次跳转。