### PR TITLE
fix(daemon): double close(c.done) panic on viewer disconnect (#163)

### DIFF
--- a/apps/daemon/internal/daemon/client_race_test.go
+++ b/apps/daemon/internal/daemon/client_race_test.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"errors"
+	"io"
+	"log"
+	"sync"
+	"testing"
+)
+
+// failTransport simulates a viewer connection that is dead in both
+// directions: Send and Recv always fail, as happens when a viewer
+// disconnects while an event is in flight.
+type failTransport struct {
+	sendCalled chan struct{}
+	closed     chan struct{}
+	closeOnce  sync.Once
+}
+
+func newFailTransport() *failTransport {
+	return &failTransport{
+		sendCalled: make(chan struct{}),
+		closed:     make(chan struct{}),
+	}
+}
+
+func (t *failTransport) Send([]byte) error {
+	t.closeOnce.Do(func() { close(t.sendCalled) })
+	return errors.New("viewer gone")
+}
+
+func (t *failTransport) Recv() ([]byte, error) {
+	return nil, errors.New("viewer gone")
+}
+
+func (t *failTransport) Close() error {
+	close(t.closed)
+	return nil
+}
+
+// TestClientConcurrentCloseNoPanic reproduces issue #163: readLoop and
+// writeLoop both try to close c.done when a viewer disconnects mid-write.
+// Without the sync.Once guard this panics with "close of closed channel".
+func TestClientConcurrentCloseNoPanic(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		tr := newFailTransport()
+		sess := &session{id: "s1", clients: map[*client]struct{}{}}
+		c := &client{
+			deviceID:  "dev1",
+			session:   sess,
+			transport: tr,
+			send:      make(chan []byte, 1),
+			done:      make(chan struct{}),
+			log:       log.New(io.Discard, "", 0),
+		}
+		c.send <- []byte("event")
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			c.writeLoop()
+		}()
+		// Wait until writeLoop's Send has failed, then unleash readLoop so
+		// both goroutines race to close c.done.
+		<-tr.sendCalled
+		go func() {
+			defer wg.Done()
+			c.readLoop(&Server{})
+		}()
+		wg.Wait()
+	}
+}

--- a/apps/daemon/internal/daemon/hub.go
+++ b/apps/daemon/internal/daemon/hub.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"encoding/json"
 	"log"
+	"sync"
 
 	"github.com/riffpad/riffpad/packages/protocol"
 )
@@ -23,7 +24,14 @@ type client struct {
 	transport viewerTransport
 	send      chan []byte
 	done      chan struct{}
+	closeOnce sync.Once
 	log       *log.Logger
+}
+
+// closeDone closes c.done exactly once; both readLoop and writeLoop may
+// trigger shutdown concurrently.
+func (c *client) closeDone() {
+	c.closeOnce.Do(func() { close(c.done) })
 }
 
 func (c *client) writeLoop() {
@@ -32,7 +40,7 @@ func (c *client) writeLoop() {
 		case data := <-c.send:
 			if err := c.transport.Send(data); err != nil {
 				c.log.Printf("ws write error device=%s: %v", c.deviceID, err)
-				close(c.done)
+				c.closeDone()
 				return
 			}
 		case <-c.done:

--- a/apps/daemon/internal/daemon/ws.go
+++ b/apps/daemon/internal/daemon/ws.go
@@ -157,7 +157,7 @@ func (s *Server) attachViewer(tr viewerTransport, deviceID, sid string, ephPub [
 
 func (c *client) readLoop(s *Server) {
 	defer func() {
-		close(c.done)
+		c.closeDone()
 		c.session.removeClient(c)
 		_ = c.transport.Close()
 	}()


### PR DESCRIPTION
## 根因

viewer（浏览器/手机 client）断开时机不当时 daemon 会 panic：`close of closed channel`，所有会话和待审批丢失。

`client.done` 有两条无同步保护的关闭路径：

- `ws.go` readLoop 退出时在 defer 里 `close(c.done)`，随后 `transport.Close()` 让 in-flight 的 Send 报错；
- `hub.go` writeLoop 在 Send 出错时也 `close(c.done)`。

时序：readLoop 先 close(done) → transport.Close() 触发 writeLoop 的 Send 报错 → writeLoop 第二次 close → panic。relay viewer 断开时关闭 recv channel 会让 readLoop 以 `io.EOF` 退出，走的是同一条路径。

## 修法

照抄 relay 侧 `hostConn`/`viewerConn` 已有的模式（`apps/relay/internal/hub/hub.go`）：给 `client` 加 `closeOnce sync.Once` 字段和 `closeDone()` 方法，两条关闭路径统一走 `closeDone()`。

- `apps/daemon/internal/daemon/hub.go`：新增 `closeOnce` 字段 + `closeDone()`，writeLoop 改用它
- `apps/daemon/internal/daemon/ws.go`：readLoop defer 改用它
- `apps/daemon/internal/daemon/client_race_test.go`：新增竞态测试，模拟 readLoop/writeLoop 并发触发关闭，断言不 panic（已在旧代码上验证可复现 panic）

`relay.go` 的 `v.recv` 关闭本来就有互斥锁保护（`closeViewer` 先删后关、`runOnce` 持锁统一关），不存在 double close，未改动。

## 验证

```
cd apps/daemon && go build ./... && go test -race ./internal/daemon/
```

全部通过；将测试单独跑在未修复代码上会 panic（`close of closed channel`），修复后 100 轮并发关闭无 panic、无 race。

Closes #163