### PR TITLE
fix(relay): 多 host 会话表隔离 + superseded 通知 (#169)

### DIFF
--- a/apps/daemon/internal/daemon/relay.go
+++ b/apps/daemon/internal/daemon/relay.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -101,9 +102,24 @@ func newRelayClient(baseURL, hostID, secret string, logger *log.Logger, onJoin f
 	}
 }
 
+// errSuperseded is returned by runOnce when the relay reports that another
+// connection with the same host credentials took over. It is process-level
+// only: restarting the daemon retries normally.
+var errSuperseded = errors.New("host superseded by another connection")
+
 func (c *relayClient) run(ctx context.Context) {
 	for {
-		if err := c.runOnce(ctx); err != nil && ctx.Err() == nil {
+		err := c.runOnce(ctx)
+		if errors.Is(err, errSuperseded) && ctx.Err() == nil {
+			// The same hostId+secret connected elsewhere — almost always a
+			// config copied to a second machine. Reconnecting would kick the
+			// other daemon off and loop forever (#169), so stop here.
+			c.log.Printf("relay: this host is already connected elsewhere (superseded); " +
+				"not reconnecting — check whether the riffpad config was copied to another machine, " +
+				"then restart this daemon")
+			return
+		}
+		if err != nil && ctx.Err() == nil {
 			c.log.Printf("relay disconnected: %v (reconnecting in 3s)", err)
 			select {
 			case <-ctx.Done():
@@ -144,6 +160,8 @@ func (c *relayClient) runOnce(ctx context.Context) error {
 		c.announce(sessions)
 	}
 
+	superseded := false
+readLoop:
 	for {
 		_, data, err := conn.ReadMessage()
 		if err != nil {
@@ -169,6 +187,9 @@ func (c *relayClient) runOnce(ctx context.Context) error {
 				continue
 			}
 			c.deliver(fr.ViewerID, payload)
+		case protocol.RelayFrameSuperseded:
+			superseded = true
+			break readLoop
 		}
 	}
 	c.mu.Lock()
@@ -179,6 +200,9 @@ func (c *relayClient) runOnce(ctx context.Context) error {
 	c.viewers = map[string]*relayViewer{}
 	c.mu.Unlock()
 	_ = conn.Close()
+	if superseded {
+		return errSuperseded
+	}
 	return fmt.Errorf("relay connection closed")
 }
 

--- a/apps/daemon/internal/daemon/relay_test.go
+++ b/apps/daemon/internal/daemon/relay_test.go
@@ -1,0 +1,54 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/riffpad/riffpad/packages/protocol"
+)
+
+// When the relay reports that the same host credentials connected elsewhere,
+// the daemon must stop auto-reconnecting instead of kick-looping with the
+// other daemon (#169).
+func TestRelayClientStopsReconnectingOnSuperseded(t *testing.T) {
+	var dials atomic.Int32
+	up := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		dials.Add(1)
+		data, _ := json.Marshal(relayFrame{Kind: protocol.RelayFrameSuperseded})
+		_ = conn.WriteMessage(websocket.TextMessage, data)
+		time.Sleep(100 * time.Millisecond)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newRelayClient("ws"+strings.TrimPrefix(srv.URL, "http"), "h1", "s1",
+		log.New(io.Discard, "", 0), nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	done := make(chan struct{})
+	go func() { c.run(ctx); close(done) }()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("run did not return after superseded")
+	}
+	// The reconnect interval is 3s; wait past it and assert no second dial.
+	time.Sleep(3500 * time.Millisecond)
+	if n := dials.Load(); n != 1 {
+		t.Fatalf("expected no reconnect after superseded, got %d dials", n)
+	}
+}

--- a/apps/relay/internal/hub/hub.go
+++ b/apps/relay/internal/hub/hub.go
@@ -84,6 +84,10 @@ type hostConn struct {
 	send chan []byte
 	done chan struct{}
 	once sync.Once
+	// writeMu serializes direct writes with writeLoop so a final control
+	// frame (superseded) can be delivered synchronously before the
+	// connection is closed.
+	writeMu sync.Mutex
 }
 
 type viewerConn struct {
@@ -99,6 +103,20 @@ type viewerConn struct {
 
 func (h *hostConn) closeDone() {
 	h.once.Do(func() { close(h.done) })
+}
+
+// writeFrame writes one frame directly on the connection, serialized with
+// writeLoop. Used for the final superseded notice, which must go out before
+// the connection is closed (queueing it on send would race with done).
+func (h *hostConn) writeFrame(fr hostFrame) {
+	data, err := json.Marshal(fr)
+	if err != nil {
+		return
+	}
+	h.writeMu.Lock()
+	defer h.writeMu.Unlock()
+	_ = h.conn.SetWriteDeadline(wsWriteDeadline())
+	_ = h.conn.WriteMessage(websocket.TextMessage, data)
 }
 
 func (v *viewerConn) closeDone() {
@@ -1054,6 +1072,10 @@ func (h *Hub) handleHostWS(w http.ResponseWriter, r *http.Request) {
 	host := &hostConn{id: hostID, conn: conn, send: make(chan []byte, 256), done: make(chan struct{})}
 	h.mu.Lock()
 	if old, ok := h.hosts[hostID]; ok {
+		// Tell the replaced connection why it is being dropped: two daemons
+		// sharing the same host credentials would otherwise kick each other
+		// in an endless reconnect loop (#169).
+		old.writeFrame(hostFrame{Kind: protocol.RelayFrameSuperseded})
 		old.closeDone()
 		_ = old.conn.Close()
 	}
@@ -1086,12 +1108,22 @@ func (h *Hub) hostReadLoop(host *hostConn) {
 		switch fr.Kind {
 		case "sessions":
 			h.mu.Lock()
-			h.sessions = map[string]SessionMeta{}
-			h.sessionHosts = map[string]string{}
-			for _, s := range fr.Sessions {
-				s.HostID = host.id
-				h.sessions[s.ID] = s
-				h.sessionHosts[s.ID] = host.id
+			if h.hosts[host.id] == host {
+				// Replace only this host's entries: other hosts of the same
+				// account (desktop + laptop) keep their sessions (#169). The
+				// current-connection check also rejects a stale announce from
+				// a superseded connection still draining its read loop.
+				for sid, hid := range h.sessionHosts {
+					if hid == host.id {
+						delete(h.sessionHosts, sid)
+						delete(h.sessions, sid)
+					}
+				}
+				for _, s := range fr.Sessions {
+					s.HostID = host.id
+					h.sessions[s.ID] = s
+					h.sessionHosts[s.ID] = host.id
+				}
 			}
 			h.mu.Unlock()
 			_ = h.store.UpsertSessions(host.id, fr.Sessions)
@@ -1116,13 +1148,18 @@ func (h *Hub) hostReadLoop(host *hostConn) {
 
 func (h *Hub) removeHost(host *hostConn) {
 	h.mu.Lock()
-	if h.hosts[host.id] == host {
+	// Only the connection currently registered under this host id may tear
+	// down its sessions: after a reconnect the old connection's deferred
+	// cleanup runs after the new one has already re-announced, and must not
+	// wipe those fresh entries (#169).
+	current := h.hosts[host.id] == host
+	if current {
 		delete(h.hosts, host.id)
-	}
-	for sid, hid := range h.sessionHosts {
-		if hid == host.id {
-			delete(h.sessionHosts, sid)
-			delete(h.sessions, sid)
+		for sid, hid := range h.sessionHosts {
+			if hid == host.id {
+				delete(h.sessionHosts, sid)
+				delete(h.sessions, sid)
+			}
 		}
 	}
 	for id, v := range h.viewers {
@@ -1133,7 +1170,9 @@ func (h *Hub) removeHost(host *hostConn) {
 		}
 	}
 	h.mu.Unlock()
-	_ = h.store.MarkHostSessionsOffline(host.id)
+	if current {
+		_ = h.store.MarkHostSessionsOffline(host.id)
+	}
 	h.log.Printf("host disconnected id=%s", host.id)
 }
 
@@ -1237,7 +1276,10 @@ func (h *hostConn) writeLoop() {
 		select {
 		case data := <-h.send:
 			_ = h.conn.SetWriteDeadline(wsWriteDeadline())
-			if err := h.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+			h.writeMu.Lock()
+			err := h.conn.WriteMessage(websocket.TextMessage, data)
+			h.writeMu.Unlock()
+			if err != nil {
 				return
 			}
 		case <-ticker.C:

--- a/apps/relay/internal/hub/hub_test.go
+++ b/apps/relay/internal/hub/hub_test.go
@@ -876,3 +876,156 @@ func TestViewerHeartbeatDropsSilentPeer(t *testing.T) {
 		t.Fatalf("silent viewer still registered: %d", n)
 	}
 }
+
+// announceSessions sends a "sessions" frame from a host connection.
+func announceSessions(t *testing.T, conn *websocket.Conn, sessions ...SessionMeta) {
+	t.Helper()
+	fr, _ := json.Marshal(hostFrame{Kind: "sessions", Sessions: sessions})
+	if err := conn.WriteMessage(websocket.TextMessage, fr); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func listSessionIDs(t *testing.T, ts *httptest.Server, token string) map[string]bool {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/sessions", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Sessions []SessionMeta `json:"sessions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	ids := map[string]bool{}
+	for _, s := range out.Sessions {
+		ids[s.ID] = true
+	}
+	return ids
+}
+
+// waitForSessions polls /api/sessions until exactly the wanted session ids
+// are listed (announces are processed asynchronously on the host read loop).
+func waitForSessions(t *testing.T, ts *httptest.Server, token string, want ...string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		got := listSessionIDs(t, ts, token)
+		if len(got) == len(want) {
+			match := true
+			for _, id := range want {
+				if !got[id] {
+					match = false
+					break
+				}
+			}
+			if match {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("sessions = %v, want %v", got, want)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// One host re-announcing its sessions must not clear the sessions announced
+// by another host of the same account (desktop + laptop) (#169).
+func TestHostAnnouncesDoNotClearOtherHosts(t *testing.T) {
+	_, ts := newTestHub(t)
+	token := registerUser(t, ts, "multi-host")
+	hostA, secretA := registerHost(t, ts, token, "desktop")
+	hostB, secretB := registerHost(t, ts, token, "laptop")
+
+	connA := dialHostWS(t, ts, hostA, secretA)
+	connB := dialHostWS(t, ts, hostB, secretB)
+
+	announceSessions(t, connA, SessionMeta{ID: "a1", Name: "a1", CLI: "claude", Status: "running"})
+	announceSessions(t, connB, SessionMeta{ID: "b1", Name: "b1", CLI: "claude", Status: "running"})
+	waitForSessions(t, ts, token, "a1", "b1")
+
+	// A replaces its own list; B's sessions must survive.
+	announceSessions(t, connA, SessionMeta{ID: "a2", Name: "a2", CLI: "claude", Status: "running"})
+	waitForSessions(t, ts, token, "a2", "b1")
+}
+
+// A reconnecting host registers its new connection before the old one's
+// deferred removeHost runs; the old cleanup must not wipe the sessions the
+// new connection just announced (#169).
+func TestReconnectDoesNotWipeReannouncedSessions(t *testing.T) {
+	_, ts := newTestHub(t)
+	token := registerUser(t, ts, "reconnect")
+	hostID, secret := registerHost(t, ts, token, "laptop")
+
+	conn1 := dialHostWS(t, ts, hostID, secret)
+	announceSessions(t, conn1, SessionMeta{ID: "s1", Name: "s1", CLI: "claude", Status: "running"})
+	waitForSessions(t, ts, token, "s1")
+
+	// New connection supersedes the old one (e.g. after a network flap), and
+	// the daemon re-announces. The old connection's deferred removeHost then
+	// runs and must leave the fresh entries alone.
+	conn2 := dialHostWS(t, ts, hostID, secret)
+	announceSessions(t, conn2, SessionMeta{ID: "s2", Name: "s2", CLI: "claude", Status: "running"})
+	waitForSessions(t, ts, token, "s2")
+
+	// Give the old connection's read loop time to notice the close and run
+	// its deferred removeHost, then confirm the sessions are still there.
+	conn1.SetReadDeadline(time.Now().Add(3 * time.Second))
+	for {
+		if _, _, err := conn1.ReadMessage(); err != nil {
+			break
+		}
+	}
+	time.Sleep(100 * time.Millisecond)
+	waitForSessions(t, ts, token, "s2")
+}
+
+// A plain disconnect (no replacement connection) still clears the host's
+// sessions from the live list.
+func TestHostDisconnectClearsSessions(t *testing.T) {
+	_, ts := newTestHub(t)
+	token := registerUser(t, ts, "disconnect")
+	hostID, secret := registerHost(t, ts, token, "laptop")
+
+	conn := dialHostWS(t, ts, hostID, secret)
+	announceSessions(t, conn, SessionMeta{ID: "s1", Name: "s1", CLI: "claude", Status: "running"})
+	waitForSessions(t, ts, token, "s1")
+
+	_ = conn.Close()
+	waitForSessions(t, ts, token)
+}
+
+// When a new connection with the same host credentials replaces an old one,
+// the relay must send a superseded frame first so the old daemon stops
+// reconnecting instead of kick-looping (#169).
+func TestSupersededFrameSentToReplacedHost(t *testing.T) {
+	_, ts := newTestHub(t)
+	token := registerUser(t, ts, "supersede")
+	hostID, secret := registerHost(t, ts, token, "laptop")
+
+	conn1 := dialHostWS(t, ts, hostID, secret)
+	_ = dialHostWS(t, ts, hostID, secret)
+
+	conn1.SetReadDeadline(time.Now().Add(3 * time.Second))
+	_, raw, err := conn1.ReadMessage()
+	if err != nil {
+		t.Fatalf("old connection got no superseded frame: %v", err)
+	}
+	var fr hostFrame
+	if err := json.Unmarshal(raw, &fr); err != nil {
+		t.Fatal(err)
+	}
+	if fr.Kind != "superseded" {
+		t.Fatalf("old connection got kind %q, want superseded", fr.Kind)
+	}
+	// The relay drops the old connection right after the notice.
+	conn1.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if _, _, err := conn1.ReadMessage(); err == nil {
+		t.Fatal("old connection still open after superseded")
+	}
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -57,6 +57,14 @@ AI coding agent（Claude Code、Codex、DeepSeek CLI、Kimi CLI 等）会长时�
 | `prompt` | mobile → daemon | 文字新指令 |
 | `file_change` | daemon → mobile | 路径与变更摘要 |
 
+daemon ↔ relay 之间另有一组不加密的路由控制帧（`/ws/host` 连接，kind 字段）：
+
+| 帧 | 方向 | 说明 |
+|---|---|---|
+| `sessions` | daemon → relay | 上报本 host 的会话列表；relay 只替换该 host 的条目，不影响同账号其他 host |
+| `join` / `leave` / `viewer` | relay ↔ daemon | viewer 接入、离开与加密信封转发 |
+| `superseded` | relay → daemon | 同一 host 凭据在别处新连接，本连接被顶替；daemon 收到后停止自动重连并日志提示（防双 daemon 互踢），重启 daemon 可重试 |
+
 ## 4. 安全基线
 
 - 传输全程 E2EE，relay 无解密能力

--- a/packages/protocol/events.go
+++ b/packages/protocol/events.go
@@ -26,6 +26,16 @@ const (
 	EventNotify       = "notify"
 )
 
+// Relay frame kinds for the daemon ↔ relay control channel on /ws/host
+// (see docs/design.md §3). Unlike the Event types above, these frames are
+// relay routing metadata and travel unencrypted.
+const (
+	// RelayFrameSuperseded is sent by the relay to the old host connection
+	// when a new connection with the same host credentials replaces it.
+	// The daemon must stop auto-reconnecting to avoid a kick loop.
+	RelayFrameSuperseded = "superseded"
+)
+
 // Agent status values.
 const (
 	StatusRunning      = "running"


### PR DESCRIPTION
## 改动点

修复同一账号多台电脑跑 daemon 时 relay 会话路由表互相踩踏的三个问题（#169）：

1. **会话表按 host 隔离**：`hub.go` 收到 `sessions` 帧时不再全局重建 `sessions`/`sessionHosts`，只替换该 host 自己的条目；A 机重连/上报不再把 B 机的会话从所有人手机列表里抹掉。同时加了「当前连接」校验，被顶替的旧连接滞后的 announce 不会覆盖新连接的条目。
2. **removeHost 竞态防护**：仅当 `h.hosts[host.id] == host`（旧连接仍是当前注册连接）时才清理该 host 的会话并 `MarkHostSessionsOffline`；旧连接的 defer 清理不再误删新连接刚 re-announce 的会话。viewer 清理不受此限制（旧连接自己的 viewer 仍被断开）。
3. **superseded 帧**：relay 顶掉旧 host 连接前先同步发送 `{"kind":"superseded"}`（`hostConn.writeMu` 保证与 writeLoop 串行、关闭连接前送达）；daemon 收到后停止自动重连（进程级，重启 daemon 即可重试），并日志提示同一 host 已在别处连接、需检查配置是否被复制到多台机器，避免同配置双 daemon 每 3s 互踢死循环。

## 协议同步

- `packages/protocol/events.go`：新增 `RelayFrameSuperseded = "superseded"` 常量（relay ↔ daemon 控制帧，不加密），relay 与 daemon 均引用该常量。
- `docs/design.md` §3：补充 daemon ↔ relay 控制帧表（sessions / join / leave / viewer / superseded）。

## 验证步骤

- `cd apps/relay && go build ./... && go test -race ./...` ✅（新增 4 个测试：多 host announce 互不影响、重连竞态不抹会话、普通断线仍清会话、superseded 帧发送）
- `cd apps/daemon && go build ./... && go test -race ./...` ✅（新增测试：收到 superseded 后不再重连）
- `cd packages/protocol && go test ./...` ✅

人肉验证：同一账号在两台机器（或同一台机器复制 `~/.config/riffpad` 到另一目录）各起一个 daemon；观察 relay 端旧连接收到 superseded 帧、被顶掉的 daemon 日志提示并停止重连，手机端会话列表不再闪烁/清空。

Closes #169