### PR TITLE
fix(daemon,scripts): 版本注入修复 + install.sh 跑马灯与 logo (#196)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
         working-directory: apps/daemon
         run: |
           mkdir -p dist
+          VERSION="${GITHUB_REF_NAME#v}"
           for target in "linux amd64" "linux arm64" "darwin amd64" "darwin arm64" "windows amd64" "windows arm64"; do
             set -- $target
             os=$1
@@ -51,9 +52,15 @@ jobs:
             ext=""
             if [ "$os" = "windows" ]; then ext=".exe"; fi
             CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" \
-              go build -trimpath -ldflags "-s -w" \
+              go build -trimpath \
+              -ldflags "-s -w -X github.com/riffpad/riffpad/apps/daemon/internal/version.Version=$VERSION" \
               -o "dist/riffpad-$os-$arch$ext" ./cmd/riffpad
           done
+          # Fail the release if the baked-in version does not match the tag.
+          ./dist/riffpad-linux-amd64 version | grep -q "$VERSION" || {
+            echo "error: binary reports an unexpected version (expected $VERSION)"
+            exit 1
+          }
           (cd dist && sha256sum riffpad-* > sha256sums.txt)
 
       - name: Upload binaries

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ __pycache__/
 apps/client-beta/test-results/
 apps/client-beta/playwright-report/
 !infra/.env.example
+
+test-notes/

--- a/apps/daemon/cmd/riffpad/main.go
+++ b/apps/daemon/cmd/riffpad/main.go
@@ -33,9 +33,8 @@ import (
 	"github.com/riffpad/riffpad/apps/daemon/internal/daemon"
 	"github.com/riffpad/riffpad/apps/daemon/internal/i18n"
 	"github.com/riffpad/riffpad/apps/daemon/internal/logging"
+	"github.com/riffpad/riffpad/apps/daemon/internal/version"
 )
-
-const version = "0.2.0"
 
 const updateRepo = "riffpad/riffpad"
 
@@ -150,7 +149,7 @@ func main() {
 	case "update":
 		err = updateCmd(os.Args[2:], dataDir)
 	case "version":
-		fmt.Println("riffpad", version)
+		fmt.Println("riffpad", version.Version)
 	case "help", "-h", "--help":
 		usage()
 	default:
@@ -1317,13 +1316,13 @@ func updateCmd(args []string, dataDir string) error {
 	noRestart := fs.Bool("no-restart", false, "do not restart the daemon after updating")
 	_ = fs.Parse(args)
 
-	fmt.Println(t.T("update_current", version))
+	fmt.Println(t.T("update_current", version.Version))
 	latest, err := latestReleaseTag()
 	if err != nil {
 		return err
 	}
 	fmt.Println(t.T("update_latest", latest))
-	if !*force && compareVersions(version, latest) >= 0 {
+	if !*force && compareVersions(version.Version, latest) >= 0 {
 		fmt.Println(t.T("update_up_to_date"))
 		return nil
 	}

--- a/apps/daemon/internal/codex/codex.go
+++ b/apps/daemon/internal/codex/codex.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
+	"github.com/riffpad/riffpad/apps/daemon/internal/version"
 	"github.com/riffpad/riffpad/packages/protocol"
 )
 
@@ -176,7 +177,7 @@ func (c *Codex) spawn(ctx context.Context) error {
 		return err
 	}
 	_ = c.request("initialize", map[string]any{
-		"clientInfo": map[string]any{"name": "riffpad", "version": "0.1.0"},
+		"clientInfo": map[string]any{"name": "riffpad", "version": version.Version},
 	})
 	return nil
 }

--- a/apps/daemon/internal/kimi/kimi.go
+++ b/apps/daemon/internal/kimi/kimi.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
+	"github.com/riffpad/riffpad/apps/daemon/internal/version"
 	"github.com/riffpad/riffpad/packages/protocol"
 )
 
@@ -161,7 +162,7 @@ func (k *Kimi) spawn(ctx context.Context) error {
 			"fs":       map[string]any{"readTextFile": false, "writeTextFile": false},
 			"terminal": false,
 		},
-		"clientInfo": map[string]any{"name": "riffpad", "version": "0.1.0"},
+		"clientInfo": map[string]any{"name": "riffpad", "version": version.Version},
 	})
 	return nil
 }

--- a/apps/daemon/internal/version/version.go
+++ b/apps/daemon/internal/version/version.go
@@ -1,0 +1,11 @@
+// Package version is the single source of truth for the riffpad CLI
+// version string. Release builds inject the tagged version at link time;
+// local/dev builds report "dev".
+package version
+
+// Version is set by the release workflow via:
+//
+//	go build -ldflags "-X github.com/riffpad/riffpad/apps/daemon/internal/version.Version=0.2.1"
+//
+// Keep it a variable (not a const) so -X can override it.
+var Version = "dev"

--- a/apps/landing/public/install.sh
+++ b/apps/landing/public/install.sh
@@ -14,6 +14,7 @@
 #   RIFFPAD_PREFIX    install directory (default: ~/.local/bin)
 #   RIFFPAD_DOWNLOAD_URL  direct binary URL (for testing/mirrors)
 #   RIFFPAD_SUMS_URL      checksums URL when RIFFPAD_DOWNLOAD_URL is set
+#   RIFFPAD_NO_AUTOSTART  set to 1 to skip registering daemon autostart
 set -eu
 
 REPO="riffpad/riffpad"
@@ -179,3 +180,29 @@ case ":${PATH:-}:" in
   *":$PREFIX:"*) ;;
   *) echo "riffpad: note: $PREFIX is not on PATH — add it or run: export PATH=\"$PREFIX:\$PATH\"" ;;
 esac
+
+# Best-effort autostart: register a systemd user service so the daemon
+# starts at login and restarts after crashes. This never fails the install —
+# if systemd is unavailable (WSL without systemd, containers, macOS), warn
+# and let the user run `riffpad setup` later. Opt out with
+# RIFFPAD_NO_AUTOSTART=1.
+if [ "$(uname -s)" = "Linux" ] &&
+  [ -z "${RIFFPAD_NO_AUTOSTART:-}" ] &&
+  command -v systemctl >/dev/null 2>&1; then
+  if systemctl --user is-enabled riffpad.service >/dev/null 2>&1; then
+    echo "riffpad: daemon autostart already enabled"
+  else
+    # A manually started daemon would conflict with the systemd unit, so
+    # stop it first and let the service take over.
+    if "$PREFIX/riffpad" status >/dev/null 2>&1; then
+      "$PREFIX/riffpad" daemon stop >/dev/null 2>&1 || true
+    fi
+    echo "riffpad: enabling daemon autostart (systemd user service)"
+    if "$PREFIX/riffpad" setup >/dev/null 2>&1; then
+      echo "riffpad: daemon autostart enabled"
+    else
+      echo "riffpad: warning: could not enable daemon autostart (systemd unavailable?)" >&2
+      echo "riffpad: run 'riffpad setup' manually when systemd is available" >&2
+    fi
+  fi
+fi

--- a/apps/landing/public/install.sh
+++ b/apps/landing/public/install.sh
@@ -51,26 +51,128 @@ else
 fi
 
 tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT INT TERM
+
+# --- 3x3 dot-matrix marquee spinner --------------------------------
+# One dot lights at a time, sweeping left-to-right / top-to-bottom across
+# the grid (9 frames, ~0.12s each), mirroring the DotMatrix indicator in
+# the web client.
+FRAME0=$(printf '●··\n···\n···')
+FRAME1=$(printf '·●·\n···\n···')
+FRAME2=$(printf '··●\n···\n···')
+FRAME3=$(printf '···\n●··\n···')
+FRAME4=$(printf '···\n·●·\n···')
+FRAME5=$(printf '···\n··●\n···')
+FRAME6=$(printf '···\n···\n●··')
+FRAME7=$(printf '···\n···\n·●·')
+FRAME8=$(printf '···\n···\n··●')
+
+_spinner_pid=
+
+tick() {
+  if command -v perl >/dev/null 2>&1; then
+    perl -e 'select undef,undef,undef,0.12'
+  elif sleep 0.12 2>/dev/null; then
+    :
+  else
+    sleep 1
+  fi
+}
+
+spinner_start() {
+  i=0
+  first=1
+  while :; do
+    if [ "$first" -eq 1 ]; then
+      first=0
+    else
+      printf '\033[3A' >&2
+    fi
+    eval "frame=\$FRAME$i"
+    printf '\r\033[K%s\n\033[K%s\n\033[K%s\n' "$frame" >&2
+    i=$(((i + 1) % 9))
+    tick
+  done
+}
+
+spinner_stop() {
+  if [ -n "$_spinner_pid" ]; then
+    kill "$_spinner_pid" 2>/dev/null || true
+    wait "$_spinner_pid" 2>/dev/null || true
+    _spinner_pid=
+    if [ -t 2 ]; then
+      printf '\033[3A\033[J' >&2
+    fi
+  fi
+}
+
+cleanup() {
+  spinner_stop
+  rm -rf "$tmp"
+}
+trap cleanup EXIT INT TERM
+
+# Runs a command with the spinner animating on stderr; returns the command's
+# status and always stops the spinner first.
+with_spinner() {
+  if [ -t 2 ]; then
+    spinner_start &
+    _spinner_pid=$!
+  fi
+  "$@" || {
+    rc=$?
+    spinner_stop
+    return $rc
+  }
+  spinner_stop
+  return 0
+}
 
 echo "riffpad: downloading $URL"
-curl -fsSL "$URL" -o "$tmp/$ASSET"
+if ! with_spinner curl -fsSL "$URL" -o "$tmp/$ASSET"; then
+  echo "riffpad: download failed" >&2
+  exit 1
+fi
 
 if [ -n "$SUMS_URL" ]; then
   echo "riffpad: verifying checksum"
-  curl -fsSL "$SUMS_URL" -o "$tmp/sha256sums.txt"
+  if ! with_spinner curl -fsSL "$SUMS_URL" -o "$tmp/sha256sums.txt"; then
+    echo "riffpad: failed to fetch checksums" >&2
+    exit 1
+  fi
   if command -v sha256sum >/dev/null 2>&1; then
-    (cd "$tmp" && grep " $ASSET$" sha256sums.txt | sha256sum -c - >/dev/null)
+    if ! (cd "$tmp" && grep " $ASSET$" sha256sums.txt | sha256sum -c - >/dev/null); then
+      echo "riffpad: checksum mismatch" >&2
+      exit 1
+    fi
   elif command -v shasum >/dev/null 2>&1; then
-    (cd "$tmp" && grep " $ASSET$" sha256sums.txt | shasum -a 256 -c - >/dev/null)
+    if ! (cd "$tmp" && grep " $ASSET$" sha256sums.txt | shasum -a 256 -c - >/dev/null); then
+      echo "riffpad: checksum mismatch" >&2
+      exit 1
+    fi
   else
     echo "riffpad: warning: no sha256sum/shasum found, skipping verification" >&2
   fi
 fi
 
-chmod 0755 "$tmp/$ASSET"
-mkdir -p "$PREFIX"
-install -m 0755 "$tmp/$ASSET" "$PREFIX/riffpad"
+echo "riffpad: installing"
+if ! with_spinner sh -c 'chmod 0755 "$1" && mkdir -p "$2" && install -m 0755 "$1" "$2/riffpad"' sh "$tmp/$ASSET" "$PREFIX"; then
+  echo "riffpad: install failed" >&2
+  exit 1
+fi
+
+if [ -t 1 ]; then
+  printf '\033[32m'
+fi
+cat <<'LOGO'
+ ██ ██ ██
+       ██
+ ██ ██ ██
+       ██
+ ██ ██ ██
+LOGO
+if [ -t 1 ]; then
+  printf '\033[0m'
+fi
 
 echo "riffpad: installed $PREFIX/riffpad ($OS/$ARCH, $VERSION)"
 case ":${PATH:-}:" in

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,6 +14,7 @@
 #   RIFFPAD_PREFIX    install directory (default: ~/.local/bin)
 #   RIFFPAD_DOWNLOAD_URL  direct binary URL (for testing/mirrors)
 #   RIFFPAD_SUMS_URL      checksums URL when RIFFPAD_DOWNLOAD_URL is set
+#   RIFFPAD_NO_AUTOSTART  set to 1 to skip registering daemon autostart
 set -eu
 
 REPO="riffpad/riffpad"
@@ -179,3 +180,29 @@ case ":${PATH:-}:" in
   *":$PREFIX:"*) ;;
   *) echo "riffpad: note: $PREFIX is not on PATH — add it or run: export PATH=\"$PREFIX:\$PATH\"" ;;
 esac
+
+# Best-effort autostart: register a systemd user service so the daemon
+# starts at login and restarts after crashes. This never fails the install —
+# if systemd is unavailable (WSL without systemd, containers, macOS), warn
+# and let the user run `riffpad setup` later. Opt out with
+# RIFFPAD_NO_AUTOSTART=1.
+if [ "$(uname -s)" = "Linux" ] &&
+  [ -z "${RIFFPAD_NO_AUTOSTART:-}" ] &&
+  command -v systemctl >/dev/null 2>&1; then
+  if systemctl --user is-enabled riffpad.service >/dev/null 2>&1; then
+    echo "riffpad: daemon autostart already enabled"
+  else
+    # A manually started daemon would conflict with the systemd unit, so
+    # stop it first and let the service take over.
+    if "$PREFIX/riffpad" status >/dev/null 2>&1; then
+      "$PREFIX/riffpad" daemon stop >/dev/null 2>&1 || true
+    fi
+    echo "riffpad: enabling daemon autostart (systemd user service)"
+    if "$PREFIX/riffpad" setup >/dev/null 2>&1; then
+      echo "riffpad: daemon autostart enabled"
+    else
+      echo "riffpad: warning: could not enable daemon autostart (systemd unavailable?)" >&2
+      echo "riffpad: run 'riffpad setup' manually when systemd is available" >&2
+    fi
+  fi
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,26 +51,128 @@ else
 fi
 
 tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT INT TERM
+
+# --- 3x3 dot-matrix marquee spinner --------------------------------
+# One dot lights at a time, sweeping left-to-right / top-to-bottom across
+# the grid (9 frames, ~0.12s each), mirroring the DotMatrix indicator in
+# the web client.
+FRAME0=$(printf '●··\n···\n···')
+FRAME1=$(printf '·●·\n···\n···')
+FRAME2=$(printf '··●\n···\n···')
+FRAME3=$(printf '···\n●··\n···')
+FRAME4=$(printf '···\n·●·\n···')
+FRAME5=$(printf '···\n··●\n···')
+FRAME6=$(printf '···\n···\n●··')
+FRAME7=$(printf '···\n···\n·●·')
+FRAME8=$(printf '···\n···\n··●')
+
+_spinner_pid=
+
+tick() {
+  if command -v perl >/dev/null 2>&1; then
+    perl -e 'select undef,undef,undef,0.12'
+  elif sleep 0.12 2>/dev/null; then
+    :
+  else
+    sleep 1
+  fi
+}
+
+spinner_start() {
+  i=0
+  first=1
+  while :; do
+    if [ "$first" -eq 1 ]; then
+      first=0
+    else
+      printf '\033[3A' >&2
+    fi
+    eval "frame=\$FRAME$i"
+    printf '\r\033[K%s\n\033[K%s\n\033[K%s\n' "$frame" >&2
+    i=$(((i + 1) % 9))
+    tick
+  done
+}
+
+spinner_stop() {
+  if [ -n "$_spinner_pid" ]; then
+    kill "$_spinner_pid" 2>/dev/null || true
+    wait "$_spinner_pid" 2>/dev/null || true
+    _spinner_pid=
+    if [ -t 2 ]; then
+      printf '\033[3A\033[J' >&2
+    fi
+  fi
+}
+
+cleanup() {
+  spinner_stop
+  rm -rf "$tmp"
+}
+trap cleanup EXIT INT TERM
+
+# Runs a command with the spinner animating on stderr; returns the command's
+# status and always stops the spinner first.
+with_spinner() {
+  if [ -t 2 ]; then
+    spinner_start &
+    _spinner_pid=$!
+  fi
+  "$@" || {
+    rc=$?
+    spinner_stop
+    return $rc
+  }
+  spinner_stop
+  return 0
+}
 
 echo "riffpad: downloading $URL"
-curl -fsSL "$URL" -o "$tmp/$ASSET"
+if ! with_spinner curl -fsSL "$URL" -o "$tmp/$ASSET"; then
+  echo "riffpad: download failed" >&2
+  exit 1
+fi
 
 if [ -n "$SUMS_URL" ]; then
   echo "riffpad: verifying checksum"
-  curl -fsSL "$SUMS_URL" -o "$tmp/sha256sums.txt"
+  if ! with_spinner curl -fsSL "$SUMS_URL" -o "$tmp/sha256sums.txt"; then
+    echo "riffpad: failed to fetch checksums" >&2
+    exit 1
+  fi
   if command -v sha256sum >/dev/null 2>&1; then
-    (cd "$tmp" && grep " $ASSET$" sha256sums.txt | sha256sum -c - >/dev/null)
+    if ! (cd "$tmp" && grep " $ASSET$" sha256sums.txt | sha256sum -c - >/dev/null); then
+      echo "riffpad: checksum mismatch" >&2
+      exit 1
+    fi
   elif command -v shasum >/dev/null 2>&1; then
-    (cd "$tmp" && grep " $ASSET$" sha256sums.txt | shasum -a 256 -c - >/dev/null)
+    if ! (cd "$tmp" && grep " $ASSET$" sha256sums.txt | shasum -a 256 -c - >/dev/null); then
+      echo "riffpad: checksum mismatch" >&2
+      exit 1
+    fi
   else
     echo "riffpad: warning: no sha256sum/shasum found, skipping verification" >&2
   fi
 fi
 
-chmod 0755 "$tmp/$ASSET"
-mkdir -p "$PREFIX"
-install -m 0755 "$tmp/$ASSET" "$PREFIX/riffpad"
+echo "riffpad: installing"
+if ! with_spinner sh -c 'chmod 0755 "$1" && mkdir -p "$2" && install -m 0755 "$1" "$2/riffpad"' sh "$tmp/$ASSET" "$PREFIX"; then
+  echo "riffpad: install failed" >&2
+  exit 1
+fi
+
+if [ -t 1 ]; then
+  printf '\033[32m'
+fi
+cat <<'LOGO'
+ ██ ██ ██
+       ██
+ ██ ██ ██
+       ██
+ ██ ██ ██
+LOGO
+if [ -t 1 ]; then
+  printf '\033[0m'
+fi
 
 echo "riffpad: installed $PREFIX/riffpad ($OS/$ARCH, $VERSION)"
 case ":${PATH:-}:" in


### PR DESCRIPTION
## 版本号 bug

- `const version = "0.2.0"` 硬编码导致 v0.2.1 发布后 `riffpad version` 仍报 0.2.0、update 永远提示有新版本
- 改为 `internal/version.Version` 变量（默认 dev），release 工作流用 `-ldflags -X` 按 tag 注入，构建后校验二进制报告版本与 tag 一致
- codex/kimi 的 clientInfo.version 同步使用同一版本变量（不再硬编码 0.1.0）

## 安装体验

- install.sh 下载/校验/安装期间显示 3x3 点阵跑马灯（对应 web client 的 DotMatrix，9 帧 0.12s 逐点扫过）
- 安装完成打印 riffpad logo 字符画（终端支持时绿色）
- `scripts/install.sh` 与线上 `apps/landing/public/install.sh` 保持同步

**验证**
1. go test ./... 全绿
2. ldflags 注入后 `version` 打印 0.2.2；无注入打印 dev
3. 本地 HTTP 服务器端到端跑通 install.sh（下载/校验/安装/logo/exit 0）
4. PTY 下确认跑马灯帧与清理转义正常

Closes #196