### PR TITLE
fix(daemon): 会话生命周期 — hook 复活 restored 会话、kill -9 活性探测、Shutdown 回收、sweep 宽限 (#170)

### DIFF
--- a/apps/daemon/internal/daemon/attach.go
+++ b/apps/daemon/internal/daemon/attach.go
@@ -43,6 +43,15 @@ func (a *attachAdapter) Stop() error { return nil }
 // viewer decision before defaulting to deny. A var so tests can shrink it.
 var approvalHookTimeout = 10 * time.Minute
 
+// attachIdleTimeout bounds how long an attach session may go without any hook
+// event before the sweeper marks it ended (#170). Hook activity is the only
+// liveness signal for a claude process running in the user's own tmux; after
+// `kill -9` the SessionEnd hook never fires, so without this the session
+// would stay "running" forever. 30min is long enough that normal thinking
+// pauses never trip it; if it does trip while claude is merely idle, the next
+// hook revives the session in attachSession. A var so tests can shrink it.
+var attachIdleTimeout = 30 * time.Minute
+
 // hookPayload is the common shape of Claude Code hook input JSON.
 type hookPayload struct {
 	HookEventName string         `json:"hook_event_name"`
@@ -121,20 +130,57 @@ func (p *hookPayload) summary() string {
 // lazily on first hook activity.
 func (s *Server) attachSession(claudeSID, cwd string) *session {
 	s.mu.Lock()
-	if sess, ok := s.sessions[claudeSID]; ok {
-		s.mu.Unlock()
+	sess, ok := s.sessions[claudeSID]
+	s.mu.Unlock()
+	if ok {
+		sess.mu.Lock()
+		_, restored := sess.adapter.(*restoredAdapter)
+		ended := sess.ended
+		if restored {
+			// The agent outlived a daemon restart (#170): the real claude
+			// process is still running in the user's terminal and its hooks
+			// keep firing. Swap the read-only restoredAdapter for a live
+			// attachAdapter in place so prompts/approvals work again.
+			sess.adapter = &attachAdapter{server: s, cwd: cwd}
+		}
+		if restored || ended {
+			// Any hook proves the agent is alive: revive sessions previously
+			// marked ended (e.g. by the sweeper's idle timeout while the user
+			// simply left claude open).
+			sess.status = protocol.StatusRunning
+			sess.ended = false
+			sess.lastSeen = time.Now()
+		}
+		sess.mu.Unlock()
+		if restored {
+			s.log.Printf("reattached session %s: restored adapter swapped for live attach adapter", claudeSID)
+		} else if ended {
+			s.log.Printf("session %s revived by hook activity", claudeSID)
+		}
+		if restored || ended {
+			s.persistSession(sess)
+			s.announceSessions()
+		}
 		return sess
 	}
 	name := claudeSID
 	if cwd != "" {
 		name = filepath.Base(cwd)
 	}
-	sess := &session{
-		id:      claudeSID,
-		meta:    protocol.SessionStartPayload{Name: name, CLI: "claude (attach)", Cwd: cwd},
-		adapter: &attachAdapter{server: s, cwd: cwd},
-		status:  protocol.StatusRunning,
-		clients: map[*client]struct{}{},
+	sess = &session{
+		id:       claudeSID,
+		meta:     protocol.SessionStartPayload{Name: name, CLI: "claude (attach)", Cwd: cwd},
+		adapter:  &attachAdapter{server: s, cwd: cwd},
+		status:   protocol.StatusRunning,
+		lastSeen: time.Now(),
+		clients:  map[*client]struct{}{},
+	}
+	s.mu.Lock()
+	if existing, ok := s.sessions[claudeSID]; ok {
+		// Lost a creation race with a concurrent hook: fall back to the
+		// existing session (revive path above handles restored/ended).
+		s.mu.Unlock()
+		return existing
 	}
 	s.sessions[claudeSID] = sess
 	s.mu.Unlock()

--- a/apps/daemon/internal/daemon/attach_test.go
+++ b/apps/daemon/internal/daemon/attach_test.go
@@ -307,6 +307,125 @@ func TestAttachPermissionTimeoutResolves(t *testing.T) {
 	}
 }
 
+// TestAttachRevivesRestoredSession covers #170: after a daemon restart a live
+// claude session comes back as a read-only restoredAdapter; the agent's next
+// hook must swap it for a live attachAdapter in place.
+func TestAttachRevivesRestoredSession(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	keys, err := config.LoadOrCreateKeys(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate the pre-restart state: a live attach session on disk.
+	ps := &PersistedSession{
+		ID: "claude-restored-1", Name: "proj", CLI: "claude (attach)",
+		Cwd: "/tmp/proj", Status: "restored", CreatedAt: time.Now(),
+	}
+	if err := persistSessionMeta(dir, ps); err != nil {
+		t.Fatal(err)
+	}
+	logger := log.New(io.Discard, "", 0)
+	srv := New(cfg, keys, dir, logger, nil)
+
+	sess := srv.getSession("claude-restored-1")
+	if sess == nil {
+		t.Fatal("session should be restored")
+	}
+	if _, ok := sess.getAdapter().(*restoredAdapter); !ok {
+		t.Fatalf("expected restoredAdapter, got %T", sess.getAdapter())
+	}
+	if err := sess.getAdapter().SendPrompt("hi"); err == nil || !strings.Contains(err.Error(), "not attached") {
+		t.Fatalf("restored session should reject prompts, got %v", err)
+	}
+
+	// The still-alive agent fires its next hook.
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	resp := authRequest(t, http.MethodPost, ts.URL+"/hooks/claude/session-start", cfg.LocalToken,
+		strings.NewReader(`{"hook_event_name":"SessionStart","session_id":"claude-restored-1","cwd":"/tmp/proj"}`))
+	resp.Body.Close()
+
+	sess = srv.getSession("claude-restored-1")
+	if _, ok := sess.getAdapter().(*attachAdapter); !ok {
+		t.Fatalf("expected attachAdapter after hook, got %T", sess.getAdapter())
+	}
+	if sess.status != protocol.StatusRunning || sess.ended {
+		t.Fatalf("expected running live session, got status=%s ended=%v", sess.status, sess.ended)
+	}
+	// SendPrompt now reaches the tmux injection path (no claude pane exists in
+	// the test environment) instead of the restored placeholder error.
+	if err := sess.getAdapter().SendPrompt("hi"); err == nil || strings.Contains(err.Error(), "not attached") {
+		t.Fatalf("expected tmux injection error, got %v", err)
+	}
+}
+
+// TestSweepIdleAttachSession covers #170: after `kill -9` on claude the
+// SessionEnd hook never fires, so the sweeper must mark a hook-silent attach
+// session ended — and a later hook must revive it (idle false positive).
+func TestSweepIdleAttachSession(t *testing.T) {
+	old := attachIdleTimeout
+	attachIdleTimeout = time.Minute
+	defer func() { attachIdleTimeout = old }()
+
+	dir := t.TempDir()
+	cfg := config.Default()
+	keys, err := config.LoadOrCreateKeys(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := log.New(io.Discard, "", 0)
+	srv := New(cfg, keys, dir, logger, nil)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	post := func(path, body string) {
+		t.Helper()
+		resp := authRequest(t, http.MethodPost, ts.URL+path, cfg.LocalToken, strings.NewReader(body))
+		resp.Body.Close()
+	}
+
+	post("/hooks/claude/session-start", `{"hook_event_name":"SessionStart","session_id":"claude-idle-1","cwd":"/tmp/proj"}`)
+	sess := srv.getSession("claude-idle-1")
+	if sess == nil || sess.status != protocol.StatusRunning {
+		t.Fatalf("expected running attach session, got %+v", sess)
+	}
+
+	// Simulate kill -9: hooks just stop coming.
+	sess.mu.Lock()
+	sess.lastSeen = time.Now().Add(-2 * time.Minute)
+	sess.mu.Unlock()
+	srv.sweepOnce()
+
+	sess = srv.getSession("claude-idle-1")
+	if sess == nil {
+		t.Fatal("idle attach session should be marked ended, not removed")
+	}
+	if !sess.ended || sess.status != protocol.StatusDone {
+		t.Fatalf("expected ended/done, got status=%s ended=%v", sess.status, sess.ended)
+	}
+	found := false
+	for _, hev := range sess.snapshot() {
+		if hev.Type != protocol.EventSessionEnd {
+			continue
+		}
+		var p protocol.SessionEndPayload
+		if err := hev.DecodePayload(&p); err == nil && p.Reason == "no_activity" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected a session_end(no_activity) event in history")
+	}
+
+	// False-positive path: the agent was merely idle; its next hook revives
+	// the session.
+	post("/hooks/claude/user-prompt-submit", `{"hook_event_name":"UserPromptSubmit","session_id":"claude-idle-1","prompt":"继续"}`)
+	sess = srv.getSession("claude-idle-1")
+	if sess.ended || sess.status != protocol.StatusRunning {
+		t.Fatalf("expected revived session, got status=%s ended=%v", sess.status, sess.ended)
+	}
+}
+
 func TestFindClaudePane(t *testing.T) {
 	out := "%0\tclaude\t/tmp/a\n" +
 		"%1\tnode /usr/local/bin/claude\t/tmp/b\n" +

--- a/apps/daemon/internal/daemon/persist.go
+++ b/apps/daemon/internal/daemon/persist.go
@@ -153,8 +153,9 @@ func aesGCM(key []byte) (cipher.AEAD, error) {
 }
 
 // restoredAdapter is a placeholder for sessions recovered after a daemon
-// restart: history is readable, but the underlying agent process is gone until
-// reattachment (M1.4 phase 2).
+// restart: history is readable, but the daemon no longer holds the agent.
+// When the (still alive) agent fires its next hook, attachSession swaps this
+// for a live attachAdapter in place (#170).
 type restoredAdapter struct {
 	id string
 }
@@ -190,8 +191,9 @@ func (r *restoredAdapter) Stop() error { return nil }
 var _ adapter.Session = (*restoredAdapter)(nil)
 
 // restoreSessions loads persisted sessions (not ended) after a daemon restart
-// so history stays available in the client. Agents are not re-attached yet
-// (phase 2 of M1.4); sessions are marked "restored" and read-only.
+// so history stays available in the client. Claude/Kimi sessions are marked
+// "restored" and read-only until their agent's next hook re-attaches them
+// (#170); Codex sessions are reattached to their app-server eagerly below.
 func (s *Server) restoreSessions() {
 	persisted, err := loadPersistedSessions(s.dataDir)
 	if err != nil {
@@ -268,7 +270,7 @@ func (s *Server) persistEvent(sess *session, ev protocol.Event) {
 }
 
 func (s *Server) persistSession(sess *session) {
-	if ci, ok := sess.adapter.(interface {
+	if ci, ok := sess.getAdapter().(interface {
 		CurrentConnect() (socket string, threadID string)
 	}); ok {
 		if sock, tid := ci.CurrentConnect(); sock != "" && tid != "" {

--- a/apps/daemon/internal/daemon/server.go
+++ b/apps/daemon/internal/daemon/server.go
@@ -51,9 +51,15 @@ type session struct {
 	events   <-chan protocol.Event
 	status   string
 	ended    bool
+	managed  bool      // daemon spawned the agent process: Shutdown reclaims it (#170)
 	lease    bool      // local TUI attached: session closes when heartbeat lapses
 	lastHB   time.Time // last lease heartbeat from the local CLI
-	lastSeen time.Time // last event activity (for dashboard "recent" display)
+	// leaseMissed records that the previous sweep already saw the lease
+	// expired; the session is closed only when two consecutive sweeps see no
+	// heartbeat, so a post-sleep sweep racing the heartbeat can't kill a live
+	// TUI (#170). Reset by every heartbeat.
+	leaseMissed bool
+	lastSeen    time.Time // last event activity (for dashboard "recent" display)
 	created  time.Time
 	connect  map[string]string // adapter connect info for restart recovery (e.g. codex socket/threadId)
 	mu       sync.Mutex
@@ -61,6 +67,15 @@ type session struct {
 	seq      uint64     // last assigned event sequence number (#173)
 	history  []protocol.Event
 	clients  map[*client]struct{}
+}
+
+// getAdapter returns the session's adapter under sess.mu. The adapter can be
+// swapped in place when a restored session is re-attached by hook activity
+// (#170), so readers must not cache sess.adapter without the lock.
+func (sess *session) getAdapter() adapter.Session {
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	return sess.adapter
 }
 
 // Server is the local daemon HTTP/WS server.
@@ -317,6 +332,22 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	case <-s.sweepDone:
 	default:
 		close(s.sweepDone)
+	}
+	// Reclaim agent processes the daemon itself spawned (#170): their Start
+	// ctx is context.Background(), so without this they outlive the daemon as
+	// orphans and pending approvals hang forever. Attach sessions run in the
+	// user's own tmux/terminal — never kill those.
+	s.mu.Lock()
+	sessions := make([]*session, 0, len(s.sessions))
+	for _, sess := range s.sessions {
+		sessions = append(sessions, sess)
+	}
+	s.mu.Unlock()
+	for _, sess := range sessions {
+		if sess.managed && !sess.ended {
+			s.log.Printf("shutdown: stopping spawned session %s", sess.id)
+			_ = sess.getAdapter().Stop()
+		}
 	}
 	if s.httpSrv == nil {
 		return nil
@@ -668,6 +699,7 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 		events:   sessAdapter.Events(),
 		status:   protocol.StatusRunning,
 		ended:    false,
+		managed:  true, // spawned by the daemon: Shutdown reclaims the process
 		created:  time.Now(),
 		lastSeen: time.Now(),
 		clients:  map[*client]struct{}{},
@@ -745,6 +777,7 @@ func (s *Server) handleSessionHeartbeat(w http.ResponseWriter, id string) {
 	if ok {
 		sess.lease = true
 		sess.lastHB = time.Now()
+		sess.leaseMissed = false
 	}
 	s.mu.Unlock()
 	if !ok {
@@ -768,7 +801,7 @@ func (s *Server) stopSession(id string) {
 	sess.ended = true
 	s.persistSession(sess)
 	s.announceSessions()
-	_ = sess.adapter.Stop()
+	_ = sess.getAdapter().Stop()
 	s.log.Printf("session %s stopped", id)
 }
 
@@ -783,7 +816,7 @@ func (s *Server) handleSessionConnect(w http.ResponseWriter, r *http.Request, id
 		writeError(w, http.StatusNotFound, "session not found")
 		return
 	}
-	ci, ok := sess.adapter.(interface {
+	ci, ok := sess.getAdapter().(interface {
 		ConnectInfo() (socket string, threadID string, err error)
 	})
 	if !ok {
@@ -867,7 +900,19 @@ func (s *Server) sweepOnce() {
 		s.mu.Lock()
 		leaseExpired := sess.lease && time.Since(sess.lastHB) > 20*time.Second
 		alreadyEnded := sess.ended
+		// Grace period (#170): after a system sleep the sweep ticker and the
+		// TUI heartbeat come due at the same time and the sweep can win the
+		// race, killing a session whose TUI is still open. Require the lease
+		// to stay expired across two consecutive sweeps before closing.
+		grace := leaseExpired && !alreadyEnded && !sess.leaseMissed
+		if grace {
+			sess.leaseMissed = true
+		}
 		s.mu.Unlock()
+		if grace {
+			s.log.Printf("session %s lease expired; granting one sweep period before closing", sess.id)
+			continue
+		}
 		if leaseExpired && !alreadyEnded {
 			s.log.Printf("session %s lease expired (no local TUI heartbeat); closing", sess.id)
 			s.stopSession(sess.id)
@@ -876,7 +921,26 @@ func (s *Server) sweepOnce() {
 		if sess.status != protocol.StatusRunning {
 			continue
 		}
-		if !sess.adapter.Alive() {
+		if _, isAttach := sess.getAdapter().(*attachAdapter); isAttach {
+			// attachAdapter.Alive is always true (the process lives in the
+			// user's tmux), so a `kill -9` on claude — where the SessionEnd
+			// hook never fires — would otherwise leave the session "running"
+			// forever. Hook activity is the only liveness signal we have; if
+			// none arrived within attachIdleTimeout, mark the session ended.
+			// False positives (user left claude idle) are harmless: the next
+			// hook revives the session in attachSession (#170).
+			sess.mu.Lock()
+			idleFor := time.Since(sess.lastSeen)
+			sess.mu.Unlock()
+			if idleFor > attachIdleTimeout {
+				ev, _ := protocol.NewEvent(sess.id, protocol.EventSessionEnd, protocol.SessionEndPayload{Reason: "no_activity"})
+				s.pumpEvent(sess, ev)
+				s.log.Printf("session %s marked ended (no hook activity for %s)", sess.id, idleFor.Round(time.Second))
+				s.announceSessions()
+			}
+			continue
+		}
+		if !sess.getAdapter().Alive() {
 			ev, _ := protocol.NewEvent(sess.id, protocol.EventSessionEnd, protocol.SessionEndPayload{Reason: "process_exit"})
 			s.pumpEvent(sess, ev)
 			s.log.Printf("session %s marked ended (process gone)", sess.id)

--- a/apps/daemon/internal/daemon/server_test.go
+++ b/apps/daemon/internal/daemon/server_test.go
@@ -482,18 +482,162 @@ func TestLeaseExpiryClosesSession(t *testing.T) {
 	}
 	srv.sessions["lease-1"] = sess
 
+	// First sweep after expiry only marks the lease as missed (#170 grace
+	// period: a post-sleep sweep can race the TUI heartbeat).
 	srv.sweepOnce()
 
 	srv.mu.Lock()
 	_, stillThere := srv.sessions["lease-1"]
 	srv.mu.Unlock()
+	if !stillThere {
+		t.Fatal("first sweep after lease expiry should grant a grace period, not close")
+	}
+	select {
+	case <-fake.stopCalled:
+		t.Fatal("adapter.Stop must not be called on the first expired sweep")
+	default:
+	}
+
+	// A second consecutive sweep without heartbeat closes the session.
+	srv.sweepOnce()
+
+	srv.mu.Lock()
+	_, stillThere = srv.sessions["lease-1"]
+	srv.mu.Unlock()
 	if stillThere {
-		t.Fatal("expired-lease session should have been removed")
+		t.Fatal("expired-lease session should have been removed after two sweeps")
 	}
 	select {
 	case <-fake.stopCalled:
 	default:
 		t.Fatal("expected adapter.Stop to be called")
+	}
+}
+
+// TestLeaseGraceResetByHeartbeat covers the laptop-lid scenario (#170): the
+// machine sleeps, the sweep and the heartbeat both come due, and the sweep
+// runs first. The grace strike must be cleared by the heartbeat so the next
+// sweep starts over instead of closing a live TUI session.
+func TestLeaseGraceResetByHeartbeat(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	keys, err := config.LoadOrCreateKeys(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := log.New(io.Discard, "", 0)
+	srv := New(cfg, keys, dir, logger, nil)
+
+	fake := &fakeSession{
+		id:         "lease-2",
+		events:     make(chan protocol.Event, 4),
+		approvals:  make(chan string, 1),
+		prompts:    make(chan string, 1),
+		stopCalled: make(chan struct{}, 1),
+	}
+	srv.sessions["lease-2"] = &session{
+		id:      "lease-2",
+		meta:    fake.Meta(),
+		adapter: fake,
+		events:  fake.events,
+		status:  protocol.StatusRunning,
+		lease:   true,
+		lastHB:  time.Now().Add(-30 * time.Second),
+		clients: map[*client]struct{}{},
+	}
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	alive := func() bool {
+		srv.mu.Lock()
+		defer srv.mu.Unlock()
+		_, ok := srv.sessions["lease-2"]
+		return ok
+	}
+	stale := func() {
+		srv.mu.Lock()
+		srv.sessions["lease-2"].lastHB = time.Now().Add(-30 * time.Second)
+		srv.mu.Unlock()
+	}
+
+	// Sweep wins the post-sleep race: strike one, session survives.
+	srv.sweepOnce()
+	if !alive() {
+		t.Fatal("first expired sweep must not close the session")
+	}
+	// The TUI heartbeat arrives right after: the strike must be cleared.
+	resp := authRequest(t, http.MethodPost, ts.URL+"/api/sessions/lease-2/heartbeat", cfg.LocalToken, nil)
+	resp.Body.Close()
+	srv.mu.Lock()
+	missed := srv.sessions["lease-2"].leaseMissed
+	srv.mu.Unlock()
+	if missed {
+		t.Fatal("heartbeat should clear the grace strike")
+	}
+	// The machine sleeps again; the next expiry must again need two sweeps.
+	stale()
+	srv.sweepOnce()
+	if !alive() {
+		t.Fatal("after a heartbeat the grace period must start over")
+	}
+	srv.sweepOnce()
+	if alive() {
+		t.Fatal("two consecutive expired sweeps without heartbeat should close the session")
+	}
+}
+
+// TestShutdownStopsManagedSessions covers #170: daemon shutdown must reclaim
+// agent processes it spawned (they run on context.Background()), while attach
+// sessions — claude running in the user's own tmux — are left alone.
+func TestShutdownStopsManagedSessions(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	keys, err := config.LoadOrCreateKeys(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := log.New(io.Discard, "", 0)
+	srv := New(cfg, keys, dir, logger, nil)
+
+	fake := &fakeSession{
+		id:         "managed-1",
+		events:     make(chan protocol.Event, 4),
+		approvals:  make(chan string, 1),
+		prompts:    make(chan string, 1),
+		stopCalled: make(chan struct{}, 1),
+	}
+	srv.sessions["managed-1"] = &session{
+		id:      "managed-1",
+		meta:    fake.Meta(),
+		adapter: fake,
+		events:  fake.events,
+		status:  protocol.StatusRunning,
+		managed: true,
+		clients: map[*client]struct{}{},
+	}
+	// An attach session and a restored session must not be touched (their
+	// Stop is a no-op anyway; this pins the managed-only selection).
+	srv.sessions["attach-1"] = &session{
+		id:      "attach-1",
+		adapter: &attachAdapter{server: srv},
+		status:  protocol.StatusRunning,
+		clients: map[*client]struct{}{},
+	}
+	srv.sessions["restored-1"] = &session{
+		id:      "restored-1",
+		adapter: &restoredAdapter{id: "restored-1"},
+		status:  "restored",
+		clients: map[*client]struct{}{},
+	}
+
+	if err := srv.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-fake.stopCalled:
+	default:
+		t.Fatal("shutdown should stop daemon-spawned sessions")
 	}
 }
 

--- a/apps/daemon/internal/daemon/ws.go
+++ b/apps/daemon/internal/daemon/ws.go
@@ -295,7 +295,7 @@ func (s *Server) dispatch(c *client, ev protocol.Event) {
 			return
 		}
 		s.mu.Unlock()
-		if err := sess.adapter.SendApproval(p.RequestID, decision); err != nil {
+		if err := sess.getAdapter().SendApproval(p.RequestID, decision); err != nil {
 			// The request is unknown to the daemon (hook timed out or already
 			// handled): ack the sending viewer so it can correct its UI instead
 			// of leaving a "已批准" card that never took effect.
@@ -316,7 +316,7 @@ func (s *Server) dispatch(c *client, ev protocol.Event) {
 		if err := ev.DecodePayload(&p); err != nil {
 			return
 		}
-		if err := sess.adapter.SendPrompt(p.Text); err != nil {
+		if err := sess.getAdapter().SendPrompt(p.Text); err != nil {
 			s.notifySession(sess, "error", "指令发送失败："+err.Error())
 		}
 	case protocol.EventControl:
@@ -325,7 +325,7 @@ func (s *Server) dispatch(c *client, ev protocol.Event) {
 			return
 		}
 		if p.Action == "stop" {
-			if err := sess.adapter.Stop(); err != nil {
+			if err := sess.getAdapter().Stop(); err != nil {
 				s.notifySession(sess, "error", "停止失败："+err.Error())
 			}
 		}


### PR DESCRIPTION
## 改动点（对应 issue 四条建议）

1. **restored → attach 原地替换**（`attach.go` `attachSession`）：hook 命中已存在会话时，若 adapter 是 `restoredAdapter`，原地换成 `attachAdapter` 并把状态拉回 `running`。同理，之前被误标结束的 attach 会话在任何新 hook 到达时复活（`ended=false`）。daemon 重启后用户终端里还活着的 claude 一旦触发任意 hook，手机端立刻恢复可发消息/可审批。
2. **attach 会话活性探测**（`server.go` `sweepOnce`）：`attachAdapter.Alive()` 恒 true，kill -9 后 SessionEnd hook 不触发，会话永远 "running"。现在 sweep 对 attach 会话检查 `lastSeen`（每个 hook 事件经 `pumpEvent` 刷新）：超过 `attachIdleTimeout = 30min` 无任何 hook 活动就 pump 一个 `session_end(no_activity)` 标记结束。取 30min 的理由：正常思考/离开不会有连续 30 分钟零 hook；误判（claude 只是闲置）无害——下一个 hook 经修复 1 的复活路径自动恢复。
3. **Shutdown 回收 spawn 子进程**（`server.go` `Shutdown`）：session 新增 `managed` 标记（仅 `createSession` spawn 的为 true）。Shutdown 时对所有 `managed && !ended` 会话调 `adapter.Stop()`。attach 会话（用户自己 tmux 里的进程）和 restored 会话（含已重接 app-server 的 codex）绝不杀。
4. **sweep 宽限**（`server.go`）：租约过期不再一判即杀，改为连续两个 sweep 周期（30s×2）都无心跳才关闭；任何心跳重置 strike（`leaseMissed`）。合盖唤醒后 sweep 先于 heartbeat 执行也只记一次 strike，心跳随即到达即清除。

## 并发处理

- adapter 可被原地替换，新增 `session.getAdapter()`（持 `sess.mu`）并替换全部 7 处读取点（`ws.go` dispatch、`stopSession`、`handleSessionConnect`、`sweepOnce`、`persistSession`），`-race` 干净。
- `attachSession` 创建路径保留"检查+插入"单次持 `s.mu` 的语义（第二个并发 hook 在插入前 double-check，输掉竞态就返回已存在的会话），不引入新锁序：沿用现有 `s.mu` → `sess.mu` 方向。

## 取舍

- **没有新增协议状态**（idle/dead）：直接复用 `session_end` + reason `no_activity`，与现有 `process_exit` 一致，`packages/protocol` 和 `docs/design.md` 无需变更。结束的会话本来就会被 `/api/sessions` 和 relay announce 过滤。
- **误判可逆**优先于精确探测：不去探 tmux pane（注入时才需要 tmux，探测会引入对 tmux 的硬依赖），用"hook 静默超时 + hook 复活"的自愈组合。
- main.go 里 spawn 的 `context.Background()` 未改为 daemon 生命周期 ctx：Shutdown 里统一 `Stop()` 已覆盖孤儿回收，且 Stop 对 claude/kimi/codex 三个 adapter 语义一致，比穿ctx 改动更小。
- restored 会话（一直无 hook 的）仍不清理——它们是只读历史，sweep 跳过 `status != running` 的会话，保持现状。

## 测试

- `TestAttachRevivesRestoredSession`：restored 会话 SendPrompt 报 "not attached" → hook 到达 → adapter 换成 attachAdapter、状态 running、SendPrompt 走 tmux 注入路径。
- `TestSweepIdleAttachSession`：模拟 kill -9（无 SessionEnd、无 hook）→ sweep 标记 ended + `session_end(no_activity)` 入历史 → 后续 hook 复活。
- `TestLeaseExpiryClosesSession`（改造）+ `TestLeaseGraceResetByHeartbeat`：第一次过期 sweep 只记 strike、心跳重置 strike、连续两次才关闭。
- `TestShutdownStopsManagedSessions`：Shutdown 只 Stop managed 会话，attach/restored 不动。
- `cd apps/daemon && go build ./... && go test -race ./...` 全绿。

## #77 评估

本 PR 让「被杀掉/闲置超时的 attach 会话」最终从列表消失（`session_end` → ended → 列表/announce 过滤），部分覆盖 #77 的 "only live sessions"；但 #77 的展示名格式（`[cli] · [目录] · [短 id]`）和 announce 结构过滤属于 client/relay 侧改动，不塞进本 PR，已在 #77 下评论说明剩余范围。

Closes #170