### PR TITLE
feat: waitlist announcement 群发邮件 + 退订管理 (#218)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
             apps/daemon/go.sum
             apps/relay/go.sum
             packages/protocol/go.sum
+            scripts/email/go.sum
 
       - name: Test daemon
         working-directory: apps/daemon
@@ -70,6 +71,10 @@ jobs:
 
       - name: Test protocol
         working-directory: packages/protocol
+        run: go test ./...
+
+      - name: Test email toolchain
+        working-directory: scripts/email
         run: go test ./...
 
       - name: Cross-compile guard (windows/darwin)

--- a/apps/landing/app/unsubscribe/UnsubscribeClient.tsx
+++ b/apps/landing/app/unsubscribe/UnsubscribeClient.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { useLanguage } from "@/components/LanguageProvider";
+
+const API_URL =
+  process.env.NEXT_PUBLIC_RIFFPAD_API_URL ?? "https://api.riffpad.ai";
+
+type Status = "idle" | "submitting" | "success" | "error";
+
+export function UnsubscribeClient() {
+  const { t } = useLanguage();
+  const params = useSearchParams();
+  const email = params.get("email") ?? "";
+  const token = params.get("token") ?? "";
+  const valid = email !== "" && token !== "";
+  const [status, setStatus] = useState<Status>("idle");
+
+  useEffect(() => {
+    setStatus("idle");
+  }, [email, token]);
+
+  async function handleUnsubscribe() {
+    if (!valid || status === "submitting") return;
+    setStatus("submitting");
+    try {
+      const res = await fetch(`${API_URL}/api/waitlist/unsubscribe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, token }),
+      });
+      if (!res.ok) throw new Error(`unsubscribe ${res.status}`);
+      setStatus("success");
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center px-6 py-16">
+      <div className="w-full max-w-md border border-hairline-strong bg-surface p-8 shadow-card">
+        <p className="label">{t.unsubscribe.label}</p>
+
+        {!valid ? (
+          <div className="mt-6">
+            <h1 className="text-lg font-bold text-ink">{t.unsubscribe.invalidTitle}</h1>
+            <p className="mt-2 text-sm leading-relaxed text-body">
+              {t.unsubscribe.invalidDesc}
+            </p>
+          </div>
+        ) : status === "success" ? (
+          <div className="mt-6">
+            <h1 className="text-lg font-bold text-accent">
+              {t.unsubscribe.successTitle}
+            </h1>
+            <p className="mt-2 text-sm leading-relaxed text-body">
+              {t.unsubscribe.successDesc}
+            </p>
+          </div>
+        ) : (
+          <>
+            <h1 className="mt-6 text-lg font-bold text-ink">
+              {t.unsubscribe.title}
+            </h1>
+            <p className="mt-2 text-sm leading-relaxed text-body">
+              {t.unsubscribe.desc}
+            </p>
+
+            <label className="label mt-6 block">{t.unsubscribe.emailLabel}</label>
+            <p className="mt-1 truncate border border-hairline bg-surface-muted px-3 py-2 text-sm text-ink">
+              {email}
+            </p>
+
+            <button
+              type="button"
+              onClick={handleUnsubscribe}
+              disabled={status === "submitting"}
+              className="btn btn-primary mt-6 w-full"
+            >
+              {status === "submitting" ? "…" : t.unsubscribe.confirm}
+            </button>
+
+            {status === "error" && (
+              <p className="mt-3 text-xs text-danger">{t.unsubscribe.error}</p>
+            )}
+          </>
+        )}
+
+        <a
+          href="/"
+          className="btn btn-ghost mt-8 -ml-2 px-2 text-xs"
+        >
+          {t.unsubscribe.back}
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/apps/landing/app/unsubscribe/page.tsx
+++ b/apps/landing/app/unsubscribe/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { UnsubscribeClient } from "./UnsubscribeClient";
+
+export const metadata: Metadata = {
+  title: "Unsubscribe - Riffpad",
+  robots: { index: false, follow: false },
+};
+
+export default function UnsubscribePage() {
+  return (
+    <Suspense fallback={null}>
+      <UnsubscribeClient />
+    </Suspense>
+  );
+}

--- a/apps/landing/lib/i18n.ts
+++ b/apps/landing/lib/i18n.ts
@@ -190,6 +190,19 @@ const en = {
     en: "EN",
     zh: "中",
   },
+  unsubscribe: {
+    label: "riffpad // unsubscribe",
+    title: "Unsubscribe from Riffpad announcements",
+    desc: "Stop receiving product updates. You can always rejoin the waitlist from riffpad.ai.",
+    emailLabel: "Email",
+    confirm: "Unsubscribe",
+    successTitle: "You're unsubscribed ✓",
+    successDesc: "You won't receive future announcement emails from Riffpad.",
+    invalidTitle: "Invalid link",
+    invalidDesc: "This unsubscribe link isn't valid. Use the link from the email you received.",
+    error: "Something went wrong — please try again.",
+    back: "← riffpad.ai",
+  },
 };
 
 const zh: typeof en = {
@@ -381,6 +394,19 @@ const zh: typeof en = {
   languages: {
     en: "EN",
     zh: "中",
+  },
+  unsubscribe: {
+    label: "riffpad // 退订",
+    title: "退订 Riffpad 公告邮件",
+    desc: "停止接收产品更新邮件。想重新订阅，随时可以回到 riffpad.ai。",
+    emailLabel: "邮箱",
+    confirm: "确认退订",
+    successTitle: "已退订 ✓",
+    successDesc: "以后不会再收到 Riffpad 的公告邮件。",
+    invalidTitle: "链接无效",
+    invalidDesc: "这个退订链接无效，请使用邮件中收到的链接。",
+    error: "出错了，请重试。",
+    back: "← riffpad.ai",
   },
 };
 

--- a/apps/relay/internal/hub/hub.go
+++ b/apps/relay/internal/hub/hub.go
@@ -135,6 +135,9 @@ type Hub struct {
 	githubUserURL  string
 	appURL         string
 	apiHosts       []string
+	unsubSecret    string
+	adminKey       string
+	webOrigins     []string
 }
 
 type ipCounter struct {
@@ -164,6 +167,9 @@ func New(logger *log.Logger, dataDir, databaseURL string) (*Hub, error) {
 		githubUserURL:  "https://api.github.com/user",
 		appURL:         envOr("RIFFPAD_APP_URL", "https://app.riffpad.ai"),
 		apiHosts:       splitCSV(os.Getenv("RIFFPAD_API_HOSTS")),
+		unsubSecret:    os.Getenv("UNSUBSCRIBE_SECRET"),
+		adminKey:       os.Getenv("WAITLIST_ADMIN_KEY"),
+		webOrigins:     splitCSV(envOr("RIFFPAD_WEB_ORIGINS", "https://riffpad.ai,https://www.riffpad.ai")),
 	}, nil
 }
 
@@ -215,6 +221,8 @@ func (h *Hub) Handler() http.Handler {
 	mux.HandleFunc("/api/devices/", h.handleDeviceDelete)
 	mux.HandleFunc("/api/hosts/", h.handleHostKillswitch)
 	mux.HandleFunc("/api/sessions", h.handleSessions)
+	mux.HandleFunc("/api/waitlist/unsubscribe", h.handleWaitlistUnsubscribe)
+	mux.HandleFunc("/api/waitlist/optouts", h.handleWaitlistOptouts)
 	mux.HandleFunc("/ws/host", h.handleHostWS)
 	mux.HandleFunc("/ws", h.handleViewerWS)
 	return mux

--- a/apps/relay/internal/hub/store.go
+++ b/apps/relay/internal/hub/store.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // User is a relay account. Hosts, devices and sessions are owned by a user.
@@ -88,6 +89,14 @@ type SessionMeta struct {
 	LastSeenAt time.Time `json:"lastSeenAt"`
 }
 
+// EmailOptout is a waitlist address that asked to stop receiving
+// announcement emails. The address is normalized (lower-cased) and stored as
+// the primary key so unsubscribe is idempotent.
+type EmailOptout struct {
+	Email     string    `gorm:"primaryKey" json:"email"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
 type Store struct {
 	db *gorm.DB
 }
@@ -110,10 +119,38 @@ func OpenStore(dataDir, databaseURL string) (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := db.AutoMigrate(&User{}, &OAuthAccount{}, &AuthToken{}, &HostRecord{}, &Device{}, &PairingRecord{}, &SessionMeta{}); err != nil {
+	if err := db.AutoMigrate(&User{}, &OAuthAccount{}, &AuthToken{}, &HostRecord{}, &Device{}, &PairingRecord{}, &SessionMeta{}, &EmailOptout{}); err != nil {
 		return nil, err
 	}
 	return &Store{db: db}, nil
+}
+
+// AddEmailOptout records an opt-out. Repeated unsubscribes are a no-op.
+func (s *Store) AddEmailOptout(email string) error {
+	o := &EmailOptout{Email: email, CreatedAt: time.Now()}
+	return s.db.Clauses(clause.OnConflict{DoNothing: true}).Create(o).Error
+}
+
+// EmailOptedOut reports whether an address has unsubscribed.
+func (s *Store) EmailOptedOut(email string) (bool, error) {
+	var n int64
+	if err := s.db.Model(&EmailOptout{}).Where("email = ?", email).Count(&n).Error; err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+// EmailOptouts returns all opted-out addresses, oldest first.
+func (s *Store) EmailOptouts() ([]string, error) {
+	var rows []EmailOptout
+	if err := s.db.Order("created_at ASC").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.Email)
+	}
+	return out, nil
 }
 
 func (s *Store) CreateUser(username, password string) (*User, error) {

--- a/apps/relay/internal/hub/waitlist.go
+++ b/apps/relay/internal/hub/waitlist.go
@@ -1,0 +1,130 @@
+package hub
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/mail"
+	"os"
+	"strings"
+	"time"
+)
+
+// Waitlist unsubscribe endpoints. The announcement tool signs every email
+// with UNSUBSCRIBE_SECRET (HMAC-SHA256 of the normalized address); the
+// landing page presents that link to the relay, which verifies the signature
+// and stores the opt-out in email_optouts. The tool then fetches the list
+// with WAITLIST_ADMIN_KEY so future sends skip opted-out addresses.
+
+func normalizeWaitlistEmail(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+func validWaitlistEmail(s string) bool {
+	if s == "" || strings.ContainsAny(s, "\r\n ") {
+		return false
+	}
+	a, err := mail.ParseAddress(s)
+	return err == nil && a.Address == s
+}
+
+func waitlistSign(email string) (string, error) {
+	if h, ok := os.LookupEnv("UNSUBSCRIBE_SECRET"); ok {
+		mac := hmac.New(sha256.New, []byte(h))
+		_, _ = mac.Write([]byte(normalizeWaitlistEmail(email)))
+		return hex.EncodeToString(mac.Sum(nil)), nil
+	}
+	return "", os.ErrNotExist
+}
+
+func waitlistValidSignature(email, token string) bool {
+	want, err := waitlistSign(email)
+	if err != nil {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(token), []byte(want)) == 1
+}
+
+// setCORSHeaders allows browser calls from the configured web origins only.
+func (h *Hub) setCORSHeaders(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	for _, allowed := range h.webOrigins {
+		if strings.EqualFold(allowed, origin) {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			break
+		}
+	}
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	w.Header().Set("Vary", "Origin")
+}
+
+// handleWaitlistUnsubscribe records an email opt-out after verifying the
+// HMAC token embedded in the announcement link. Idempotent.
+func (h *Hub) handleWaitlistUnsubscribe(w http.ResponseWriter, r *http.Request) {
+	h.setCORSHeaders(w, r)
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w)
+		return
+	}
+	if h.unsubSecret == "" {
+		writeError(w, http.StatusServiceUnavailable, "waitlist unsubscribe not configured")
+		return
+	}
+	if !h.allowRate("waitlist-unsub", clientIP(r), 10, time.Minute) {
+		writeError(w, http.StatusTooManyRequests, "rate limit exceeded")
+		return
+	}
+	var req struct {
+		Email string `json:"email"`
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid body")
+		return
+	}
+	email := normalizeWaitlistEmail(req.Email)
+	if !validWaitlistEmail(email) || req.Token == "" {
+		writeError(w, http.StatusBadRequest, "invalid email or token")
+		return
+	}
+	if !waitlistValidSignature(email, req.Token) {
+		writeError(w, http.StatusBadRequest, "invalid token")
+		return
+	}
+	if err := h.store.AddEmailOptout(email); err != nil {
+		h.log.Printf("waitlist opt-out failed email=%s: %v", email, err)
+		writeError(w, http.StatusInternalServerError, "failed to save opt-out")
+		return
+	}
+	h.log.Printf("waitlist opt-out email=%s", email)
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// handleWaitlistOptouts returns the opted-out addresses for the announcement
+// tool. Protected by WAITLIST_ADMIN_KEY; not meant for browsers.
+func (h *Hub) handleWaitlistOptouts(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+		return
+	}
+	if h.adminKey == "" || subtle.ConstantTimeCompare(
+		[]byte(r.Header.Get("X-Admin-Key")), []byte(h.adminKey)) != 1 {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	emails, err := h.store.EmailOptouts()
+	if err != nil {
+		h.log.Printf("waitlist opt-outs read failed: %v", err)
+		writeError(w, http.StatusInternalServerError, "failed to read opt-outs")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"emails": emails})
+}

--- a/apps/relay/internal/hub/waitlist_test.go
+++ b/apps/relay/internal/hub/waitlist_test.go
@@ -1,0 +1,176 @@
+package hub
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newWaitlistTestHub(t *testing.T) (*Hub, *httptest.Server) {
+	t.Helper()
+	t.Setenv("UNSUBSCRIBE_SECRET", "test-secret")
+	t.Setenv("WAITLIST_ADMIN_KEY", "admin-key")
+	t.Setenv("RIFFPAD_WEB_ORIGINS", "https://riffpad.ai,https://www.riffpad.ai")
+	h, err := New(log.New(io.Discard, "", 0), t.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(h.Handler())
+	t.Cleanup(ts.Close)
+	return h, ts
+}
+
+func TestWaitlistUnsubscribe(t *testing.T) {
+	h, ts := newWaitlistTestHub(t)
+	email := "User@Example.com"
+	token, err := waitlistSign(email)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	post := func(origin string, body string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/waitlist/unsubscribe", strings.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { resp.Body.Close() })
+		return resp
+	}
+
+	body, _ := json.Marshal(map[string]string{"email": email, "token": token})
+	resp := post("https://riffpad.ai", string(body))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("valid unsubscribe status %d", resp.StatusCode)
+	}
+	if resp.Header.Get("Access-Control-Allow-Origin") != "https://riffpad.ai" {
+		t.Fatalf("missing CORS header: %q", resp.Header.Get("Access-Control-Allow-Origin"))
+	}
+
+	// Idempotent: unsubscribing twice is still 200.
+	resp = post("https://www.riffpad.ai", string(body))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("repeated unsubscribe status %d", resp.StatusCode)
+	}
+
+	// Disallowed origin must not get CORS headers.
+	resp = post("https://evil.example", string(body))
+	if resp.Header.Get("Access-Control-Allow-Origin") != "" {
+		t.Fatal("CORS header leaked to disallowed origin")
+	}
+
+	// Bad token is rejected.
+	resp = post("", `{"email":"a@b.c","token":"deadbeef"}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("forged token status %d", resp.StatusCode)
+	}
+
+	// Invalid email is rejected.
+	resp = post("", `{"email":"nope","token":"x"}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("invalid email status %d", resp.StatusCode)
+	}
+
+	// Preflight from an allowed origin passes.
+	req, _ := http.NewRequest(http.MethodOptions, ts.URL+"/api/waitlist/unsubscribe", nil)
+	req.Header.Set("Origin", "https://riffpad.ai")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	pre, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pre.Body.Close()
+	if pre.StatusCode != http.StatusNoContent || pre.Header.Get("Access-Control-Allow-Origin") != "https://riffpad.ai" {
+		t.Fatalf("preflight failed: status %d, ACAO %q", pre.StatusCode, pre.Header.Get("Access-Control-Allow-Origin"))
+	}
+
+	optedOut, err := h.store.EmailOptedOut(strings.ToLower(email))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !optedOut {
+		t.Fatal("email not recorded as opted out")
+	}
+}
+
+func TestWaitlistOptoutsAdminOnly(t *testing.T) {
+	_, ts := newWaitlistTestHub(t)
+	if _, err := waitlistSign("a@b.c"); err != nil {
+		t.Fatal(err)
+	}
+	if err := postJSON(ts.URL+"/api/waitlist/unsubscribe", map[string]string{
+		"email": "a@b.c", "token": mustToken(t, "a@b.c"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	get := func(key string) *http.Response {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/waitlist/optouts", nil)
+		if key != "" {
+			req.Header.Set("X-Admin-Key", key)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { resp.Body.Close() })
+		return resp
+	}
+
+	if resp := get(""); resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("missing key status %d", resp.StatusCode)
+	}
+	if resp := get("wrong"); resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("wrong key status %d", resp.StatusCode)
+	}
+	resp := get("admin-key")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("valid key status %d", resp.StatusCode)
+	}
+	var out struct {
+		Emails []string `json:"emails"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Emails) != 1 || out.Emails[0] != "a@b.c" {
+		t.Fatalf("unexpected optouts: %v", out.Emails)
+	}
+}
+
+func mustToken(t *testing.T, email string) string {
+	t.Helper()
+	tok, err := waitlistSign(email)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tok
+}
+
+func postJSON(url string, v any) error {
+	b, _ := json.Marshal(v)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unsubscribe status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -1,6 +1,6 @@
 # Riffpad 开发计划（Dev Plan）
 
-> 最后更新：2026-08-08（按实际开发进度整理）
+> 最后更新：2026-08-09（按实际开发进度整理）
 > 关联文档：[PRD](prd.md)（产品需求）、[TSD](tsd.md)（技术规格）、[无 tmux 注入调研](agent-injection-research.md)
 > 用途：追踪 M0 → M3 的开发进度；每个里程碑完成时更新状态。
 
@@ -202,6 +202,7 @@
 | M3.21 | macOS daemon 管理：`riffpad setup` 支持 launchd LaunchAgent（登录自启 + 崩溃重启）；`riffpad daemon restart` 与 `riffpad update` 自动重启在 macOS 优先走 `launchctl kickstart -k`，保持 launchd 为唯一进程账本 | `[ ]` | setup 安装/移除 LaunchAgent；restart/update 检测 launchd 托管并走 launchctl；真机验证 | — |
 | M3.22 | Windows daemon 管理：`riffpad daemon restart` 与 `riffpad update` 自动重启检测 `RiffpadDaemon` 计划任务，停止旧进程后 `schtasks /Run` 由任务管理器拉起，保持任务账本一致 | `[x]` | daemonRestart 任务分支 + 单测（运行中停旧启新 / 未运行直接拉起）已实现 | #208 |
 | M3.23 | 弃用 attach 模式：入口关闭（代码保留，`riffpad detach` 仍可用于清理旧 hooks），统一 `riffpad run` 托管模式；`riffpad run` 支持位置参数（`riffpad run codex`） | `[x]` | attachCmd 返回弃用提示；run 位置参数 + 单测已实现 | #214 |
+| M3.24 | 群发邮件 + 退订管理：`scripts/email`（Formspree 拉取/去重、SMTP 群发、HMAC 退订链接、跳过已退订）；relay `/api/waitlist/unsubscribe` + `/api/waitlist/optouts`（`email_optouts` 表，CORS 仅 riffpad.ai/www）；landing `/unsubscribe` 退订页（中英、深浅色一致） | `[~]` | 首次公告可发出；退订幂等；后续发送自动跳过；生产 env 配 `UNSUBSCRIBE_SECRET`/`WAITLIST_ADMIN_KEY` | #218 |
 
 ---
 

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -7,3 +7,8 @@ GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 RIFFPAD_API_HOSTS=api.riffpad.ai
 RIFFPAD_APP_URL=https://app.riffpad.ai
+# Waitlist announcements: HMAC secret for unsubscribe links (shared with
+# scripts/email) and admin key for the announcement tool to fetch opt-outs.
+UNSUBSCRIBE_SECRET=
+WAITLIST_ADMIN_KEY=
+RIFFPAD_WEB_ORIGINS=https://riffpad.ai,https://www.riffpad.ai

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}
       RIFFPAD_API_HOSTS: ${RIFFPAD_API_HOSTS:-}
       RIFFPAD_APP_URL: ${RIFFPAD_APP_URL:-https://app.riffpad.ai}
+      UNSUBSCRIBE_SECRET: ${UNSUBSCRIBE_SECRET:-}
+      WAITLIST_ADMIN_KEY: ${WAITLIST_ADMIN_KEY:-}
+      RIFFPAD_WEB_ORIGINS: ${RIFFPAD_WEB_ORIGINS:-https://riffpad.ai,https://www.riffpad.ai}
     depends_on:
       postgres:
         condition: service_healthy

--- a/scripts/email/README.md
+++ b/scripts/email/README.md
@@ -1,0 +1,56 @@
+# Riffpad waitlist email toolchain
+
+Operator tool for sending waitlist announcements with one-click
+unsubscribe. Pure Go standard library (no runtime dependencies beyond a
+binary build).
+
+## Commands
+
+```sh
+# 1. Pull and dedupe waitlist emails from Formspree (Professional/Business
+#    plan API; on the free plan export the CSV from the dashboard instead)
+FORMSPREE_API_KEY=xxx FORMSPREE_FORM_ID=xjgqddar \
+  go run . fetch -out waitlist.csv
+
+# 2. Preview the rendered emails without sending
+SMTP_PASS=xxx UNSUBSCRIBE_SECRET=yyy \
+  go run . send -recipients waitlist.csv -template templates/announcement.txt.example \
+    -subject "Riffpad is in beta" -dry-run
+
+# 3. Send for real (Spacemail free tier: ~20 emails/hour, 50 recipients per
+#    message; add -interval 180s to stay under the limit)
+SMTP_PASS=xxx UNSUBSCRIBE_SECRET=yyy WAITLIST_ADMIN_KEY=zzz \
+  go run . send -recipients waitlist.csv -template templates/announcement.txt.example \
+    -subject "Riffpad is in beta" -interval 180s
+
+# Helper: print the unsubscribe URL for one address
+UNSUBSCRIBE_SECRET=yyy go run . token -email you@example.com
+```
+
+## Environment
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `SMTP_HOST` | `mail.spacemail.com` | SMTP server (implicit TLS) |
+| `SMTP_PORT` | `465` | SMTP port |
+| `SMTP_USER` | `hi@riffpad.ai` | SMTP login |
+| `SMTP_PASS` | — | SMTP password (required unless `--dry-run`) |
+| `FROM` | `SMTP_USER` | From address |
+| `UNSUBSCRIBE_SECRET` | — | HMAC secret shared with the relay (required) |
+| `UNSUBSCRIBE_BASE_URL` | `https://riffpad.ai/unsubscribe` | unsubscribe page |
+| `RIFFPAD_API_URL` | `https://api.riffpad.ai` | relay base URL |
+| `WAITLIST_ADMIN_KEY` | — | relay admin key for fetching opt-outs |
+| `FORMSPREE_API_KEY` / `FORMSPREE_FORM_ID` | — | Formspree credentials for `fetch` |
+
+## How unsubscribe works
+
+Each email gets `https://riffpad.ai/unsubscribe?email=...&token=...` where
+the token is `HMAC-SHA256(UNSUBSCRIBE_SECRET, email)`. The landing page
+posts it to `POST /api/waitlist/unsubscribe` on the relay, which verifies
+the signature and stores the address in the `email_optouts` table. The
+`send` command fetches that list (`GET /api/waitlist/optouts` with
+`X-Admin-Key`) and skips opted-out addresses.
+
+If a template does not include `{{.UnsubscribeURL}}`, a footer with the
+unsubscribe link is appended automatically so every sent message stays
+compliant.

--- a/scripts/email/env.go
+++ b/scripts/email/env.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+// loadEnvFile reads a simple KEY=VALUE file (quotes stripped, "#" comments
+// skipped) into the process environment without overriding variables that
+// are already set. A missing file is not an error.
+func loadEnvFile(path string) error {
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		val = strings.TrimSpace(val)
+		if len(val) >= 2 &&
+			((val[0] == '"' && val[len(val)-1] == '"') ||
+				(val[0] == '\'' && val[len(val)-1] == '\'')) {
+			val = val[1 : len(val)-1]
+		}
+		if _, exists := os.LookupEnv(key); !exists {
+			_ = os.Setenv(key, val)
+		}
+	}
+	return nil
+}

--- a/scripts/email/env_test.go
+++ b/scripts/email/env_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadEnvFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	data := "# comment\nSMTP_HOST=mail.spacemail.com\nSMTP_PASS='p@ss*w*d'\nQUOTED=\"x\"\n"
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SMTP_PASS", "existing")
+	if err := loadEnvFile(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv("SMTP_HOST"); got != "mail.spacemail.com" {
+		t.Fatalf("SMTP_HOST = %q", got)
+	}
+	// Existing variables must not be overridden.
+	if got := os.Getenv("SMTP_PASS"); got != "existing" {
+		t.Fatalf("SMTP_PASS overridden to %q", got)
+	}
+	if got := os.Getenv("QUOTED"); got != "x" {
+		t.Fatalf("QUOTED = %q", got)
+	}
+	// Missing file is not an error.
+	if err := loadEnvFile(filepath.Join(t.TempDir(), "nope")); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/scripts/email/formspree.go
+++ b/scripts/email/formspree.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+type formspreeResponse struct {
+	Submissions []map[string]any `json:"submissions"`
+}
+
+func fetchFormspree(formID, apiKey string) ([]recipient, error) {
+	u := fmt.Sprintf("https://formspree.io/api/0/forms/%s/submissions", formID)
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth("", apiKey)
+	req.Header.Set("Accept", "application/json")
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("formspree status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var out formspreeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode formspree response: %w", err)
+	}
+
+	seen := map[string]bool{}
+	var recs []recipient
+	for _, sub := range out.Submissions {
+		email := submissionEmail(sub)
+		email = normalizeEmail(email)
+		if email == "" || !validEmail(email) || seen[email] {
+			continue
+		}
+		seen[email] = true
+		recs = append(recs, recipient{Email: email, Date: submissionDate(sub)})
+	}
+	sort.Slice(recs, func(i, j int) bool { return recs[i].Email < recs[j].Email })
+	return recs, nil
+}
+
+func submissionEmail(sub map[string]any) string {
+	if v, ok := sub["email"].(string); ok {
+		return v
+	}
+	if data, ok := sub["data"].(map[string]any); ok {
+		if v, ok := data["email"].(string); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+func submissionDate(sub map[string]any) string {
+	for _, k := range []string{"_date", "created_at", "date"} {
+		if v, ok := sub[k].(string); ok {
+			return v
+		}
+	}
+	return ""
+}

--- a/scripts/email/go.mod
+++ b/scripts/email/go.mod
@@ -1,0 +1,3 @@
+module github.com/riffpad/riffpad/scripts/email
+
+go 1.25

--- a/scripts/email/main.go
+++ b/scripts/email/main.go
@@ -13,6 +13,9 @@ import (
 )
 
 func main() {
+	if err := loadEnvFile(".env"); err != nil {
+		fmt.Fprintf(os.Stderr, "riffpad-email: warning: cannot load .env: %v\n", err)
+	}
 	if len(os.Args) < 2 {
 		usage()
 		os.Exit(2)

--- a/scripts/email/main.go
+++ b/scripts/email/main.go
@@ -1,0 +1,236 @@
+// Command riffpad-email is the operator toolchain for Riffpad waitlist
+// announcements: pull submissions from Formspree, render a template, send
+// each recipient a personalized email over SMTP (implicit TLS), and embed a
+// signed one-click unsubscribe link backed by the relay's email_optouts table.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "fetch":
+		cmdFetch(os.Args[2:])
+	case "send":
+		cmdSend(os.Args[2:])
+	case "token":
+		cmdToken(os.Args[2:])
+	case "help", "-h", "--help":
+		usage()
+	default:
+		fmt.Fprintf(os.Stderr, "riffpad-email: unknown command %q\n\n", os.Args[1])
+		usage()
+		os.Exit(2)
+	}
+}
+
+func usage() {
+	fmt.Fprint(os.Stderr, `riffpad-email - Riffpad waitlist announcement toolchain
+
+Commands:
+  fetch    pull Formspree submissions into a recipients CSV (deduped)
+  send     send a template email to every recipient with a signed
+           unsubscribe link, skipping emails already opted out
+  token    print the unsubscribe URL for one email (testing)
+
+Examples:
+  FORMSPREE_API_KEY=xxx FORMSPREE_FORM_ID=xjgqddar \
+    riffpad-email fetch -out waitlist.csv
+
+  SMTP_PASS=xxx UNSUBSCRIBE_SECRET=yyy \
+    riffpad-email send -recipients waitlist.csv -template announcement.txt \
+      -subject "Riffpad is live - try the beta"
+
+Environment:
+  SMTP_HOST              SMTP server (default mail.spacemail.com)
+  SMTP_PORT              SMTP port (default 465, implicit TLS)
+  SMTP_USER              SMTP login (default hi@riffpad.ai)
+  SMTP_PASS              SMTP password
+  FROM                   From address (default SMTP_USER)
+  UNSUBSCRIBE_SECRET     HMAC secret shared with the relay (required)
+  UNSUBSCRIBE_BASE_URL   unsubscribe page (default https://riffpad.ai/unsubscribe)
+  RIFFPAD_API_URL        relay API (default https://api.riffpad.ai)
+  WAITLIST_ADMIN_KEY     relay admin key used to fetch opt-outs
+  FORMSPREE_API_KEY      Formspree API key (Professional/Business plans)
+  FORMSPREE_FORM_ID      Formspree form hashid
+`)
+}
+
+func envOr(key, def string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return def
+}
+
+func cmdToken(args []string) {
+	fs := flag.NewFlagSet("token", flag.ExitOnError)
+	email := fs.String("email", "", "email address")
+	fs.Parse(args)
+	if *email == "" {
+		fatalf("token: -email is required")
+	}
+	u, err := unsubscribeURL(*email)
+	if err != nil {
+		fatalf("token: %v", err)
+	}
+	fmt.Println(u)
+}
+
+func cmdSend(args []string) {
+	fs := flag.NewFlagSet("send", flag.ExitOnError)
+	recipients := fs.String("recipients", "", "recipients CSV (email[,name][,date])")
+	template := fs.String("template", "", "email body template (text/template)")
+	subject := fs.String("subject", "", "email subject")
+	from := fs.String("from", "", "From address (default SMTP_USER)")
+	dryRun := fs.Bool("dry-run", false, "render only, do not send")
+	interval := fs.Duration("interval", 3*time.Second, "delay between sends")
+	fs.Parse(args)
+
+	if *recipients == "" || *template == "" || *subject == "" {
+		fatalf("send: -recipients, -template and -subject are required")
+	}
+	if os.Getenv("UNSUBSCRIBE_SECRET") == "" {
+		fatalf("send: UNSUBSCRIBE_SECRET is required")
+	}
+
+	recs, err := loadRecipients(*recipients)
+	if err != nil {
+		fatalf("send: %v", err)
+	}
+	if len(recs) == 0 {
+		fatalf("send: no recipients in %s", *recipients)
+	}
+
+	optedOut := map[string]bool{}
+	if key := os.Getenv("WAITLIST_ADMIN_KEY"); key != "" {
+		emails, err := fetchOptOuts(key)
+		if err != nil {
+			fatalf("send: fetch opt-outs: %v", err)
+		}
+		for _, e := range emails {
+			optedOut[normalizeEmail(e)] = true
+		}
+		fmt.Fprintf(os.Stderr, "riffpad-email: %d opted-out email(s) loaded from relay\n", len(optedOut))
+	} else {
+		fmt.Fprintln(os.Stderr, "riffpad-email: WAITLIST_ADMIN_KEY not set, skipping opt-out check")
+	}
+
+	bodyTmpl, err := loadTemplate(*template)
+	if err != nil {
+		fatalf("send: %v", err)
+	}
+
+	var sender *smtpSender
+	if !*dryRun {
+		sender = newSMTPSender(envOr("SMTP_HOST", "mail.spacemail.com"),
+			envOrInt("SMTP_PORT", 465),
+			envOr("SMTP_USER", "hi@riffpad.ai"),
+			os.Getenv("SMTP_PASS"),
+			*from)
+		if sender.from == "" {
+			sender.from = sender.user
+		}
+		if sender.pass == "" {
+			fatalf("send: SMTP_PASS is required unless -dry-run")
+		}
+	}
+
+	var sent, skipped, failed int
+	for i, r := range recs {
+		email := normalizeEmail(r.Email)
+		if email == "" {
+			skipped++
+			continue
+		}
+		if optedOut[email] {
+			fmt.Fprintf(os.Stderr, "  skip (opted out): %s\n", email)
+			skipped++
+			continue
+		}
+		u, err := unsubscribeURL(email)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  FAIL %s: %v\n", email, err)
+			failed++
+			continue
+		}
+		body, err := renderBody(bodyTmpl, r, u)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  FAIL %s: %v\n", email, err)
+			failed++
+			continue
+		}
+		if *dryRun {
+			fmt.Printf("==> %s (%d/%d)\n%s\n\n", email, i+1, len(recs), body)
+			sent++
+			continue
+		}
+		if err := sender.send(email, *subject, body); err != nil {
+			fmt.Fprintf(os.Stderr, "  FAIL %s: %v\n", email, err)
+			failed++
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "  OK   %s\n", email)
+		sent++
+		if i < len(recs)-1 && *interval > 0 {
+			time.Sleep(*interval)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "riffpad-email: done - sent=%d skipped=%d failed=%d\n", sent, skipped, failed)
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+func cmdFetch(args []string) {
+	fs := flag.NewFlagSet("fetch", flag.ExitOnError)
+	formID := fs.String("form-id", "", "Formspree form hashid (or FORMSPREE_FORM_ID)")
+	apiKey := fs.String("api-key", "", "Formspree API key (or FORMSPREE_API_KEY)")
+	out := fs.String("out", "-", "output CSV path (default stdout)")
+	fs.Parse(args)
+
+	if *formID == "" {
+		*formID = os.Getenv("FORMSPREE_FORM_ID")
+	}
+	if *apiKey == "" {
+		*apiKey = os.Getenv("FORMSPREE_API_KEY")
+	}
+	if *formID == "" || *apiKey == "" {
+		fatalf("fetch: -form-id and -api-key are required (or FORMSPREE_FORM_ID / FORMSPREE_API_KEY)")
+	}
+	subs, err := fetchFormspree(*formID, *apiKey)
+	if err != nil {
+		fatalf("fetch: %v", err)
+	}
+	if err := writeRecipientsCSV(*out, subs); err != nil {
+		fatalf("fetch: %v", err)
+	}
+	fmt.Fprintf(os.Stderr, "riffpad-email: %d recipient(s) written to %s\n", len(subs), *out)
+}
+
+func envOrInt(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	var n int
+	if _, err := fmt.Sscanf(v, "%d", &n); err != nil || n <= 0 {
+		return def
+	}
+	return n
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "riffpad-email: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/scripts/email/optouts.go
+++ b/scripts/email/optouts.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func fetchOptOuts(adminKey string) ([]string, error) {
+	u := strings.TrimSuffix(envOr("RIFFPAD_API_URL", "https://api.riffpad.ai"), "/") + "/api/waitlist/optouts"
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Admin-Key", adminKey)
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("optouts status %d", resp.StatusCode)
+	}
+	var out struct {
+		Emails []string `json:"emails"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out.Emails, nil
+}

--- a/scripts/email/recipients.go
+++ b/scripts/email/recipients.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+type recipient struct {
+	Email string
+	Name  string
+	Date  string
+}
+
+func loadRecipients(path string) ([]recipient, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	r.FieldsPerRecord = -1
+	r.TrimLeadingSpace = true
+
+	header, err := r.Read()
+	if err != nil {
+		return nil, fmt.Errorf("read header: %w", err)
+	}
+	idx := map[string]int{}
+	for i, h := range header {
+		idx[strings.ToLower(strings.TrimSpace(h))] = i
+	}
+	emailCol, ok := idx["email"]
+	if !ok {
+		return nil, fmt.Errorf("CSV needs an \"email\" column, got %v", header)
+	}
+	nameCol, nameOK := idx["name"]
+	dateCol, dateOK := idx["date"]
+
+	seen := map[string]bool{}
+	var out []recipient
+	for {
+		row, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		email := normalizeEmail(row[emailCol])
+		if email == "" || !validEmail(email) || seen[email] {
+			continue
+		}
+		seen[email] = true
+		rec := recipient{Email: email}
+		if nameOK && len(row) > nameCol {
+			rec.Name = strings.TrimSpace(row[nameCol])
+		}
+		if dateOK && len(row) > dateCol {
+			rec.Date = strings.TrimSpace(row[dateCol])
+		}
+		out = append(out, rec)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Email < out[j].Email })
+	return out, nil
+}
+
+func writeRecipientsCSV(path string, recs []recipient) error {
+	var w io.Writer = os.Stdout
+	var f *os.File
+	if path != "-" {
+		var err error
+		f, err = os.Create(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		w = f
+	}
+	cw := csv.NewWriter(w)
+	if err := cw.Write([]string{"email", "name", "date"}); err != nil {
+		return err
+	}
+	for _, r := range recs {
+		if err := cw.Write([]string{r.Email, r.Name, r.Date}); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}

--- a/scripts/email/sender.go
+++ b/scripts/email/sender.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/smtp"
+	"strings"
+)
+
+type smtpSender struct {
+	host     string
+	port     int
+	user     string
+	pass     string
+	from     string
+	addr     string
+}
+
+func newSMTPSender(host string, port int, user, pass, from string) *smtpSender {
+	return &smtpSender{
+		host: host,
+		port: port,
+		user: user,
+		pass: pass,
+		from: from,
+		addr: net.JoinHostPort(host, fmt.Sprintf("%d", port)),
+	}
+}
+
+func (s *smtpSender) send(to, subject, body string) error {
+	conn, err := tls.Dial("tcp", s.addr, &tls.Config{ServerName: s.host})
+	if err != nil {
+		return fmt.Errorf("tls dial: %w", err)
+	}
+	defer conn.Close()
+
+	c, err := smtp.NewClient(conn, s.host)
+	if err != nil {
+		return fmt.Errorf("smtp client: %w", err)
+	}
+	defer c.Close()
+
+	if err := c.Auth(smtp.PlainAuth("", s.user, s.pass, s.host)); err != nil {
+		return fmt.Errorf("auth: %w", err)
+	}
+	if err := c.Mail(s.from); err != nil {
+		return fmt.Errorf("mail from: %w", err)
+	}
+	if err := c.Rcpt(to); err != nil {
+		return fmt.Errorf("rcpt %s: %w", to, err)
+	}
+	w, err := c.Data()
+	if err != nil {
+		return fmt.Errorf("data: %w", err)
+	}
+	subject = strings.ReplaceAll(strings.ReplaceAll(subject, "\r", " "), "\n", " ")
+	msg := fmt.Sprintf(
+		"From: %s\r\nTo: %s\r\nSubject: %s\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n%s",
+		s.from, to, subject, body)
+	if _, err := w.Write([]byte(msg)); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("close data: %w", err)
+	}
+	return c.Quit()
+}

--- a/scripts/email/template.go
+++ b/scripts/email/template.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+)
+
+func loadTemplate(path string) (*template.Template, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	t, err := template.New("body").Option("missingkey=error").Parse(string(raw))
+	if err != nil {
+		return nil, fmt.Errorf("parse template: %w", err)
+	}
+	return t, nil
+}
+
+// renderBody renders the template and guarantees the unsubscribe link is
+// present, appending a plain footer if the template forgot it.
+func renderBody(t *template.Template, r recipient, u string) (string, error) {
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, map[string]string{
+		"Email":          r.Email,
+		"Name":           r.Name,
+		"UnsubscribeURL": u,
+	}); err != nil {
+		return "", err
+	}
+	body := strings.TrimRight(buf.String(), "\n")
+	if !strings.Contains(body, u) {
+		body += "\n\n---\n" + u
+	}
+	return body + "\n", nil
+}

--- a/scripts/email/templates/announcement.txt.example
+++ b/scripts/email/templates/announcement.txt.example
@@ -1,0 +1,16 @@
+Hi{{if .Name}} {{.Name}}{{end}},
+
+Riffpad is now in beta. Install the CLI and pair your phone to watch,
+approve and steer Claude Code / Codex sessions from anywhere:
+
+  https://riffpad.ai
+
+We'd love your feedback on the waitlist Discord:
+  https://discord.gg/riffpad
+
+Talk soon,
+The Riffpad team
+
+---
+You're receiving this because you joined the Riffpad waitlist.
+Unsubscribe: {{.UnsubscribeURL}}

--- a/scripts/email/token.go
+++ b/scripts/email/token.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"net/mail"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// normalizeEmail canonicalizes an address: lower-case, trimmed, no display
+// name. The relay stores and matches the same form.
+func normalizeEmail(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+func validEmail(s string) bool {
+	if s == "" || strings.ContainsAny(s, "\r\n ") {
+		return false
+	}
+	a, err := mail.ParseAddress(s)
+	return err == nil && a.Address == s
+}
+
+func signEmail(email string) (string, error) {
+	secret := os.Getenv("UNSUBSCRIBE_SECRET")
+	if secret == "" {
+		return "", fmt.Errorf("UNSUBSCRIBE_SECRET is not set")
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(normalizeEmail(email)))
+	return hex.EncodeToString(mac.Sum(nil)), nil
+}
+
+func validSignature(email, token string) bool {
+	want, err := signEmail(email)
+	if err != nil {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(token), []byte(want)) == 1
+}
+
+func unsubscribeURL(email string) (string, error) {
+	email = normalizeEmail(email)
+	if !validEmail(email) {
+		return "", fmt.Errorf("invalid email %q", email)
+	}
+	tok, err := signEmail(email)
+	if err != nil {
+		return "", err
+	}
+	base := strings.TrimSuffix(envOr("UNSUBSCRIBE_BASE_URL", "https://riffpad.ai/unsubscribe"), "/")
+	return base + "?email=" + url.QueryEscape(email) + "&token=" + tok, nil
+}

--- a/scripts/email/token_test.go
+++ b/scripts/email/token_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUnsubscribeTokenRoundTrip(t *testing.T) {
+	t.Setenv("UNSUBSCRIBE_SECRET", "test-secret")
+	u, err := unsubscribeURL("User@Example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(u, "https://riffpad.ai/unsubscribe?email=user%40example.com&token=") {
+		t.Fatalf("unexpected URL: %s", u)
+	}
+	tok := strings.TrimPrefix(u, "https://riffpad.ai/unsubscribe?email=user%40example.com&token=")
+	if !validSignature("USER@example.com", tok) {
+		t.Fatal("valid signature rejected")
+	}
+	if validSignature("other@example.com", tok) {
+		t.Fatal("signature accepted for another email")
+	}
+	if validSignature("user@example.com", "deadbeef") {
+		t.Fatal("forged signature accepted")
+	}
+}
+
+func TestUnsubscribeURLRejectsInvalidEmail(t *testing.T) {
+	t.Setenv("UNSUBSCRIBE_SECRET", "s")
+	if _, err := unsubscribeURL("not-an-email"); err == nil {
+		t.Fatal("expected error for invalid email")
+	}
+}
+
+func TestLoadRecipients(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "waitlist.csv")
+	data := "Email,Name,Date\n  Alice@Example.com ,Alice,2026-08-01\nbob@example.com,Bob,2026-08-02\nbob@example.com,Dup,2026-08-03\nnope,\n"
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	recs, err := loadRecipients(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("want 2 unique recipients, got %d", len(recs))
+	}
+	if recs[0].Email != "alice@example.com" || recs[0].Name != "Alice" {
+		t.Fatalf("unexpected first recipient: %+v", recs[0])
+	}
+}
+
+func TestRenderBodyAppendsUnsubscribeFooter(t *testing.T) {
+	tmpl, err := loadTemplate(filepath.Join(t.TempDir(), "missing.txt"))
+	if err == nil {
+		t.Fatal("expected error for missing template")
+	}
+	path := filepath.Join(t.TempDir(), "body.txt")
+	if err := os.WriteFile(path, []byte("Hello {{.Email}}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tmpl, err = loadTemplate(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := renderBody(tmpl, recipient{Email: "a@b.c", Name: "Ann"}, "https://riffpad.ai/unsubscribe?email=a%40b.c&token=x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(body, "Hello a@b.c") || !strings.Contains(body, "https://riffpad.ai/unsubscribe") {
+		t.Fatalf("body missing content: %q", body)
+	}
+}
+
+func TestFetchOptOuts(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/waitlist/optouts" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if r.Header.Get("X-Admin-Key") != "k" {
+			t.Errorf("missing admin key")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"emails":["a@b.c"," d@e.f "]}`))
+	}))
+	t.Setenv("RIFFPAD_API_URL", ts.URL)
+	got, err := fetchOptOuts("k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != "a@b.c" || got[1] != " d@e.f " {
+		t.Fatalf("unexpected optouts: %v", got)
+	}
+}
+
+func TestNormalizeEmail(t *testing.T) {
+	if got := normalizeEmail("  Foo@Bar.COM "); got != "foo@bar.com" {
+		t.Fatalf("normalize: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #218

## 改动
- **scripts/email**（Go 纯标准库）：`fetch` 拉 Formspree 提交并去重导出 CSV；`send` 按模板逐封 SMTP 发送（隐式 TLS），每封带 HMAC 签名的退订链接，发送前从 relay 拉取已退订列表并跳过；`token` 生成单个退订链接；支持 `--dry-run` / `--interval` 限速
- **relay**：`POST /api/waitlist/unsubscribe`（HMAC 校验 + 幂等写入 `email_optouts` 表）；`GET /api/waitlist/optouts`（`X-Admin-Key` 保护，供群发工具拉取）；CORS 仅放行 riffpad.ai / www.riffpad.ai
- **landing**：`/unsubscribe` 退订页（中英双语、深浅色一致、noindex），点击确认后 POST 到 relay
- **infra/CI/dev-plan**：新增 `UNSUBSCRIBE_SECRET` / `WAITLIST_ADMIN_KEY` / `RIFFPAD_WEB_ORIGINS` env；compose 透传；CI 增加 scripts/email 测试；dev-plan M3.24

## 验证
- [x] `go test ./...`：relay（含 waitlist 单测：token 校验/幂等/CORS/admin）、scripts/email 全部通过
- [x] `pnpm lint` + `pnpm build`：landing 通过，/unsubscribe 路由生成
- [x] `scripts/email send --dry-run` 样例渲染通过（模板缺退订链接时自动补 footer）
- [ ] 生产配置 `UNSUBSCRIBE_SECRET` + `WAITLIST_ADMIN_KEY` 后真发首封（部署后人工验证）