### PR TITLE
fix(ci): Vercel landing 构建纳入 install 脚本等外部变更 (#204)

### DIFF
--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git -C \"$(git rev-parse --show-toplevel)\" diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- apps/landing apps/docs scripts/install.sh scripts/install.ps1 pnpm-lock.yaml package.json"
+}


### PR DESCRIPTION
## 问题

Vercel monorepo 自动跳过只检测 apps/landing 目录；只改 scripts/install.sh（如 #202/#203）不会触发 landing 构建，线上 install.sh 保持旧版（最近一次生产部署即被 Ignored Build Step 取消）。

## 改动

新增 apps/landing/vercel.json，自定义 ignoreCommand：
- 变更涉及 apps/landing、apps/docs、scripts/install.sh、scripts/install.ps1、pnpm-lock.yaml、package.json 时构建
- 其余变更跳过；无 VERCEL_GIT_PREVIOUS_SHA 时强制构建
- 退出码约定：0=跳过，非 0=构建

**验证**
1. 本地模拟：仅 scripts/install.sh 变更 → exit 1（构建）；无变更 → exit 0（跳过）
2. 合并后 Vercel 生产部署应重新构建并上线新版 install.sh

Closes #204