### PR TITLE
chore(scripts): 移除 install.sh 动画与 logo 字符画 (#202)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,91 +52,17 @@ else
 fi
 
 tmp="$(mktemp -d)"
-
-# --- 3x3 dot-matrix marquee spinner --------------------------------
-# One dot lights at a time, sweeping left-to-right / top-to-bottom across
-# the grid (9 frames, ~0.12s each), mirroring the DotMatrix indicator in
-# the web client.
-FRAME0=$(printf '●··\n···\n···')
-FRAME1=$(printf '·●·\n···\n···')
-FRAME2=$(printf '··●\n···\n···')
-FRAME3=$(printf '···\n●··\n···')
-FRAME4=$(printf '···\n·●·\n···')
-FRAME5=$(printf '···\n··●\n···')
-FRAME6=$(printf '···\n···\n●··')
-FRAME7=$(printf '···\n···\n·●·')
-FRAME8=$(printf '···\n···\n··●')
-
-_spinner_pid=
-
-tick() {
-  if command -v perl >/dev/null 2>&1; then
-    perl -e 'select undef,undef,undef,0.12'
-  elif sleep 0.12 2>/dev/null; then
-    :
-  else
-    sleep 1
-  fi
-}
-
-spinner_start() {
-  i=0
-  first=1
-  while :; do
-    if [ "$first" -eq 1 ]; then
-      first=0
-    else
-      printf '\033[3A' >&2
-    fi
-    eval "frame=\$FRAME$i"
-    printf '\r\033[K%s\n\033[K%s\n\033[K%s\n' "$frame" >&2
-    i=$(((i + 1) % 9))
-    tick
-  done
-}
-
-spinner_stop() {
-  if [ -n "$_spinner_pid" ]; then
-    kill "$_spinner_pid" 2>/dev/null || true
-    wait "$_spinner_pid" 2>/dev/null || true
-    _spinner_pid=
-    if [ -t 2 ]; then
-      printf '\033[3A\033[J' >&2
-    fi
-  fi
-}
-
-cleanup() {
-  spinner_stop
-  rm -rf "$tmp"
-}
-trap cleanup EXIT INT TERM
-
-# Runs a command with the spinner animating on stderr; returns the command's
-# status and always stops the spinner first.
-with_spinner() {
-  if [ -t 2 ]; then
-    spinner_start &
-    _spinner_pid=$!
-  fi
-  "$@" || {
-    rc=$?
-    spinner_stop
-    return $rc
-  }
-  spinner_stop
-  return 0
-}
+trap 'rm -rf "$tmp"' EXIT INT TERM
 
 echo "riffpad: downloading $URL"
-if ! with_spinner curl -fsSL "$URL" -o "$tmp/$ASSET"; then
+if ! curl -fsSL "$URL" -o "$tmp/$ASSET"; then
   echo "riffpad: download failed" >&2
   exit 1
 fi
 
 if [ -n "$SUMS_URL" ]; then
   echo "riffpad: verifying checksum"
-  if ! with_spinner curl -fsSL "$SUMS_URL" -o "$tmp/sha256sums.txt"; then
+  if ! curl -fsSL "$SUMS_URL" -o "$tmp/sha256sums.txt"; then
     echo "riffpad: failed to fetch checksums" >&2
     exit 1
   fi
@@ -156,24 +82,9 @@ if [ -n "$SUMS_URL" ]; then
 fi
 
 echo "riffpad: installing"
-if ! with_spinner sh -c 'chmod 0755 "$1" && mkdir -p "$2" && install -m 0755 "$1" "$2/riffpad"' sh "$tmp/$ASSET" "$PREFIX"; then
-  echo "riffpad: install failed" >&2
-  exit 1
-fi
-
-if [ -t 1 ]; then
-  printf '\033[32m'
-fi
-cat <<'LOGO'
- ██ ██ ██
-       ██
- ██ ██ ██
-       ██
- ██ ██ ██
-LOGO
-if [ -t 1 ]; then
-  printf '\033[0m'
-fi
+chmod 0755 "$tmp/$ASSET"
+mkdir -p "$PREFIX"
+install -m 0755 "$tmp/$ASSET" "$PREFIX/riffpad"
 
 echo "riffpad: installed $PREFIX/riffpad ($OS/$ARCH, $VERSION)"
 case ":${PATH:-}:" in


### PR DESCRIPTION
install.sh 恢复纯文本输出：移除 3x3 点阵跑马灯与 ASCII logo（用户反馈体验不佳）。自动注册 systemd 自启逻辑保留。

**验证**
1. sh -n 语法通过
2. 本地 HTTP 端到端安装：downloading → verifying checksum → installing → installed，exit 0

Closes #202