### PR TITLE
chore(license): Apache-2.0 default + BSL 1.1 for apps/relay

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,45 @@
+Copyright (c) 2026 Liu Zhening.
+
+Riffpad — Licensing Notice
+==========================
+
+This repository (https://github.com/riffpad/riffpad) ships multiple components
+under different licenses. Unless a subdirectory contains its own LICENSE file
+that overrides this notice, the default license below applies.
+
+
+Default license: Apache License 2.0
+-----------------------------------
+Applies to the entire repository EXCEPT the component listed under "Exception"
+below. Components under Apache-2.0:
+
+  apps/daemon         CLI / host daemon              Apache-2.0
+  apps/client-beta    web & mobile client            Apache-2.0
+  apps/landing        marketing site                 Apache-2.0
+  apps/docs           documentation site             Apache-2.0
+  apps/mobile         mobile shell                   Apache-2.0
+  packages/protocol   shared protocol library        Apache-2.0
+  packages/webui      embedded web UI assets         Apache-2.0
+  scripts/            tooling (installers, email)    Apache-2.0
+  infra/              deployment configuration       Apache-2.0
+
+See ./LICENSE for the full text.
+
+
+Exception: Business Source License 1.1
+---------------------------------------
+  apps/relay          the relay server               BSL 1.1
+
+Source-available. Non-production use and the Additional Use Grant (personal,
+evaluation, and internal business use, including self-hosting) are permitted;
+offering it as a hosted/managed relay service to third parties is not.
+On the Change Date (2030-08-09) it automatically converts to Apache-2.0.
+See apps/relay/LICENSE for full terms.
+
+
+Why the split
+-------------
+The CLI and clients are open source (Apache-2.0) for transparency and
+community contribution. The relay server that powers the hosted service at
+app.riffpad.ai is under BSL to protect that service while remaining
+source-available for review.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Watch, approve, and steer Claude Code, Codex, and other AI coding CLIs from your
 [![GitHub stars](https://img.shields.io/github/stars/riffpad/riffpad?style=flat&color=1a7f37)](https://github.com/riffpad/riffpad/stargazers)
 [![Docs](https://img.shields.io/badge/docs-riffpad.ai-1a7f37)](https://www.riffpad.ai/docs/guide/quickstart)
 [![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/CDNFTg2QyM)
+[![License](https://img.shields.io/badge/license-Apache--2.0%20%7C%20relay%20BSL-1a7f37)](LICENSE)
 
 [Website](https://riffpad.ai) · [Documentation](https://www.riffpad.ai/docs/guide/quickstart) · [Discord community](https://discord.gg/CDNFTg2QyM) · [App](https://app.riffpad.ai)
 
@@ -117,3 +118,17 @@ Questions, ideas, or show-and-tell? Join us:
 - [Discord](https://discord.gg/CDNFTg2QyM) — the community hangout
 - [GitHub Issues](https://github.com/riffpad/riffpad/issues) — bugs and feature requests
 - [Documentation](https://www.riffpad.ai/docs/guide/quickstart) — install, pairing, security model
+
+## License
+
+Riffpad is **Apache-2.0** by default — the CLI (`apps/daemon`), clients
+(`apps/client-beta`, `apps/mobile`), landing/docs, and the shared `packages/`
+libraries all use it. See the [LICENSE](LICENSE) file.
+
+The relay server (`apps/relay`) is under **Business Source License 1.1** —
+source-available, with personal and internal use permitted (including
+self-hosting); it converts to Apache-2.0 on 2030-08-09. See
+[`apps/relay/LICENSE`](apps/relay/LICENSE). A full breakdown lives in
+[`NOTICE`](NOTICE).
+
+Copyright (c) 2026 Liu Zhening.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,6 +15,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/riffpad/riffpad?style=flat&color=1a7f37)](https://github.com/riffpad/riffpad/stargazers)
 [![Docs](https://img.shields.io/badge/docs-riffpad.ai-1a7f37)](https://www.riffpad.ai/docs/guide/quickstart)
 [![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/CDNFTg2QyM)
+[![License](https://img.shields.io/badge/license-Apache--2.0%20%7C%20relay%20BSL-1a7f37)](LICENSE)
 
 [官网](https://riffpad.ai) · [文档](https://www.riffpad.ai/docs/guide/quickstart) · [Discord 社区](https://discord.gg/CDNFTg2QyM) · [App](https://app.riffpad.ai)
 
@@ -107,3 +108,16 @@ CLI 支持中英文，自动跟随系统语言，可用 `riffpad --lang zh` / `r
 - [Discord](https://discord.gg/CDNFTg2QyM) — 社区讨论
 - [GitHub Issues](https://github.com/riffpad/riffpad/issues) — 反馈 bug 和功能建议
 - [文档](https://www.riffpad.ai/docs/guide/quickstart) — 安装、配对、安全模型
+
+## 开源协议
+
+Riffpad 默认采用 **Apache-2.0**——CLI（`apps/daemon`）、各客户端
+（`apps/client-beta`、`apps/mobile`）、官网/文档站以及共享的 `packages/`
+库都是。详见 [LICENSE](LICENSE)。
+
+relay 服务（`apps/relay`）采用 **Business Source License 1.1**——
+源码公开，允许个人和内部使用（含自部署）；2030-08-09 起自动转为
+Apache-2.0。详见 [`apps/relay/LICENSE`](apps/relay/LICENSE)。完整的协议
+划分见 [`NOTICE`](NOTICE)。
+
+Copyright (c) 2026 Liu Zhening.

--- a/apps/client-beta/package.json
+++ b/apps/client-beta/package.json
@@ -1,5 +1,6 @@
 {
   "name": "client-beta",
+  "license": "Apache-2.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "docs",
+  "license": "Apache-2.0",
   "version": "0.1.0",
   "private": true,
   "packageManager": "pnpm@9.0.0",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,5 +1,6 @@
 {
   "name": "landing",
+  "license": "Apache-2.0",
   "version": "0.1.0",
   "private": true,
   "packageManager": "pnpm@9.0.0",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,5 +1,6 @@
 {
   "name": "mobile",
+  "license": "Apache-2.0",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/apps/relay/LICENSE
+++ b/apps/relay/LICENSE
@@ -1,0 +1,72 @@
+License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+Parameters
+
+Licensor:             Liu Zhening
+Licensed Work:        The riffpad relay server source code, comprising the
+                      contents of the apps/relay directory of the riffpad
+                      repository (https://github.com/riffpad/riffpad).
+Additional Use Grant: You may use the Licensed Work for personal, evaluation,
+                      and internal business purposes, including running your
+                      own instance for yourself or within your organization,
+                      provided that You do not offer the Licensed Work — or
+                      any service substantially built on it — to third parties
+                      as a hosted, managed, or multi-tenant relay service that
+                      competes with the Licensor's offering.
+
+                      Offering the Licensed Work to third parties on a hosted
+                      or managed basis is a "competitive offering" and is not
+                      permitted under this Grant. Use solely within Your own
+                      organization (including affiliates under common control)
+                      is not competitive.
+Change Date:          2030-08-09
+Change License:       Apache License 2.0
+
+For information about alternative licensing arrangements for the Licensed Work,
+please contact the riffpad maintainers at https://github.com/riffpad/riffpad.
+
+Notice
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS, IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "riffpad",
+  "license": "Apache-2.0",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## What
- **Apache-2.0** as the default repo license (`LICENSE`)
- **BSL 1.1** for `apps/relay` — Licensor Liu Zhening, Change Date 2030-08-09 → Apache-2.0; personal/internal use permitted (`apps/relay/LICENSE`)
- `NOTICE` with per-component breakdown + copyright
- `"license": "Apache-2.0"` on all Apache `package.json`
- README (en/zh) license badge + License section

## Why
The repo had no license (= "all rights reserved"). Making it explicit unblocks fork/contribution/integration. CLI/clients open under Apache-2.0 for transparency & community; the relay stays under BSL to protect the hosted service (`app.riffpad.ai`) while remaining source-available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)