### PR TITLE
feat(cli): 关闭 attach 入口 + riffpad run 支持位置参数 (#214)

### DIFF
--- a/apps/daemon/cmd/riffpad/main.go
+++ b/apps/daemon/cmd/riffpad/main.go
@@ -707,8 +707,18 @@ func runCmd(args []string, base string) error {
 	name := fs.String("name", "", "session name")
 	prompt := fs.String("prompt", "", "initial prompt")
 	cwd := fs.String("cwd", "", "working directory")
-	cli := fs.String("cli", "claude", "agent CLI (claude|kimi|codex)")
+	cli := fs.String("cli", "", "agent CLI (claude|kimi|codex)")
 	_ = fs.Parse(args)
+	rest := fs.Args()
+	if len(rest) > 1 {
+		return fmt.Errorf("unexpected arguments: %v", rest)
+	}
+	if len(rest) == 1 {
+		*cli = rest[0]
+	}
+	if *cli == "" {
+		*cli = "claude"
+	}
 	if *cwd == "" {
 		// Default to the directory where the user ran the command, not the
 		// daemon's own cwd (the daemon may have been started elsewhere).
@@ -854,6 +864,11 @@ func logsCmd(dataDir string) error {
 // from the web UI / mobile. Existing user hooks are preserved: only riffpad's
 // own entries are replaced, making repeated attaches idempotent.
 func attachCmd(base string) error {
+	// Attach mode is deprecated: it permanently edits the user's global
+	// Claude settings, which breaks normal claude startup when the daemon is
+	// off or unpaired. The implementation is kept below for reference; only
+	// the entry point is disabled (#214).
+	return fmt.Errorf("%s", t.T("attach_deprecated"))
 	if !reachable(base) {
 		return fmt.Errorf("%s", t.T("daemon_start_hint", base))
 	}

--- a/apps/daemon/cmd/riffpad/main_test.go
+++ b/apps/daemon/cmd/riffpad/main_test.go
@@ -243,6 +243,16 @@ func userHookEntry(command string) map[string]any {
 	}
 }
 
+func riffpadHookEntry(path string) map[string]any {
+	return map[string]any{
+		"matcher": "",
+		"hooks": []any{map[string]any{
+			"type": "http",
+			"url":  "http://127.0.0.1:8787/hooks/claude/" + path,
+		}},
+	}
+}
+
 func writeClaudeSettings(t *testing.T, home string, settings map[string]any) {
 	t.Helper()
 	dir := filepath.Join(home, ".claude")
@@ -308,59 +318,48 @@ func TestAttachPreservesUserHooks(t *testing.T) {
 		},
 	})
 
-	if err := attachCmd(base); err != nil {
-		t.Fatal(err)
+	if err := attachCmd(base); err == nil || !strings.Contains(err.Error(), "deprecated") {
+		t.Fatalf("expected deprecated error, got %v", err)
 	}
 	settings := readClaudeSettings(t, home)
 	if settings["model"] != "opus" {
 		t.Fatalf("unrelated setting lost: %+v", settings)
 	}
 	riffpad, user := countHooks(t, settings)
-	if user != 2 {
-		t.Fatalf("expected 2 user hook entries kept, got %d", user)
-	}
-	if riffpad != 8 {
-		t.Fatalf("expected 8 riffpad hook entries injected, got %d", riffpad)
-	}
-}
-
-func TestAttachIsIdempotent(t *testing.T) {
-	home, base := setupAttachEnv(t)
-	writeClaudeSettings(t, home, map[string]any{
-		"hooks": map[string]any{"PreToolUse": []any{userHookEntry("my-formatter")}},
-	})
-
-	for i := 0; i < 2; i++ {
-		if err := attachCmd(base); err != nil {
-			t.Fatal(err)
-		}
-	}
-	settings := readClaudeSettings(t, home)
-	riffpad, user := countHooks(t, settings)
-	if riffpad != 8 || user != 1 {
-		t.Fatalf("re-attach duplicated entries: riffpad=%d user=%d", riffpad, user)
+	if riffpad != 0 || user != 2 {
+		t.Fatalf("disabled attach must not touch settings: riffpad=%d user=%d", riffpad, user)
 	}
 }
 
 func TestDetachRemovesOnlyRiffpadHooks(t *testing.T) {
-	home, base := setupAttachEnv(t)
-	writeClaudeSettings(t, home, map[string]any{
-		"hooks": map[string]any{"PreToolUse": []any{userHookEntry("my-formatter")}},
-	})
-	if err := attachCmd(base); err != nil {
-		t.Fatal(err)
+	home, _ := setupAttachEnv(t)
+	legacyHooks := map[string]any{
+		"MessageDisplay":    []any{riffpadHookEntry("message-display")},
+		"Notification":      []any{riffpadHookEntry("notification")},
+		"PermissionRequest": []any{riffpadHookEntry("permission")},
+		"PostToolUse":       []any{riffpadHookEntry("post-tool-use")},
+		"PreToolUse":        []any{riffpadHookEntry("pre-tool-use")},
+		"SessionEnd":        []any{riffpadHookEntry("session-end")},
+		"SessionStart":      []any{riffpadHookEntry("session-start")},
+		"UserPromptSubmit":  []any{riffpadHookEntry("user-prompt-submit")},
 	}
-
-	// Simulate the user adding another hook while attached.
-	settings := readClaudeSettings(t, home)
-	hooks := settings["hooks"].(map[string]any)
-	hooks["PostToolUse"] = append(hooks["PostToolUse"].([]any), userHookEntry("my-linter"))
-	writeClaudeSettings(t, home, settings)
+	writeClaudeSettings(t, home, map[string]any{
+		"model": "opus",
+		"hooks": map[string]any{
+			"PreToolUse":   []any{userHookEntry("my-formatter"), riffpadHookEntry("pre-tool-use")},
+			"Notification": []any{userHookEntry("my-notifier")},
+			"PostToolUse":  legacyHooks["PostToolUse"],
+			"SessionStart": legacyHooks["SessionStart"],
+		},
+	})
 
 	if err := detachCmd(); err != nil {
 		t.Fatal(err)
 	}
-	settings = readClaudeSettings(t, home)
+	settings := readClaudeSettings(t, home)
+	if settings["model"] != "opus" {
+		t.Fatalf("unrelated setting lost: %+v", settings)
+	}
 	riffpad, user := countHooks(t, settings)
 	if riffpad != 0 {
 		t.Fatalf("expected no riffpad entries after detach, got %d", riffpad)
@@ -423,6 +422,40 @@ func TestRunCmdSuccess(t *testing.T) {
 	}
 	if gotBinary != want {
 		t.Fatalf("expected resolved binary %q in request, got %q", want, gotBinary)
+	}
+}
+
+func TestRunCmdAcceptsPositionalCLI(t *testing.T) {
+	var gotCLI string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			CLI string `json:"cli"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		gotCLI = req.CLI
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": "s1", "url": "http://x/s1", "cli": req.CLI})
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := runCmd([]string{"kimi"}, srv.URL); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if gotCLI != "kimi" {
+		t.Fatalf("expected positional cli kimi, got %q", gotCLI)
+	}
+}
+
+func TestRunCmdRejectsMultiplePositionals(t *testing.T) {
+	err := runCmd([]string{"codex", "claude"}, "http://127.0.0.1:1")
+	if err == nil || !strings.Contains(err.Error(), "unexpected arguments") {
+		t.Fatalf("expected unexpected-arguments error, got %v", err)
+	}
+}
+
+func TestAttachCmdDeprecated(t *testing.T) {
+	err := attachCmd("http://127.0.0.1:1")
+	if err == nil || !strings.Contains(err.Error(), "deprecated") {
+		t.Fatalf("expected deprecated error, got %v", err)
 	}
 }
 

--- a/apps/daemon/internal/i18n/messages.go
+++ b/apps/daemon/internal/i18n/messages.go
@@ -12,9 +12,7 @@ Usage:
                                 --local allows a local-only code without login)
   riffpad sessions              list sessions
   riffpad auth                  show the logged-in relay account
-  riffpad run [--name N] [--prompt P] [--cwd D] [--cli claude|kimi|codex]
-  riffpad attach                inject Claude Code hooks so the daemon captures your own CLI session
-  riffpad detach                remove injected hooks
+  riffpad run [codex|claude|kimi] [--name N] [--prompt P] [--cwd D]
   riffpad login [--url wss://…]  log in to Riffpad cloud (GitHub OAuth by default;
                                 --username … for password login)
   riffpad logout                clear the saved login token
@@ -94,7 +92,8 @@ Usage:
 		"unsupported_cli":             "unsupported cli %q",
 		"usage_daemon":                "usage: riffpad daemon start|stop|restart",
 		"usage_login":                 "usage: riffpad login [--url wss://…] | riffpad logout",
-		"usage_run":                   "usage: riffpad run [--name N] [--prompt P] [--cwd D] [--cli claude|kimi|codex]",
+		"usage_run":                   "usage: riffpad run [codex|claude|kimi] [--name N] [--prompt P] [--cwd D]",
+		"attach_deprecated":           "Attach mode is deprecated and disabled. Use `riffpad run --cli claude` instead.",
 	},
 	"zh": {
 		"usage": `riffpad — AI agent 远程遥控
@@ -107,10 +106,8 @@ Usage:
                                 --local 允许未登录时生成仅本机可用的码）
   riffpad sessions              列出会话
   riffpad auth                  查看当前登录的 relay 账号
-  riffpad run [--name N] [--prompt P] [--cwd D] [--cli claude|kimi|codex]
+  riffpad run [codex|claude|kimi] [--name N] [--prompt P] [--cwd D]
                                 创建并启动会话
-  riffpad attach                注入 Claude Code hooks，让 daemon 捕获你自己启动的会话
-  riffpad detach                移除注入的 hooks
   riffpad login [--url wss://…]  登录 Riffpad 云服务（默认 GitHub 授权；
                                 --username … 使用密码登录）
   riffpad logout                清除登录 token
@@ -190,6 +187,7 @@ Usage:
 		"unsupported_cli":             "不支持的 CLI %q",
 		"usage_daemon":                "用法：riffpad daemon start|stop|restart",
 		"usage_login":                 "用法：riffpad login [--url wss://…] | riffpad logout",
-		"usage_run":                   "用法：riffpad run [--name N] [--prompt P] [--cwd D] [--cli claude|kimi|codex]",
+		"usage_run":                   "用法：riffpad run [codex|claude|kimi] [--name N] [--prompt P] [--cwd D]",
+		"attach_deprecated":           "附着模式已弃用并关闭。请改用 `riffpad run --cli claude`。",
 	},
 }

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -201,6 +201,7 @@
 | M3.20 | 本地模式配对体验与 LAN 自托管：`riffpad pair` 默认要求登录，`--local` 才生成仅本机可用的配对码；后续支持同一局域网内自托管（relay 退化/直连），手机可直接配对本机 daemon | `[~]` | pair 登录引导已实现（#206）；LAN 直连待 M3.4 排期 | #206 |
 | M3.21 | macOS daemon 管理：`riffpad setup` 支持 launchd LaunchAgent（登录自启 + 崩溃重启）；`riffpad daemon restart` 与 `riffpad update` 自动重启在 macOS 优先走 `launchctl kickstart -k`，保持 launchd 为唯一进程账本 | `[ ]` | setup 安装/移除 LaunchAgent；restart/update 检测 launchd 托管并走 launchctl；真机验证 | — |
 | M3.22 | Windows daemon 管理：`riffpad daemon restart` 与 `riffpad update` 自动重启检测 `RiffpadDaemon` 计划任务，停止旧进程后 `schtasks /Run` 由任务管理器拉起，保持任务账本一致 | `[x]` | daemonRestart 任务分支 + 单测（运行中停旧启新 / 未运行直接拉起）已实现 | #208 |
+| M3.23 | 弃用 attach 模式：入口关闭（代码保留，`riffpad detach` 仍可用于清理旧 hooks），统一 `riffpad run` 托管模式；`riffpad run` 支持位置参数（`riffpad run codex`） | `[x]` | attachCmd 返回弃用提示；run 位置参数 + 单测已实现 | #214 |
 
 ---
 


### PR DESCRIPTION
## 改动

- `riffpad attach` 入口关闭：直接返回弃用提示（`attach_deprecated`），实现代码保留不删；`riffpad detach` 保留用于清理旧 hooks；daemon 侧 hook 端点不变
- `riffpad run` 支持位置参数：`riffpad run codex` / `riffpad run claude` / `riffpad run kimi`，`--cli` 仍可用；多余位置参数报错
- usage 文案、dev plan（M3.23）同步
- 旧 attach 相关测试改为弃用语义：attach 不触碰 settings；detach 清理测试改为手工构造旧 hooks 文件

**验证**
1. go test ./... 全绿（新增：位置参数、多余参数报错、attach 弃用）
2. gofmt 干净

Closes #214