### PR TITLE
feat(email): HTML 邮件模板 + 发件人显示名 + 跨端图标修复 (#222)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ apps/client-beta/playwright-report/
 !infra/.env.example
 
 test-notes/
+scripts/email/*.csv
 apps/landing/public/install.sh
 apps/landing/public/install.ps1

--- a/scripts/email/README.md
+++ b/scripts/email/README.md
@@ -36,6 +36,7 @@ UNSUBSCRIBE_SECRET=yyy go run . token -email you@example.com
 | `SMTP_USER` | `hi@riffpad.ai` | SMTP login |
 | `SMTP_PASS` | — | SMTP password (required unless `--dry-run`) |
 | `FROM` | `SMTP_USER` | From address |
+| `FROM_NAME` | `Riffpad` | From display name shown in mail clients |
 | `UNSUBSCRIBE_SECRET` | — | HMAC secret shared with the relay (required) |
 | `UNSUBSCRIBE_BASE_URL` | `https://riffpad.ai/unsubscribe` | unsubscribe page |
 | `RIFFPAD_API_URL` | `https://api.riffpad.ai` | relay base URL |

--- a/scripts/email/main.go
+++ b/scripts/email/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"text/template"
 	"time"
 )
 
@@ -92,14 +93,15 @@ func cmdToken(args []string) {
 func cmdSend(args []string) {
 	fs := flag.NewFlagSet("send", flag.ExitOnError)
 	recipients := fs.String("recipients", "", "recipients CSV (email[,name][,date])")
-	template := fs.String("template", "", "email body template (text/template)")
+	bodyTemplate := fs.String("template", "", "email body template (text/template)")
+	htmlTemplate := fs.String("template-html", "", "optional HTML template (multipart/alternative email)")
 	subject := fs.String("subject", "", "email subject")
 	from := fs.String("from", "", "From address (default SMTP_USER)")
 	dryRun := fs.Bool("dry-run", false, "render only, do not send")
 	interval := fs.Duration("interval", 3*time.Second, "delay between sends")
 	fs.Parse(args)
 
-	if *recipients == "" || *template == "" || *subject == "" {
+	if *recipients == "" || *bodyTemplate == "" || *subject == "" {
 		fatalf("send: -recipients, -template and -subject are required")
 	}
 	if os.Getenv("UNSUBSCRIBE_SECRET") == "" {
@@ -128,18 +130,30 @@ func cmdSend(args []string) {
 		fmt.Fprintln(os.Stderr, "riffpad-email: WAITLIST_ADMIN_KEY not set, skipping opt-out check")
 	}
 
-	bodyTmpl, err := loadTemplate(*template)
+	bodyTmpl, err := loadTemplate(*bodyTemplate)
 	if err != nil {
 		fatalf("send: %v", err)
+	}
+	var htmlTmpl *template.Template
+	if *htmlTemplate != "" {
+		htmlTmpl, err = loadTemplate(*htmlTemplate)
+		if err != nil {
+			fatalf("send: %v", err)
+		}
 	}
 
 	var sender *smtpSender
 	if !*dryRun {
+		fromName := os.Getenv("FROM_NAME")
+		if fromName == "" {
+			fromName = "Riffpad"
+		}
 		sender = newSMTPSender(envOr("SMTP_HOST", "mail.spacemail.com"),
 			envOrInt("SMTP_PORT", 465),
 			envOr("SMTP_USER", "hi@riffpad.ai"),
 			os.Getenv("SMTP_PASS"),
-			*from)
+			*from,
+			fromName)
 		if sender.from == "" {
 			sender.from = sender.user
 		}
@@ -172,12 +186,24 @@ func cmdSend(args []string) {
 			failed++
 			continue
 		}
+		htmlBody := ""
+		if htmlTmpl != nil {
+			htmlBody, err = renderBodyHTML(htmlTmpl, r, u)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "  FAIL %s: %v\n", email, err)
+				failed++
+				continue
+			}
+		}
 		if *dryRun {
 			fmt.Printf("==> %s (%d/%d)\n%s\n\n", email, i+1, len(recs), body)
+			if htmlBody != "" {
+				fmt.Printf("--- html ---\n%s\n\n", htmlBody)
+			}
 			sent++
 			continue
 		}
-		if err := sender.send(email, *subject, body); err != nil {
+		if err := sender.send(email, *subject, body, htmlBody); err != nil {
 			fmt.Fprintf(os.Stderr, "  FAIL %s: %v\n", email, err)
 			failed++
 			continue

--- a/scripts/email/preview.html
+++ b/scripts/email/preview.html
@@ -1,0 +1,340 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Riffpad waitlist announcement — preview</title>
+  <script>
+    (function () {
+      var saved = null;
+      try { saved = localStorage.getItem("riffpad-email-theme"); } catch (e) {}
+      var dark = saved === "dark" || (saved !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+      document.documentElement.dataset.theme = dark ? "dark" : "light";
+    })();
+  </script>
+  <style>
+    :root {
+      --canvas: #e9e8e3;
+      --paper: #ffffff;
+      --ink: #191917;
+      --body: #46463f;
+      --mute: #73736a;
+      --hairline: rgba(25, 25, 23, 0.12);
+      --hairline-strong: rgba(25, 25, 23, 0.35);
+      --accent: #1a7f37;
+      --accent-ink: #ffffff;
+      --code-bg: #f4f3ee;
+      --code-border: rgba(25, 25, 23, 0.14);
+      --zh-bg: #fbfaf7;
+      --shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 12px 32px rgba(0, 0, 0, 0.08);
+    }
+    :root[data-theme="dark"] {
+      --canvas: #0b0b0c;
+      --paper: #121214;
+      --ink: #e8e6e3;
+      --body: #a8a8ad;
+      --mute: #7c7c82;
+      --hairline: rgba(255, 255, 255, 0.1);
+      --hairline-strong: rgba(255, 255, 255, 0.22);
+      --accent: #7ee787;
+      --accent-ink: #191917;
+      --code-bg: #1a1a1d;
+      --code-border: #2a2a2e;
+      --zh-bg: #17171a;
+      --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 16px 48px rgba(0, 0, 0, 0.45);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: var(--canvas);
+      color: var(--ink);
+      font-family: "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB",
+        "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+      -webkit-font-smoothing: antialiased;
+      padding: 40px 16px 64px;
+    }
+    .stage { max-width: 680px; margin: 0 auto; }
+
+    .toolbar {
+      display: flex; align-items: center; justify-content: space-between;
+      flex-wrap: wrap; gap: 8px;
+      font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase;
+      color: var(--mute); margin-bottom: 14px; font-family: ui-monospace,
+      SFMono-Regular, Menlo, Consolas, monospace;
+    }
+    .toolbar .tag { color: var(--accent); font-weight: 700; }
+    .toolbar-right { display: flex; align-items: center; gap: 14px; }
+    .theme-toggle { display: inline-flex; border: 1px solid var(--hairline-strong); }
+    .theme-toggle button {
+      border: 0; background: transparent; cursor: pointer; color: var(--mute);
+      font: inherit; letter-spacing: inherit; text-transform: inherit;
+      padding: 3px 8px;
+    }
+    .theme-toggle button.active { background: var(--accent); color: var(--accent-ink); }
+
+    .email {
+      background: var(--paper);
+      border: 1px solid var(--hairline);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+    .mail-head {
+      display: flex; align-items: center; gap: 10px;
+      padding: 22px 28px; border-bottom: 1px solid var(--hairline);
+    }
+    .mail-head svg { width: 26px; height: 26px; flex: none; }
+    .mail-head svg rect { fill: var(--accent); }
+    .wordmark {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 18px; font-weight: 700; letter-spacing: -0.02em;
+    }
+    .badge {
+      margin-left: auto; font-size: 10px; font-weight: 700;
+      letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent);
+      border: 1px solid currentColor; padding: 3px 7px;
+    }
+
+    .body { padding: 30px 28px 10px; }
+    .hero h1 { font-size: 24px; line-height: 1.25; letter-spacing: -0.01em; }
+    .hero p { margin-top: 10px; font-size: 14px; line-height: 1.7; color: var(--body); }
+
+    .features { margin-top: 24px; display: grid; gap: 14px; }
+    .feature { display: flex; gap: 12px; }
+    .f-icon {
+      flex: none; width: 18px; margin-top: 2px; color: var(--accent);
+      font-size: 12px; line-height: 1.6;
+    }
+    .feature h3 { font-size: 13px; letter-spacing: 0.02em; }
+    .feature p { margin-top: 3px; font-size: 13px; line-height: 1.6; color: var(--body); }
+
+    .install { margin-top: 26px; border: 1px solid var(--code-border); background: var(--code-bg); }
+    .install-head {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 9px 12px; border-bottom: 1px solid var(--code-border);
+      font-size: 10px; font-weight: 700; letter-spacing: 0.14em;
+      text-transform: uppercase; color: var(--mute);
+    }
+    .install-head button {
+      border: 0; background: transparent; cursor: pointer; color: var(--accent);
+      font: inherit; letter-spacing: inherit; text-transform: inherit;
+      font-weight: 700; padding: 2px 4px;
+    }
+    .install-head button:hover { text-decoration: underline; }
+    pre {
+      padding: 14px 12px; font-family: ui-monospace, SFMono-Regular, Menlo,
+      Consolas, monospace; font-size: 13px; line-height: 1.65; overflow-x: auto;
+      color: var(--ink); white-space: pre;
+    }
+    pre .c { color: var(--mute); }
+
+    .cta { display: flex; gap: 10px; margin-top: 26px; }
+    .btn {
+      display: inline-flex; align-items: center; justify-content: center;
+      padding: 11px 18px; font-size: 13px; font-weight: 700; text-decoration: none;
+      border: 1px solid transparent; transition: none;
+    }
+    .btn-primary { background: var(--accent); color: var(--accent-ink); }
+    .btn-ghost { border-color: var(--hairline-strong); color: var(--ink); }
+
+    .divider {
+      margin: 30px 0 24px; border: 0; border-top: 1px dashed var(--hairline-strong);
+    }
+    .zh-head {
+      font-size: 10px; font-weight: 700; letter-spacing: 0.14em;
+      text-transform: uppercase; color: var(--mute); margin-bottom: 16px;
+    }
+
+    .footer {
+      margin-top: 28px; padding: 18px 28px 22px; border-top: 1px solid var(--hairline);
+      font-size: 11px; line-height: 1.8; color: var(--mute);
+    }
+    .footer .links a { color: var(--mute); text-decoration: none; margin-right: 14px; }
+    .footer .links a:hover { color: var(--accent); text-decoration: underline; }
+    .footer .unsub { margin-top: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    .footer .unsub a { color: var(--accent); }
+    .footer .copy { margin-top: 8px; }
+  </style>
+</head>
+<body>
+  <div class="stage">
+    <div class="toolbar">
+      <span><span class="tag">preview</span> · riffpad waitlist announcement · 2026-08-09</span>
+      <span class="toolbar-right">
+        <span>subject: Riffpad is in beta</span>
+        <span class="theme-toggle">
+          <button type="button" data-theme-btn="light">light</button>
+          <button type="button" data-theme-btn="dark">dark</button>
+        </span>
+      </span>
+    </div>
+
+    <article class="email">
+      <header class="mail-head">
+        <svg viewBox="0 0 300 300" fill="none" aria-hidden="true">
+          <g transform="rotate(-90, 150, 150)">
+            <rect x="70" y="70" width="40" height="40" fill="#1a7f37" />
+            <rect x="130" y="70" width="40" height="40" fill="#1a7f37" />
+            <rect x="190" y="70" width="40" height="40" fill="#1a7f37" />
+            <rect x="70" y="130" width="100" height="40" fill="#1a7f37" />
+            <rect x="190" y="130" width="40" height="40" fill="#1a7f37" />
+            <rect x="70" y="190" width="160" height="40" fill="#1a7f37" />
+          </g>
+        </svg>
+        <span class="wordmark">riffpad</span>
+        <span class="badge">beta</span>
+      </header>
+
+      <div class="body">
+        <section class="hero">
+          <h1>Your AI coding agents, in your pocket.</h1>
+          <p>
+            Riffpad is now in beta — a tiny local daemon that bridges Claude
+            Code, Codex and Kimi Code to your phone. Watch long tasks run,
+            approve file changes, and send a new instruction without going
+            back to the desk.
+          </p>
+        </section>
+
+        <section class="features">
+          <div class="feature">
+            <span class="f-icon">■</span>
+            <div>
+              <h3>Watch long tasks run</h3>
+              <p>Session status, tool calls and file changes stream to your phone in real time.</p>
+            </div>
+          </div>
+          <div class="feature">
+            <span class="f-icon">■</span>
+            <div>
+              <h3>Approve from anywhere</h3>
+              <p>When the agent waits for permission, one tap on your phone keeps it moving.</p>
+            </div>
+          </div>
+          <div class="feature">
+            <span class="f-icon">■</span>
+            <div>
+              <h3>Local-first, end-to-end encrypted</h3>
+              <p>Code and API keys stay on your computer. The relay forwards ciphertext and keeps none of it.</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="install">
+          <div class="install-head">
+            <span>Quick start</span>
+            <button type="button" onclick="copyCmd('cmd')">copy</button>
+          </div>
+          <pre id="cmd">curl -fsSL https://riffpad.ai/install.sh | sh
+riffpad login
+riffpad pair
+riffpad run codex</pre>
+        </section>
+
+        <div class="cta">
+          <a class="btn btn-primary" href="https://app.riffpad.ai">Open the app</a>
+          <a class="btn btn-ghost" href="https://www.riffpad.ai/docs/guide/quickstart">Read the docs</a>
+        </div>
+
+        <hr class="divider" />
+
+        <section class="zh">
+          <div class="zh-head">中文版 · same content</div>
+
+          <div class="hero">
+            <h1>把你的 AI 编程 Agent 装进口袋</h1>
+            <p>
+              Riffpad 现在开放 Beta——一个本地 daemon，把 Claude Code、Codex、
+              Kimi Code 等 CLI agent 桥接到手机。躺在床上也能看长任务跑完、
+              审批文件变更、远程补一句新指令。
+            </p>
+          </div>
+
+          <div class="features">
+            <div class="feature">
+              <span class="f-icon">■</span>
+              <div>
+                <h3>实时查看任务进度</h3>
+                <p>会话状态、工具调用与文件变更实时同步到手机。</p>
+              </div>
+            </div>
+            <div class="feature">
+              <span class="f-icon">■</span>
+              <div>
+                <h3>随时随地一键审批</h3>
+                <p>agent 等待权限时，在手机上点一下就能继续。</p>
+              </div>
+            </div>
+            <div class="feature">
+              <span class="f-icon">■</span>
+              <div>
+                <h3>本地优先，端到端加密</h3>
+                <p>代码和 API key 只留在电脑上，云端只转发密文、不留存。</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="install">
+            <div class="install-head">
+              <span>快速开始</span>
+              <button type="button" onclick="copyCmd('cmd-zh')">copy</button>
+            </div>
+            <pre id="cmd-zh">curl -fsSL https://riffpad.ai/install.sh | sh
+riffpad login
+riffpad pair
+riffpad run codex</pre>
+          </div>
+
+          <div class="cta">
+            <a class="btn btn-primary" href="https://app.riffpad.ai">打开 App</a>
+            <a class="btn btn-ghost" href="https://www.riffpad.ai/docs/guide/quickstart">阅读文档</a>
+          </div>
+        </section>
+      </div>
+
+      <footer class="footer">
+        <div class="links">
+          <a href="https://www.riffpad.ai/docs/guide/quickstart">Docs</a>
+          <a href="https://discord.gg/CDNFTg2QyM">Discord</a>
+          <a href="https://app.riffpad.ai">App</a>
+        </div>
+        <p class="unsub">
+          You're receiving this because you joined the Riffpad waitlist.
+          <a href="#">Unsubscribe / 退订</a>
+        </p>
+        <p class="copy">© 2026 Riffpad · riffpad.ai</p>
+      </footer>
+    </article>
+  </div>
+
+  <script>
+    var currentTheme = document.documentElement.dataset.theme;
+    document.querySelectorAll("[data-theme-btn]").forEach(function (b) {
+      b.classList.toggle("active", b.dataset.themeBtn === currentTheme);
+      b.addEventListener("click", function () {
+        var theme = b.dataset.themeBtn;
+        document.documentElement.dataset.theme = theme;
+        try { localStorage.setItem("riffpad-email-theme", theme); } catch (e) {}
+        document.querySelectorAll("[data-theme-btn]").forEach(function (x) {
+          x.classList.toggle("active", x.dataset.themeBtn === theme);
+        });
+      });
+    });
+    window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function (e) {
+      try { if (localStorage.getItem("riffpad-email-theme")) return; } catch (err) {}
+      var theme = e.matches ? "dark" : "light";
+      document.documentElement.dataset.theme = theme;
+      document.querySelectorAll("[data-theme-btn]").forEach(function (x) {
+        x.classList.toggle("active", x.dataset.themeBtn === theme);
+      });
+    });
+    function copyCmd(id) {
+      const el = document.getElementById(id);
+      const btn = el.closest(".install").querySelector(".install-head button");
+      const text = el.innerText;
+      navigator.clipboard.writeText(text).then(() => {
+        btn.textContent = "copied ✓";
+        setTimeout(() => (btn.textContent = "copy"), 1200);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/scripts/email/sender.go
+++ b/scripts/email/sender.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"bytes"
+	"crypto/rand"
 	"crypto/tls"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
+	"mime"
 	"net"
 	"net/smtp"
 	"strings"
@@ -14,21 +19,27 @@ type smtpSender struct {
 	user     string
 	pass     string
 	from     string
+	fromName string
 	addr     string
 }
 
-func newSMTPSender(host string, port int, user, pass, from string) *smtpSender {
+func newSMTPSender(host string, port int, user, pass, from, fromName string) *smtpSender {
 	return &smtpSender{
-		host: host,
-		port: port,
-		user: user,
-		pass: pass,
-		from: from,
-		addr: net.JoinHostPort(host, fmt.Sprintf("%d", port)),
+		host:     host,
+		port:     port,
+		user:     user,
+		pass:     pass,
+		from:     from,
+		fromName: fromName,
+		addr:     net.JoinHostPort(host, fmt.Sprintf("%d", port)),
 	}
 }
 
-func (s *smtpSender) send(to, subject, body string) error {
+func (s *smtpSender) send(to, subject, plainText, htmlText string) error {
+	msg, err := s.buildMessage(to, subject, plainText, htmlText)
+	if err != nil {
+		return err
+	}
 	conn, err := tls.Dial("tcp", s.addr, &tls.Config{ServerName: s.host})
 	if err != nil {
 		return fmt.Errorf("tls dial: %w", err)
@@ -54,15 +65,70 @@ func (s *smtpSender) send(to, subject, body string) error {
 	if err != nil {
 		return fmt.Errorf("data: %w", err)
 	}
-	subject = strings.ReplaceAll(strings.ReplaceAll(subject, "\r", " "), "\n", " ")
-	msg := fmt.Sprintf(
-		"From: %s\r\nTo: %s\r\nSubject: %s\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n%s",
-		s.from, to, subject, body)
-	if _, err := w.Write([]byte(msg)); err != nil {
+	if _, err := w.Write(msg); err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
 	if err := w.Close(); err != nil {
 		return fmt.Errorf("close data: %w", err)
 	}
 	return c.Quit()
+}
+
+// buildMessage renders a MIME message: text/plain alone, or
+// multipart/alternative with a text/plain fallback plus the HTML part.
+// Both parts are base64-encoded so non-ASCII (Chinese) survives any relay.
+func (s *smtpSender) buildMessage(to, subject, plainText, htmlText string) ([]byte, error) {
+	subject = strings.ReplaceAll(strings.ReplaceAll(subject, "\r", " "), "\n", " ")
+	var b bytes.Buffer
+	fromHeader := s.from
+	if s.fromName != "" {
+		fromHeader = fmt.Sprintf("%s <%s>", mime.QEncoding.Encode("utf-8", s.fromName), s.from)
+	}
+	fmt.Fprintf(&b, "From: %s\r\nTo: %s\r\nSubject: %s\r\n", fromHeader, to, mime.QEncoding.Encode("utf-8", subject))
+	if htmlText == "" {
+		b.WriteString("MIME-Version: 1.0\r\n")
+		b.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
+		b.WriteString("Content-Transfer-Encoding: base64\r\n\r\n")
+		b.WriteString(base64Body(plainText))
+		b.WriteString("\r\n")
+		return b.Bytes(), nil
+	}
+	boundary, err := newBoundary()
+	if err != nil {
+		return nil, err
+	}
+	b.WriteString("MIME-Version: 1.0\r\n")
+	fmt.Fprintf(&b, "Content-Type: multipart/alternative; boundary=%q\r\n\r\n", boundary)
+	fmt.Fprintf(&b, "--%s\r\n", boundary)
+	b.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
+	b.WriteString("Content-Transfer-Encoding: base64\r\n\r\n")
+	b.WriteString(base64Body(plainText))
+	b.WriteString("\r\n\r\n")
+	fmt.Fprintf(&b, "--%s\r\n", boundary)
+	b.WriteString("Content-Type: text/html; charset=UTF-8\r\n")
+	b.WriteString("Content-Transfer-Encoding: base64\r\n\r\n")
+	b.WriteString(base64Body(htmlText))
+	b.WriteString("\r\n\r\n")
+	fmt.Fprintf(&b, "--%s--\r\n", boundary)
+	return b.Bytes(), nil
+}
+
+func newBoundary() (string, error) {
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return "riffpad-" + hex.EncodeToString(raw), nil
+}
+
+func base64Body(s string) string {
+	raw := base64.StdEncoding.EncodeToString([]byte(s))
+	var b strings.Builder
+	for len(raw) > 76 {
+		b.WriteString(raw[:76])
+		b.WriteString("\r\n")
+		raw = raw[76:]
+	}
+	b.WriteString(raw)
+	return b.String()
 }

--- a/scripts/email/sender_test.go
+++ b/scripts/email/sender_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildMessagePlainTextOnly(t *testing.T) {
+	s := newSMTPSender("mail.test", 465, "u@test", "p", "from@test", "Riffpad")
+	msg, err := s.buildMessage("to@test", "hello world", "plain body", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(msg)
+	if !strings.Contains(text, "Content-Type: text/plain; charset=UTF-8") {
+		t.Fatalf("missing plain content type:\n%s", text)
+	}
+	if strings.Contains(text, "multipart/alternative") {
+		t.Fatal("unexpected multipart for plain-only message")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(strings.Split(text, "\r\n\r\n")[1]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(decoded) != "plain body" {
+		t.Fatalf("unexpected body: %q", decoded)
+	}
+}
+
+func TestBuildMessageMultipartAlternative(t *testing.T) {
+	s := newSMTPSender("mail.test", 465, "u@test", "p", "from@test", "Riffpad")
+	plain := "纯文本兜底 with unsubscribe https://x/unsub"
+	html := "<html><body>中文 HTML <a href=\"https://x/unsub\">退订</a></body></html>"
+	msg, err := s.buildMessage("to@test", "Riffpad is in beta — 测试", plain, html)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(msg)
+	if !strings.Contains(text, "multipart/alternative; boundary=\"riffpad-") {
+		t.Fatalf("missing multipart header:\n%s", text)
+	}
+	if !strings.Contains(text, "Content-Type: text/plain; charset=UTF-8") ||
+		!strings.Contains(text, "Content-Type: text/html; charset=UTF-8") {
+		t.Fatalf("missing parts:\n%s", text)
+	}
+	// Decode and verify both parts survived round-trip.
+	parts := map[string]string{}
+	boundary := strings.Split(strings.Split(text, "boundary=\"")[1], "\"")[0]
+	chunks := strings.Split(text, "--"+boundary)
+	for _, chunk := range chunks {
+		chunk = strings.TrimPrefix(chunk, "\r\n")
+		headerEnd := strings.Index(chunk, "\r\n\r\n")
+		if headerEnd < 0 {
+			continue
+		}
+		var contentType string
+		for _, line := range strings.Split(chunk[:headerEnd], "\r\n") {
+			if strings.HasPrefix(line, "Content-Type: ") {
+				contentType = strings.TrimSpace(strings.TrimPrefix(line, "Content-Type: "))
+				break
+			}
+		}
+		if contentType != "" {
+			b64 := chunk[headerEnd+4:]
+			b64 = strings.TrimSuffix(strings.TrimSpace(b64), "--")
+			raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(b64))
+			if err != nil {
+				t.Fatalf("decode %s: %v", contentType, err)
+			}
+			parts[contentType] = string(raw)
+		}
+	}
+	if parts["text/plain; charset=UTF-8"] != plain {
+		t.Fatalf("plain mismatch: %q", parts["text/plain; charset=UTF-8"])
+	}
+	if parts["text/html; charset=UTF-8"] != html {
+		t.Fatalf("html mismatch: %q", parts["text/html; charset=UTF-8"])
+	}
+}
+
+func TestRenderBodyHTMLAppendsUnsubscribeFooter(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "body.html")
+	if err := os.WriteFile(path, []byte("<p>Hello {{.Email}}</p>"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tmpl, err := loadTemplate(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := "https://riffpad.ai/unsubscribe?email=a%40b.c&token=x"
+	body, err := renderBodyHTML(tmpl, recipient{Email: "a@b.c"}, u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(body, u) || !strings.Contains(body, "<p>Hello a@b.c</p>") {
+		t.Fatalf("html body incomplete: %s", body)
+	}
+}

--- a/scripts/email/template.go
+++ b/scripts/email/template.go
@@ -37,3 +37,22 @@ func renderBody(t *template.Template, r recipient, u string) (string, error) {
 	}
 	return body + "\n", nil
 }
+
+// renderBodyHTML renders an HTML email template. If the template forgot the
+// unsubscribe link, a minimal footer is appended so every message stays
+// compliant.
+func renderBodyHTML(t *template.Template, r recipient, u string) (string, error) {
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, map[string]string{
+		"Email":          r.Email,
+		"Name":           r.Name,
+		"UnsubscribeURL": u,
+	}); err != nil {
+		return "", err
+	}
+	body := strings.TrimRight(buf.String(), "\n")
+	if !strings.Contains(body, u) {
+		body += `<p style="font-size:11px;color:#73736a;">Unsubscribe / 退订: <a href="` + u + `" style="color:#1a7f37;">` + u + `</a></p>`
+	}
+	return body + "\n", nil
+}

--- a/scripts/email/templates/beta-announcement.html
+++ b/scripts/email/templates/beta-announcement.html
@@ -1,0 +1,214 @@
+<!--
+  Riffpad waitlist announcement — HTML part.
+  Email-client-safe: tables + inline styles only, 600px, no JS.
+  Variables: {{.Email}}, {{.Name}}, {{.UnsubscribeURL}}.
+-->
+<div style="background-color:#e9e8e3;padding:24px 12px;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0 auto;max-width:600px;">
+    <tr>
+      <td style="background:#ffffff;border:1px solid #ddddd6;font-family:'Helvetica Neue',Helvetica,Arial,'PingFang SC','Hiragino Sans GB','Microsoft YaHei',sans-serif;">
+        <!-- Header -->
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td style="padding:22px 28px;border-bottom:1px solid #e4e4dd;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td width="44" style="vertical-align:middle;">
+                    <img src="https://riffpad.ai/logo-email.png" width="44" height="44" alt="Riffpad" style="display:block;border:0;" />
+                  </td>
+                  <td style="vertical-align:middle;padding-left:10px;white-space:nowrap;">
+                    <span style="font-family:Menlo,Consolas,monospace;font-size:18px;font-weight:700;color:#191917;letter-spacing:-0.02em;">riffpad</span>
+                  </td>
+                  <td style="text-align:right;vertical-align:middle;white-space:nowrap;">
+                    <span style="font-size:10px;font-weight:700;letter-spacing:0.14em;text-transform:uppercase;color:#1a7f37;border:1px solid #1a7f37;padding:3px 7px;">beta</span>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+
+        <!-- Body -->
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td style="padding:30px 28px 10px;">
+              <h1 style="margin:0;font-size:24px;line-height:1.25;color:#191917;letter-spacing:-0.01em;">Your AI coding agents, in your pocket.</h1>
+              <p style="margin:10px 0 0;font-size:14px;line-height:1.7;color:#46463f;">
+                Riffpad is now in beta — a tiny local daemon that bridges Claude
+                Code, Codex and Kimi Code to your phone. Watch long tasks run,
+                approve file changes, and send a new instruction without going
+                back to the desk.
+              </p>
+
+              <!-- Features -->
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:24px;">
+                <tr>
+                  <td style="padding:0 0 14px;">
+                    <table role="presentation" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="vertical-align:top;width:18px;"><span style="color:#1a7f37;font-size:12px;line-height:1.6;">■</span></td>
+                        <td style="padding-left:12px;font-size:13px;line-height:1.6;color:#46463f;">
+                          <strong style="display:block;font-size:13px;color:#191917;">Watch long tasks run</strong>
+                          Session status, tool calls and file changes stream to your phone in real time.
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:0 0 14px;">
+                    <table role="presentation" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="vertical-align:top;width:18px;"><span style="color:#1a7f37;font-size:12px;line-height:1.6;">■</span></td>
+                        <td style="padding-left:12px;font-size:13px;line-height:1.6;color:#46463f;">
+                          <strong style="display:block;font-size:13px;color:#191917;">Approve from anywhere</strong>
+                          When the agent waits for permission, one tap on your phone keeps it moving.
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:0;">
+                    <table role="presentation" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="vertical-align:top;width:18px;"><span style="color:#1a7f37;font-size:12px;line-height:1.6;">■</span></td>
+                        <td style="padding-left:12px;font-size:13px;line-height:1.6;color:#46463f;">
+                          <strong style="display:block;font-size:13px;color:#191917;">Local-first, end-to-end encrypted</strong>
+                          Code and API keys stay on your computer. The relay forwards ciphertext and keeps none of it.
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- Quick start -->
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:26px;border:1px solid #d9d8d2;background:#f4f3ee;">
+                <tr>
+                  <td style="padding:9px 12px;border-bottom:1px solid #d9d8d2;font-size:10px;font-weight:700;letter-spacing:0.14em;text-transform:uppercase;color:#73736a;">Quick start</td>
+                </tr>
+                <tr>
+                  <td style="padding:14px 12px;font-family:Menlo,Consolas,monospace;font-size:13px;line-height:1.65;color:#191917;white-space:pre;">curl -fsSL https://riffpad.ai/install.sh | sh
+riffpad login
+riffpad pair
+riffpad run codex</td>
+                </tr>
+              </table>
+
+              <!-- CTA -->
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin-top:26px;">
+                <tr>
+                  <td>
+                    <a href="https://app.riffpad.ai" style="display:inline-block;padding:11px 18px;background:#1a7f37;color:#ffffff;text-decoration:none;font-size:13px;font-weight:700;">Open the app</a>
+                  </td>
+                  <td style="padding-left:10px;">
+                    <a href="https://www.riffpad.ai/docs/guide/quickstart" style="display:inline-block;padding:10px 17px;border:1px solid #9b9a92;color:#191917;text-decoration:none;font-size:13px;font-weight:700;">Read the docs</a>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- Divider -->
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:30px 0 24px;">
+                <tr>
+                  <td style="border-top:1px dashed #b4b3ab;font-size:0;line-height:0;">&nbsp;</td>
+                </tr>
+              </table>
+
+              <!-- Chinese section -->
+              <p style="margin:0 0 16px;font-size:10px;font-weight:700;letter-spacing:0.14em;text-transform:uppercase;color:#73736a;">中文版 · same content</p>
+
+              <h1 style="margin:0;font-size:24px;line-height:1.25;color:#191917;letter-spacing:-0.01em;">把你的 AI 编程 Agent 装进口袋</h1>
+              <p style="margin:10px 0 0;font-size:14px;line-height:1.7;color:#46463f;">
+                Riffpad 现在开放 Beta——一个本地 daemon，把 Claude Code、Codex、
+                Kimi Code 等 CLI agent 桥接到手机。躺在床上也能看长任务跑完、
+                审批文件变更、远程补一句新指令。
+              </p>
+
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:24px;">
+                <tr>
+                  <td style="padding:0 0 14px;">
+                    <table role="presentation" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="vertical-align:top;width:18px;"><span style="color:#1a7f37;font-size:12px;line-height:1.6;">■</span></td>
+                        <td style="padding-left:12px;font-size:13px;line-height:1.6;color:#46463f;">
+                          <strong style="display:block;font-size:13px;color:#191917;">实时查看任务进度</strong>
+                          会话状态、工具调用与文件变更实时同步到手机。
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:0 0 14px;">
+                    <table role="presentation" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="vertical-align:top;width:18px;"><span style="color:#1a7f37;font-size:12px;line-height:1.6;">■</span></td>
+                        <td style="padding-left:12px;font-size:13px;line-height:1.6;color:#46463f;">
+                          <strong style="display:block;font-size:13px;color:#191917;">随时随地一键审批</strong>
+                          agent 等待权限时，在手机上点一下就能继续。
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:0;">
+                    <table role="presentation" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="vertical-align:top;width:18px;"><span style="color:#1a7f37;font-size:12px;line-height:1.6;">■</span></td>
+                        <td style="padding-left:12px;font-size:13px;line-height:1.6;color:#46463f;">
+                          <strong style="display:block;font-size:13px;color:#191917;">本地优先，端到端加密</strong>
+                          代码和 API key 只留在电脑上，云端只转发密文、不留存。
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:26px;border:1px solid #d9d8d2;background:#f4f3ee;">
+                <tr>
+                  <td style="padding:9px 12px;border-bottom:1px solid #d9d8d2;font-size:10px;font-weight:700;letter-spacing:0.14em;text-transform:uppercase;color:#73736a;">快速开始</td>
+                </tr>
+                <tr>
+                  <td style="padding:14px 12px;font-family:Menlo,Consolas,monospace;font-size:13px;line-height:1.65;color:#191917;white-space:pre;">curl -fsSL https://riffpad.ai/install.sh | sh
+riffpad login
+riffpad pair
+riffpad run codex</td>
+                </tr>
+              </table>
+
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin-top:26px;">
+                <tr>
+                  <td>
+                    <a href="https://app.riffpad.ai" style="display:inline-block;padding:11px 18px;background:#1a7f37;color:#ffffff;text-decoration:none;font-size:13px;font-weight:700;">打开 App</a>
+                  </td>
+                  <td style="padding-left:10px;">
+                    <a href="https://www.riffpad.ai/docs/guide/quickstart" style="display:inline-block;padding:10px 17px;border:1px solid #9b9a92;color:#191917;text-decoration:none;font-size:13px;font-weight:700;">阅读文档</a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+
+        <!-- Footer -->
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td style="padding:18px 28px 22px;border-top:1px solid #e4e4dd;font-size:11px;line-height:1.8;color:#73736a;">
+              <a href="https://www.riffpad.ai/docs/guide/quickstart" style="color:#73736a;text-decoration:none;margin-right:14px;">Docs</a>
+              <a href="https://discord.gg/CDNFTg2QyM" style="color:#73736a;text-decoration:none;margin-right:14px;">Discord</a>
+              <a href="https://app.riffpad.ai" style="color:#73736a;text-decoration:none;">App</a>
+              <p style="margin:12px 0 0;font-family:Menlo,Consolas,monospace;">
+                You're receiving this because you joined the Riffpad waitlist.
+                <a href="{{.UnsubscribeURL}}" style="color:#1a7f37;">Unsubscribe / 退订</a>
+              </p>
+              <p style="margin:8px 0 0;">© 2026 Riffpad · riffpad.ai</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</div>

--- a/scripts/email/templates/beta-announcement.txt
+++ b/scripts/email/templates/beta-announcement.txt
@@ -1,0 +1,54 @@
+Hi{{if .Name}} {{.Name}}{{end}},
+
+Riffpad is now in beta — your AI coding agents, in your pocket.
+
+You joined the waitlist, so here's the short version: Riffpad is a tiny
+local daemon that bridges Claude Code, Codex and Kimi Code to your phone.
+Watch long tasks run, approve file changes, and send a new instruction
+without going back to the desk.
+
+Local-first and end-to-end encrypted:
+  • your code and API keys stay on your computer
+  • the relay only forwards ciphertext, and keeps none of it
+  • the phone is read-only by default — every approve/steer is your tap
+
+Try it in four lines:
+
+  curl -fsSL https://riffpad.ai/install.sh | sh
+  riffpad login
+  riffpad pair
+  riffpad run codex
+
+Then open https://app.riffpad.ai and enter the pairing code from your
+terminal. Docs: https://www.riffpad.ai/docs/guide/quickstart
+Questions or feedback? Say hi on Discord: https://discord.gg/CDNFTg2QyM
+
+—
+
+Riffpad 现在开放 Beta 了——把你的 AI 编程 agent 装进口袋。
+
+你之前加入了 waitlist，所以这封邮件直接说重点：Riffpad 是一个本地
+daemon，把 Claude Code、Codex、Kimi Code 等 CLI agent 桥接到手机。
+躺在床上也能看长任务跑完、审批文件变更、远程补一句新指令。
+
+本地优先 + 端到端加密：
+  • 代码和 API key 只留在你的电脑上
+  • 云端只转发密文，且不留存任何内容
+  • 手机默认只读，每次同意/转向都是你亲手点的
+
+四步开始：
+
+  curl -fsSL https://riffpad.ai/install.sh | sh
+  riffpad login
+  riffpad pair
+  riffpad run codex
+
+然后在 https://app.riffpad.ai 输入终端里的配对码。
+文档：https://www.riffpad.ai/docs/guide/quickstart
+有问题或反馈？来 Discord 找我们：https://discord.gg/CDNFTg2QyM
+
+Best,
+The Riffpad team
+
+You're receiving this because you joined the Riffpad waitlist.
+Unsubscribe / 退订：{{.UnsubscribeURL}}


### PR DESCRIPTION
Closes #222

## 改动
- 发送器支持 `-template-html`：multipart/alternative（HTML + 纯文本兜底），base64 编码，单测覆盖双段往返
- `FROM_NAME`（默认 Riffpad）作为发件人显示名
- `templates/beta-announcement.html`：600px table + inline CSS，手机端头部 nowrap、特性图标 `■`
- `preview.html` 预览页（深/浅色 + 中英同版式）
- gitignore 忽略 `scripts/email/*.csv`

## 验证
- [x] go test ./... 通过
- [x] 测试邮件确认发件人/手机端排版/图标
- [ ] 正式 20 封发送（进行中）