### PR TITLE
feat(daemon): Claude 前台 TUI（PTY 桥 + per-session hooks）(#230)

### DIFF
--- a/apps/daemon/cmd/riffpad/console_unix.go
+++ b/apps/daemon/cmd/riffpad/console_unix.go
@@ -1,0 +1,141 @@
+//go:build !windows
+
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"golang.org/x/term"
+)
+
+// attachConsoleTUI bridges the user's terminal to the daemon-hosted
+// interactive PTY (Claude foreground mode). Raw mode forwards keystrokes,
+// window resizes are propagated, and Ctrl-C reaches the vendor TUI. When the
+// vendor process exits (or the console disconnects) the daemon session is
+// closed, matching the no-silent-hosting convention.
+func attachConsoleTUI(base, sessionID string) error {
+	fmt.Println("正在启动 Claude TUI（会话已托管到 daemon）…")
+	wsURL := strings.Replace(base, "http://", "ws://", 1) +
+		"/api/sessions/" + sessionID + "/pty"
+	if tok := localToken(); tok != "" {
+		wsURL += "?token=" + url.QueryEscape(tok)
+	}
+	var conn *websocket.Conn
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+		if err == nil {
+			conn = c
+			break
+		}
+		if time.Now().After(deadline) {
+			// Session may be left running headless if the console never
+			// attached; close it so we never silently host in the background.
+			if resp, stopErr := daemonDo(nil, http.MethodPost, base+"/api/sessions/"+sessionID+"/stop", nil); stopErr == nil {
+				_ = resp.Body.Close()
+			}
+			return fmt.Errorf("连接会话 PTY 失败: %w", err)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	defer conn.Close()
+
+	fd := int(os.Stdin.Fd())
+	oldState, err := term.MakeRaw(fd)
+	if err != nil {
+		return fmt.Errorf("raw terminal: %w", err)
+	}
+	defer term.Restore(fd, oldState)
+
+	resize := func() {
+		if w, h, err := term.GetSize(fd); err == nil && w > 0 && h > 0 {
+			_ = conn.WriteJSON(map[string]any{
+				"resize": map[string]uint16{"cols": uint16(w), "rows": uint16(h)},
+			})
+		}
+	}
+	resize()
+
+	winch := make(chan os.Signal, 1)
+	signal.Notify(winch, syscall.SIGWINCH)
+	defer signal.Stop(winch)
+	go func() {
+		for range winch {
+			resize()
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			var msg struct {
+				Out  string `json:"out"`
+				Exit *int   `json:"exit"`
+			}
+			if err := conn.ReadJSON(&msg); err != nil {
+				return
+			}
+			if msg.Out != "" {
+				if b, err := base64.StdEncoding.DecodeString(msg.Out); err == nil {
+					_, _ = os.Stdout.Write(b)
+				}
+			}
+			if msg.Exit != nil {
+				return
+			}
+		}
+	}()
+
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := os.Stdin.Read(buf)
+			if n > 0 {
+				_ = conn.WriteJSON(map[string]any{
+					"in": base64.StdEncoding.EncodeToString(buf[:n]),
+				})
+			}
+			if err != nil {
+				_ = conn.Close()
+				return
+			}
+		}
+	}()
+
+	// Lease heartbeat so a dead CLI (SIGKILL/panic) lets the daemon close the
+	// session instead of leaving a ghost.
+	hbStop := make(chan struct{})
+	defer close(hbStop)
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if resp, err := daemonDo(nil, http.MethodPost, base+"/api/sessions/"+sessionID+"/heartbeat", nil); err == nil {
+					_ = resp.Body.Close()
+				}
+			case <-hbStop:
+				return
+			}
+		}
+	}()
+
+	<-done
+	_ = term.Restore(fd, oldState)
+	if resp, err := daemonDo(nil, http.MethodPost, base+"/api/sessions/"+sessionID+"/stop", nil); err == nil {
+		_ = resp.Body.Close()
+	}
+	fmt.Printf("Claude TUI 已退出，会话 %s 已关闭。\n", sessionID)
+	return nil
+}

--- a/apps/daemon/cmd/riffpad/console_windows.go
+++ b/apps/daemon/cmd/riffpad/console_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package main
+
+import "fmt"
+
+// attachConsoleTUI is unavailable on Windows (creack/pty is unsupported);
+// runCmd falls back to headless hosting before ever calling this.
+func attachConsoleTUI(base, sessionID string) error {
+	return fmt.Errorf("前台 TUI 暂不支持 Windows")
+}

--- a/apps/daemon/cmd/riffpad/main.go
+++ b/apps/daemon/cmd/riffpad/main.go
@@ -817,6 +817,13 @@ func runCmd(args []string, base string) error {
 	if data.CLI == "codex" {
 		return attachCodexTUI(base, data.ID)
 	}
+	if data.CLI == "claude" {
+		if runtime.GOOS == "windows" {
+			fmt.Println(t.T("session_url", data.ID, data.URL))
+			return nil
+		}
+		return attachConsoleTUI(base, data.ID)
+	}
 	fmt.Println(t.T("session_url", data.ID, data.URL))
 	return nil
 }

--- a/apps/daemon/go.mod
+++ b/apps/daemon/go.mod
@@ -12,6 +12,7 @@ require (
 )
 
 require (
+	github.com/creack/pty v1.1.24 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	rsc.io/qr v0.2.0 // indirect
 )

--- a/apps/daemon/go.sum
+++ b/apps/daemon/go.sum
@@ -1,3 +1,5 @@
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/apps/daemon/internal/adapter/adapter.go
+++ b/apps/daemon/internal/adapter/adapter.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"io"
 
 	"github.com/riffpad/riffpad/packages/protocol"
 )
@@ -16,6 +17,21 @@ type Session interface {
 	SendPrompt(text string) error
 	Alive() bool
 	Stop() error
+}
+
+// TerminalSession is implemented by adapters that expose an interactive PTY
+// (e.g. Claude foreground mode). The daemon uses it to bridge the vendor TUI
+// to a local CLI console over WebSocket.
+type TerminalSession interface {
+	AttachPTY() (Terminal, error)
+}
+
+// Terminal is one console attached to a session PTY. Read blocks until the
+// vendor process writes output; Write sends input; Resize propagates the
+// local window size; Close detaches this console (the process keeps running).
+type Terminal interface {
+	io.ReadWriteCloser
+	Resize(cols, rows uint16) error
 }
 
 // CreateRequest describes a session to start.

--- a/apps/daemon/internal/claude/claude.go
+++ b/apps/daemon/internal/claude/claude.go
@@ -27,6 +27,13 @@ type pendingTool struct {
 	input map[string]any
 }
 
+// ptyTerm is one console attached to the interactive TUI. The type is
+// platform-neutral; the PTY-backed methods live in tui_unix.go.
+type ptyTerm struct {
+	c  *Claude
+	ch chan []byte
+}
+
 // approvalTimeout bounds how long a permission prompt waits for a viewer
 // decision before defaulting to deny, mirroring the attach hook path.
 // A var so tests can shrink it.
@@ -46,16 +53,19 @@ type Claude struct {
 
 	cmd    *exec.Cmd
 	stdin  io.WriteCloser
+	pty    *os.File
 	events chan protocol.Event
 	stopCh chan struct{}
 	doneCh chan struct{}
 
 	mu               sync.Mutex
+	interactive      bool
 	ctx              context.Context
 	launched         bool
 	exited           bool
 	pendingTools     map[string]pendingTool
 	pendingApprovals map[string]chan string
+	ptySubs          map[*ptyTerm]struct{}
 }
 
 // New creates a Claude Code session adapter.
@@ -78,6 +88,8 @@ func New(req adapter.CreateRequest) *Claude {
 		doneCh:           make(chan struct{}),
 		pendingTools:     make(map[string]pendingTool),
 		pendingApprovals: make(map[string]chan string),
+		interactive:      true,
+		ptySubs:          make(map[*ptyTerm]struct{}),
 	}
 }
 
@@ -94,6 +106,11 @@ func (c *Claude) Start(ctx context.Context) error {
 	c.mu.Lock()
 	c.ctx = ctx
 	c.mu.Unlock()
+	if c.interactive {
+		// Interactive TUI must spawn immediately even without an initial
+		// prompt (unlike headless `claude -p`, which exits on empty input).
+		return c.ensureStarted()
+	}
 	if c.prompt == "" {
 		return nil
 	}
@@ -121,6 +138,13 @@ func (c *Claude) ensureStarted() error {
 }
 
 func (c *Claude) spawn(ctx context.Context) error {
+	if c.interactive {
+		if err := c.spawnInteractive(ctx); err == nil {
+			return nil
+		} else {
+			log.Printf("claude[%s] interactive spawn failed (%v); falling back to headless", c.id, err)
+		}
+	}
 	if err := c.writeSettings(); err != nil {
 		return fmt.Errorf("write settings: %w", err)
 	}
@@ -217,6 +241,9 @@ func (c *Claude) Stop() error {
 	if c.cmd != nil && c.cmd.Process != nil {
 		_ = c.cmd.Process.Kill()
 	}
+	if c.pty != nil {
+		_ = c.pty.Close()
+	}
 	<-c.doneCh
 	return nil
 }
@@ -259,6 +286,12 @@ func (c *Claude) SendPrompt(text string) error {
 	// Mirror codex/kimi: echo the user's message back as an event so the
 	// phone client renders it (the daemon itself never sees the text again).
 	_ = c.emit(protocol.EventUserMessage, protocol.AgentMessagePayload{Text: text})
+	if c.interactive && c.pty != nil {
+		if _, err := fmt.Fprintf(c.pty, "%s\r", text); err != nil {
+			return err
+		}
+		return nil
+	}
 	msg := map[string]any{
 		"type": "user",
 		"message": map[string]any{
@@ -294,21 +327,23 @@ func (c *Claude) writeSettings() error {
 	settings := map[string]any{"hooks": map[string]any{}}
 	hooks := map[string]any{}
 	if c.hookBase != "" {
-		hookURL := c.hookBase + "/hooks/claude/notification?session=" + c.id
-		if c.hookToken != "" {
-			hookURL += "&token=" + url.QueryEscape(c.hookToken)
-		}
-		hooks["Notification"] = []any{
-			map[string]any{
-				"matcher": "",
-				"hooks": []any{
-					map[string]any{
-						"type":    "http",
-						"url":     hookURL,
-						"timeout": 10,
+		for event, spec := range c.hookSpecs() {
+			hookURL := c.hookBase + "/hooks/claude/" + spec.path + "?session=" + c.id
+			if c.hookToken != "" {
+				hookURL += "&token=" + url.QueryEscape(c.hookToken)
+			}
+			hooks[event] = []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{
+							"type":    "http",
+							"url":     hookURL,
+							"timeout": spec.timeout,
+						},
 					},
 				},
-			},
+			}
 		}
 	}
 	if len(hooks) > 0 {
@@ -319,6 +354,31 @@ func (c *Claude) writeSettings() error {
 		return err
 	}
 	return os.WriteFile(c.settingsPath, data, 0o600)
+}
+
+type hookSpec struct {
+	path    string // daemon route suffix (kebab-case)
+	timeout int    // seconds
+}
+
+// hookSpecs returns the Claude hooks to register, keyed by the event name
+// Claude expects in settings.json. The interactive TUI needs the full set
+// (structured events + permissions flow through hooks); headless
+// stream-json mode only needs Notification.
+func (c *Claude) hookSpecs() map[string]hookSpec {
+	if !c.interactive {
+		return map[string]hookSpec{"Notification": {path: "notification", timeout: 10}}
+	}
+	return map[string]hookSpec{
+		"SessionStart":      {path: "session-start", timeout: 10},
+		"SessionEnd":        {path: "session-end", timeout: 10},
+		"UserPromptSubmit":  {path: "user-prompt-submit", timeout: 30},
+		"MessageDisplay":    {path: "message-display", timeout: 10},
+		"PreToolUse":        {path: "pre-tool-use", timeout: 10},
+		"PostToolUse":       {path: "post-tool-use", timeout: 10},
+		"PermissionRequest": {path: "permission", timeout: 600},
+		"Notification":      {path: "notification", timeout: 10},
+	}
 }
 
 func (c *Claude) readLoop(r io.Reader) {

--- a/apps/daemon/internal/claude/claude_test.go
+++ b/apps/daemon/internal/claude/claude_test.go
@@ -191,6 +191,62 @@ func TestWriteSettingsHookShape(t *testing.T) {
 	}
 }
 
+func TestWriteSettingsInteractiveRegistersAllHooks(t *testing.T) {
+	c := New(adapter.CreateRequest{
+		ID:        "s1",
+		DataDir:   t.TempDir(),
+		HookBase:  "http://127.0.0.1:8787",
+		HookToken: "tok",
+	})
+	if !c.interactive {
+		t.Fatal("expected interactive mode by default")
+	}
+	if err := c.writeSettings(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(c.settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var s struct {
+		Hooks map[string][]struct {
+			Matcher string           `json:"matcher"`
+			Hooks   []map[string]any `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &s); err != nil {
+		t.Fatalf("settings not valid JSON: %v\n%s", err, data)
+	}
+	want := []string{
+		"SessionStart", "SessionEnd", "UserPromptSubmit", "MessageDisplay",
+		"PreToolUse", "PostToolUse", "PermissionRequest", "Notification",
+	}
+	if len(s.Hooks) != len(want) {
+		t.Fatalf("expected %d hook events, got %d (%v)", len(want), len(s.Hooks), keysOf(s.Hooks))
+	}
+	for _, name := range want {
+		entries := s.Hooks[name]
+		if len(entries) != 1 || len(entries[0].Hooks) != 1 {
+			t.Fatalf("hook %s: expected 1 matcher with 1 hook, got %+v", name, entries)
+		}
+		u, _ := entries[0].Hooks[0]["url"].(string)
+		if !strings.Contains(u, "?session=s1") || !strings.Contains(u, "token=tok") {
+			t.Fatalf("hook %s url missing session/token: %q", name, u)
+		}
+	}
+}
+
+func keysOf(m map[string][]struct {
+	Matcher string           `json:"matcher"`
+	Hooks   []map[string]any `json:"hooks"`
+}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
 func TestHookCallbackAutoAllowed(t *testing.T) {
 	c := New(adapter.CreateRequest{ID: "s1"})
 	c.handleLine([]byte(`{"type":"control_request","request_id":"r2","request":{"subtype":"hook_callback","callback_id":"hook_user_prompt","input":{"hook_event_name":"UserPromptSubmit"}}}`))

--- a/apps/daemon/internal/claude/tui_unix.go
+++ b/apps/daemon/internal/claude/tui_unix.go
@@ -1,0 +1,138 @@
+//go:build !windows
+
+package claude
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
+)
+
+// spawnInteractive launches Claude Code's real interactive TUI on a PTY the
+// daemon owns. Structured events and approvals keep flowing through the
+// per-session settings hooks (see writeSettings); the PTY bytes are bridged
+// to a local CLI console via AttachPTY. When no console is attached the read
+// loop still drains the PTY so the TUI never blocks.
+func (c *Claude) spawnInteractive(ctx context.Context) error {
+	if err := c.writeSettings(); err != nil {
+		return fmt.Errorf("write settings: %w", err)
+	}
+	args := []string{"--settings", c.settingsPath, "--permission-mode", "default"}
+	cmd := exec.CommandContext(ctx, c.binary, args...)
+	if c.cwd != "" {
+		cmd.Dir = c.cwd
+	}
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		return fmt.Errorf("start %s TUI: %w", c.binary, err)
+	}
+	c.cmd = cmd
+	c.pty = ptmx
+	go func() {
+		_ = cmd.Wait()
+		c.mu.Lock()
+		c.exited = true
+		c.mu.Unlock()
+		_ = ptmx.Close()
+		c.closePTYSubs()
+		close(c.doneCh)
+	}()
+	go c.ptyReadLoop()
+	return nil
+}
+
+// ptyReadLoop drains the PTY master continuously and fans output out to the
+// attached console(s). With no console, bytes are discarded (never block).
+func (c *Claude) ptyReadLoop() {
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := c.pty.Read(buf)
+		if n > 0 {
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+			c.mu.Lock()
+			for sub := range c.ptySubs {
+				select {
+				case sub.ch <- chunk:
+				default: // slow console: drop rather than block the TUI
+				}
+			}
+			c.mu.Unlock()
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (c *Claude) closePTYSubs() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for sub := range c.ptySubs {
+		close(sub.ch)
+		delete(c.ptySubs, sub)
+	}
+}
+
+// AttachPTY hands a console to the interactive TUI. It waits briefly for the
+// TUI process to start (the daemon returns the create response before spawn
+// finishes), then registers the console. One console at a time is enforced
+// by the daemon (a new `riffpad run` replaces the old attach).
+func (c *Claude) AttachPTY() (adapter.Terminal, error) {
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		c.mu.Lock()
+		ptyFile := c.pty
+		c.mu.Unlock()
+		if ptyFile != nil {
+			t := &ptyTerm{c: c, ch: make(chan []byte, 256)}
+			c.mu.Lock()
+			c.ptySubs[t] = struct{}{}
+			c.mu.Unlock()
+			return t, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("PTY not ready after 15s")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// ptyTerm implements adapter.Terminal for one console.
+func (t *ptyTerm) Read(p []byte) (int, error) {
+	chunk, ok := <-t.ch
+	if !ok {
+		return 0, io.EOF
+	}
+	n := copy(p, chunk)
+	return n, nil
+}
+
+func (t *ptyTerm) Write(p []byte) (int, error) {
+	if t.c.pty == nil {
+		return 0, fmt.Errorf("PTY closed")
+	}
+	return t.c.pty.Write(p)
+}
+
+func (t *ptyTerm) Resize(cols, rows uint16) error {
+	if t.c.pty == nil {
+		return fmt.Errorf("PTY closed")
+	}
+	return pty.Setsize(t.c.pty, &pty.Winsize{Cols: cols, Rows: rows})
+}
+
+func (t *ptyTerm) Close() error {
+	t.c.mu.Lock()
+	defer t.c.mu.Unlock()
+	if _, ok := t.c.ptySubs[t]; ok {
+		delete(t.c.ptySubs, t)
+		close(t.ch)
+	}
+	return nil
+}

--- a/apps/daemon/internal/claude/tui_windows.go
+++ b/apps/daemon/internal/claude/tui_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package claude
+
+import (
+	"context"
+	"fmt"
+)
+
+// spawnInteractive is unsupported on Windows (creack/pty reports
+// ErrUnsupported); the adapter falls back to headless stream-json hosting.
+func (c *Claude) spawnInteractive(ctx context.Context) error {
+	return fmt.Errorf("interactive PTY not supported on Windows")
+}

--- a/apps/daemon/internal/daemon/attach.go
+++ b/apps/daemon/internal/daemon/attach.go
@@ -27,6 +27,7 @@ func (a *attachAdapter) Events() <-chan protocol.Event { return nil }
 func (a *attachAdapter) Meta() protocol.SessionStartPayload {
 	return protocol.SessionStartPayload{}
 }
+
 // SendApproval on an attachAdapter is only reached when the request is not in
 // the server's pendingHooks map (see Server.dispatch), i.e. the hook already
 // timed out or was resolved — so it always reports the approval as expired.
@@ -81,6 +82,17 @@ func decodeHook(r *http.Request) (hookPayload, bool) {
 		return p, false
 	}
 	return p, true
+}
+
+// hookSessionID prefers the daemon session id passed in the hook URL
+// (?session=<id>) — hosted interactive Claude registers its per-session
+// hooks with that param — and falls back to Claude's own session id for
+// classic attach sessions.
+func hookSessionID(r *http.Request, p hookPayload) string {
+	if sid := r.URL.Query().Get("session"); sid != "" {
+		return sid
+	}
+	return p.SessionID
 }
 
 func (p *hookPayload) toolName() string {
@@ -237,7 +249,8 @@ func (s *Server) handleHookSessionStart(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusBadRequest, "invalid hook payload")
 		return
 	}
-	s.attachSession(p.SessionID, p.CWD)
+	sid := hookSessionID(r, p)
+	s.attachSession(sid, p.CWD)
 	writeJSON(w, http.StatusOK, map[string]any{})
 }
 
@@ -247,10 +260,11 @@ func (s *Server) handleHookSessionEnd(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid hook payload")
 		return
 	}
-	sess := s.getSession(p.SessionID)
+	sid := hookSessionID(r, p)
+	sess := s.getSession(sid)
 	if sess != nil {
 		sess.status = protocol.StatusDone
-		ev, err := protocol.NewEvent(p.SessionID, protocol.EventSessionEnd, protocol.SessionEndPayload{Reason: p.Reason})
+		ev, err := protocol.NewEvent(sid, protocol.EventSessionEnd, protocol.SessionEndPayload{Reason: p.Reason})
 		if err == nil {
 			s.pumpEvent(sess, ev)
 		}
@@ -265,8 +279,9 @@ func (s *Server) handleHookPreToolUse(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid hook payload")
 		return
 	}
-	sess := s.attachSession(p.SessionID, p.CWD)
-	ev, err := protocol.NewEvent(p.SessionID, protocol.EventToolCall, protocol.ToolCallPayload{
+	sid := hookSessionID(r, p)
+	sess := s.attachSession(sid, p.CWD)
+	ev, err := protocol.NewEvent(sid, protocol.EventToolCall, protocol.ToolCallPayload{
 		Tool:    p.toolName(),
 		Status:  "started",
 		Summary: p.summary(),
@@ -284,7 +299,8 @@ func (s *Server) handleHookPostToolUse(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid hook payload")
 		return
 	}
-	sess := s.attachSession(p.SessionID, p.CWD)
+	sid := hookSessionID(r, p)
+	sess := s.attachSession(sid, p.CWD)
 	name := p.toolName()
 	input := p.toolInput()
 	switch name {
@@ -294,7 +310,7 @@ func (s *Server) handleHookPostToolUse(w http.ResponseWriter, r *http.Request) {
 		// row resolves to done instead of spinning forever (the client treats
 		// a missing exit code as "running").
 		exit := 0
-		ev, err := protocol.NewEvent(p.SessionID, protocol.EventCommand, protocol.CommandPayload{Command: cmd, ExitCode: &exit})
+		ev, err := protocol.NewEvent(sid, protocol.EventCommand, protocol.CommandPayload{Command: cmd, ExitCode: &exit})
 		if err == nil {
 			s.pumpEvent(sess, ev)
 		}
@@ -303,12 +319,12 @@ func (s *Server) handleHookPostToolUse(w http.ResponseWriter, r *http.Request) {
 		if path == "" {
 			path, _ = input["path"].(string)
 		}
-		ev, err := protocol.NewEvent(p.SessionID, protocol.EventFileChange, protocol.FileChangePayload{Path: path, Summary: "updated"})
+		ev, err := protocol.NewEvent(sid, protocol.EventFileChange, protocol.FileChangePayload{Path: path, Summary: "updated"})
 		if err == nil {
 			s.pumpEvent(sess, ev)
 		}
 	}
-	ev, err := protocol.NewEvent(p.SessionID, protocol.EventToolCall, protocol.ToolCallPayload{Tool: name, Status: "completed"})
+	ev, err := protocol.NewEvent(sid, protocol.EventToolCall, protocol.ToolCallPayload{Tool: name, Status: "completed"})
 	if err == nil {
 		s.pumpEvent(sess, ev)
 	}
@@ -325,8 +341,9 @@ func (s *Server) handleHookUserPromptSubmit(w http.ResponseWriter, r *http.Reque
 		writeJSON(w, http.StatusOK, map[string]any{})
 		return
 	}
-	sess := s.attachSession(p.SessionID, p.CWD)
-	ev, err := protocol.NewEvent(p.SessionID, protocol.EventUserMessage, protocol.PromptPayload{Text: p.Prompt})
+	sid := hookSessionID(r, p)
+	sess := s.attachSession(sid, p.CWD)
+	ev, err := protocol.NewEvent(sid, protocol.EventUserMessage, protocol.PromptPayload{Text: p.Prompt})
 	if err == nil {
 		s.pumpEvent(sess, ev)
 	}
@@ -339,7 +356,8 @@ func (s *Server) handleHookMessageDisplay(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusBadRequest, "invalid hook payload")
 		return
 	}
-	sess := s.attachSession(p.SessionID, p.CWD)
+	sid := hookSessionID(r, p)
+	sess := s.attachSession(sid, p.CWD)
 	// Accumulate per message_id; emit once when the final batch arrives so the
 	// timeline shows whole assistant messages instead of many partial cards.
 	if p.MessageID != "" && !p.Final {
@@ -360,7 +378,7 @@ func (s *Server) handleHookMessageDisplay(w http.ResponseWriter, r *http.Request
 		writeJSON(w, http.StatusOK, map[string]any{})
 		return
 	}
-	ev, err := protocol.NewEvent(p.SessionID, protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: text})
+	ev, err := protocol.NewEvent(sid, protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: text})
 	if err == nil {
 		s.pumpEvent(sess, ev)
 	}
@@ -394,9 +412,10 @@ func (s *Server) handleHookNotification(w http.ResponseWriter, r *http.Request) 
 		writeJSON(w, http.StatusOK, map[string]any{})
 		return
 	}
-	s.log.Printf("notification hook session=%s type=%s msg=%q", p.SessionID, notifType, p.Message)
-	sess := s.attachSession(p.SessionID, p.CWD)
-	ev, err := protocol.NewEvent(p.SessionID, protocol.EventNotify, protocol.NotifyPayload{Level: level, Message: p.Message})
+	sid := hookSessionID(r, p)
+	s.log.Printf("notification hook session=%s type=%s msg=%q", sid, notifType, p.Message)
+	sess := s.attachSession(sid, p.CWD)
+	ev, err := protocol.NewEvent(sid, protocol.EventNotify, protocol.NotifyPayload{Level: level, Message: p.Message})
 	if err == nil {
 		s.pumpEvent(sess, ev)
 	}
@@ -409,14 +428,15 @@ func (s *Server) handleHookPermission(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid hook payload")
 		return
 	}
-	sess := s.attachSession(p.SessionID, p.CWD)
+	sid := hookSessionID(r, p)
+	sess := s.attachSession(sid, p.CWD)
 	reqID := "hook-" + protocol.NewID()
 	ch := make(chan string, 1)
 	s.mu.Lock()
 	s.pendingHooks[reqID] = ch
 	s.mu.Unlock()
-	s.log.Printf("permission hook request session=%s tool=%s req=%s", p.SessionID, p.toolName(), reqID)
-	ev, err := protocol.NewEvent(p.SessionID, protocol.EventApprovalReq, protocol.ApprovalRequestPayload{
+	s.log.Printf("permission hook request session=%s tool=%s req=%s", sid, p.toolName(), reqID)
+	ev, err := protocol.NewEvent(sid, protocol.EventApprovalReq, protocol.ApprovalRequestPayload{
 		RequestID: reqID,
 		Action:    p.toolName(),
 		Summary:   p.summary(),

--- a/apps/daemon/internal/daemon/hook_routing_test.go
+++ b/apps/daemon/internal/daemon/hook_routing_test.go
@@ -1,0 +1,74 @@
+package daemon
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/riffpad/riffpad/apps/daemon/internal/config"
+	"github.com/riffpad/riffpad/packages/protocol"
+)
+
+// TestHookRoutesToHostedSessionByQuery: hosted interactive Claude registers
+// hooks with ?session=<daemon id>; the handler must route to that session
+// instead of creating a duplicate attach session keyed by Claude's own id.
+func TestHookRoutesToHostedSessionByQuery(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	keys, err := config.LoadOrCreateKeys(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := New(cfg, keys, dir, log.New(io.Discard, "", 0), nil)
+	fake := &fakeSession{
+		id:         "host-1",
+		events:     make(chan protocol.Event, 16),
+		approvals:  make(chan string, 1),
+		prompts:    make(chan string, 1),
+		stopCalled: make(chan struct{}, 1),
+	}
+	sess := &session{
+		id:      "host-1",
+		meta:    fake.Meta(),
+		adapter: fake,
+		events:  fake.events,
+		status:  protocol.StatusRunning,
+		clients: map[*client]struct{}{},
+	}
+	srv.sessions["host-1"] = sess
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	body := `{"session_id":"claude-own-id","cwd":"/tmp","message":"done!","notification":{"type":"agent_completed","message":"done!"}}`
+	req, err := http.NewRequest(http.MethodPost,
+		ts.URL+"/hooks/claude/notification?session=host-1&token="+cfg.LocalToken,
+		strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("hook status %d", resp.StatusCode)
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if len(srv.sessions) != 1 {
+		t.Fatalf("expected only the hosted session, got %d sessions", len(srv.sessions))
+	}
+	if _, dup := srv.sessions["claude-own-id"]; dup {
+		t.Fatal("duplicate attach session created despite ?session= routing")
+	}
+	sess = srv.sessions["host-1"]
+	if n := len(sess.history); n == 0 || sess.history[n-1].Type != protocol.EventNotify {
+		t.Fatalf("expected notify event in hosted session history, got %+v", sess.history)
+	}
+}

--- a/apps/daemon/internal/daemon/pty_test.go
+++ b/apps/daemon/internal/daemon/pty_test.go
@@ -1,0 +1,152 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"log"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/gorilla/websocket"
+	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
+	"github.com/riffpad/riffpad/apps/daemon/internal/config"
+	"github.com/riffpad/riffpad/packages/protocol"
+	"golang.org/x/sys/unix"
+)
+
+type ptyTestTerm struct {
+	m        *os.File
+	lastCols uint16
+	lastRows uint16
+}
+
+func (t *ptyTestTerm) Read(p []byte) (int, error)  { return t.m.Read(p) }
+func (t *ptyTestTerm) Write(p []byte) (int, error) { return t.m.Write(p) }
+func (t *ptyTestTerm) Close() error                { return t.m.Close() }
+func (t *ptyTestTerm) Resize(c, r uint16) error    { t.lastCols, t.lastRows = c, r; return nil }
+
+type ptyTestAdapter struct {
+	id     string
+	events chan protocol.Event
+	master *os.File
+	last   *ptyTestTerm
+}
+
+func (f *ptyTestAdapter) ID() string                    { return f.id }
+func (f *ptyTestAdapter) Events() <-chan protocol.Event { return f.events }
+func (f *ptyTestAdapter) Meta() protocol.SessionStartPayload {
+	return protocol.SessionStartPayload{Name: "pty", CLI: "claude", Cwd: "/tmp"}
+}
+func (f *ptyTestAdapter) Start(_ context.Context) error  { return nil }
+func (f *ptyTestAdapter) SendApproval(_, _ string) error { return nil }
+func (f *ptyTestAdapter) SendPrompt(_ string) error      { return nil }
+func (f *ptyTestAdapter) Alive() bool                    { return true }
+func (f *ptyTestAdapter) Stop() error                    { return nil }
+func (f *ptyTestAdapter) AttachPTY() (adapter.Terminal, error) {
+	f.last = &ptyTestTerm{m: f.master}
+	return f.last, nil
+}
+
+func TestPTYConsoleRoundTrip(t *testing.T) {
+	master, slave, err := pty.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer slave.Close()
+
+	// Disable echo/canonical so input written to the master does not bounce
+	// back as an extra output frame.
+	tio, err := unix.IoctlGetTermios(int(slave.Fd()), unix.TCGETS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tio.Lflag &^= unix.ECHO | unix.ICANON
+	if err := unix.IoctlSetTermios(int(slave.Fd()), unix.TCSETS, tio); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	cfg := config.Default()
+	keys, err := config.LoadOrCreateKeys(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := New(cfg, keys, dir, log.New(io.Discard, "", 0), nil)
+	ad := &ptyTestAdapter{id: "pty-1", events: make(chan protocol.Event, 8), master: master}
+	srv.sessions["pty-1"] = &session{
+		id:      "pty-1",
+		meta:    ad.Meta(),
+		adapter: ad,
+		events:  ad.events,
+		status:  protocol.StatusRunning,
+		clients: map[*client]struct{}{},
+	}
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/api/sessions/pty-1/pty?token=" + cfg.LocalToken
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Client → PTY: bytes arrive on the slave.
+	if err := conn.WriteJSON(map[string]any{"in": base64.StdEncoding.EncodeToString([]byte("hello"))}); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 16)
+	if n, err := slave.Read(buf); err != nil || string(buf[:n]) != "hello" {
+		t.Fatalf("slave got %q err=%v", buf[:n], err)
+	}
+
+	// PTY → client: writing to the slave produces an {"out"} frame.
+	if _, err := slave.Write([]byte("world")); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var msg struct {
+			Out string `json:"out"`
+		}
+		if err := conn.SetReadDeadline(deadline); err != nil {
+			t.Fatal(err)
+		}
+		if err := conn.ReadJSON(&msg); err != nil {
+			t.Fatal(err)
+		}
+		if msg.Out != "" {
+			raw, err := base64.StdEncoding.DecodeString(msg.Out)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(raw) != "world" {
+				t.Fatalf("unexpected out: %q", raw)
+			}
+			break
+		}
+	}
+
+	// Resize propagates to the terminal implementation.
+	if err := conn.WriteJSON(map[string]any{"resize": map[string]uint16{"cols": 120, "rows": 40}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := srv.ptys["pty-1"]; got == nil {
+		t.Fatal("console not registered")
+	}
+	deadline = time.Now().Add(5 * time.Second)
+	for ad.last == nil || ad.last.lastCols != 120 || ad.last.lastRows != 40 {
+		if time.Now().After(deadline) {
+			t.Fatalf("resize not applied: cols=%d rows=%d", ad.last.lastCols, ad.last.lastRows)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/apps/daemon/internal/daemon/pty_unix.go
+++ b/apps/daemon/internal/daemon/pty_unix.go
@@ -1,0 +1,112 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"encoding/base64"
+	"net/http"
+	"sync"
+
+	"github.com/gorilla/websocket"
+	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
+)
+
+// ptyUpgrader accepts local-only console connections. The localAuth
+// middleware has already validated the token; loopback enforcement happens
+// at the HTTP layer, so the WS itself trusts the caller.
+var ptyUpgrader = websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+
+// handleSessionPTY bridges one local CLI console to a session's interactive
+// PTY. Frames: client → {"in": base64} / {"resize": {cols, rows}};
+// daemon → {"out": base64} / {"exit": 0}. Only one console per session: a
+// new attach replaces (and closes) the previous one, so re-running
+// `riffpad run claude` re-attaches cleanly.
+func (s *Server) handleSessionPTY(w http.ResponseWriter, r *http.Request, id string) {
+	s.mu.Lock()
+	sess, ok := s.sessions[id]
+	s.mu.Unlock()
+	if !ok {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	ts, ok := sess.getAdapter().(adapter.TerminalSession)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "session does not expose a PTY")
+		return
+	}
+	term, err := ts.AttachPTY()
+	if err != nil {
+		writeError(w, http.StatusConflict, err.Error())
+		return
+	}
+	conn, err := ptyUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		_ = term.Close()
+		return
+	}
+
+	// Single-console policy: close any previous console for this session.
+	s.mu.Lock()
+	if prev, ok := s.ptys[id]; ok {
+		_ = prev.Close()
+	}
+	s.ptys[id] = conn
+	s.mu.Unlock()
+	defer func() {
+		_ = term.Close()
+		s.mu.Lock()
+		if s.ptys[id] == conn {
+			delete(s.ptys, id)
+		}
+		s.mu.Unlock()
+	}()
+
+	var writeMu sync.Mutex
+	writeJSONFrame := func(v any) error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return conn.WriteJSON(v)
+	}
+
+	// PTY → WS. Runs until the process exits (master EOF), then tells the
+	// console and tears the connection down.
+	go func() {
+		buf := make([]byte, 32*1024)
+		for {
+			n, err := term.Read(buf)
+			if n > 0 {
+				_ = writeJSONFrame(map[string]any{
+					"out": base64.StdEncoding.EncodeToString(buf[:n]),
+				})
+			}
+			if err != nil {
+				break
+			}
+		}
+		_ = writeJSONFrame(map[string]any{"exit": 0})
+		_ = conn.Close()
+	}()
+
+	// WS → PTY: input bytes and resize events.
+	for {
+		var msg struct {
+			In     string `json:"in"`
+			Resize *struct {
+				Cols uint16 `json:"cols"`
+				Rows uint16 `json:"rows"`
+			} `json:"resize"`
+		}
+		if err := conn.ReadJSON(&msg); err != nil {
+			return
+		}
+		if msg.In != "" {
+			b, err := base64.StdEncoding.DecodeString(msg.In)
+			if err == nil {
+				_, _ = term.Write(b)
+			}
+		}
+		if msg.Resize != nil {
+			_ = term.Resize(msg.Resize.Cols, msg.Resize.Rows)
+		}
+	}
+}

--- a/apps/daemon/internal/daemon/pty_windows.go
+++ b/apps/daemon/internal/daemon/pty_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package daemon
+
+import "net/http"
+
+// handleSessionPTY is unavailable on Windows: creack/pty reports
+// ErrUnsupported, so foreground TUI attach is compiled out. `riffpad run`
+// falls back to headless hosting there.
+func (s *Server) handleSessionPTY(w http.ResponseWriter, r *http.Request, id string) {
+	writeError(w, http.StatusNotImplemented, "PTY console is not supported on Windows yet")
+}

--- a/apps/daemon/internal/daemon/server.go
+++ b/apps/daemon/internal/daemon/server.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
 	"github.com/riffpad/riffpad/apps/daemon/internal/claude"
 	"github.com/riffpad/riffpad/apps/daemon/internal/codex"
@@ -97,6 +98,7 @@ type Server struct {
 	sessions     map[string]*session
 	pendingHooks map[string]chan string
 	messageBuf   map[string]string
+	ptys         map[string]*websocket.Conn
 }
 
 // New creates a daemon server.
@@ -120,6 +122,7 @@ func New(cfg *config.Config, keys *config.Keys, dataDir string, logger *log.Logg
 		sessions:     map[string]*session{},
 		pendingHooks: map[string]chan string{},
 		messageBuf:   map[string]string{},
+		ptys:         map[string]*websocket.Conn{},
 	}
 	s.loadDevices()
 	s.cleanupCodexProcesses()
@@ -785,6 +788,10 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	}
 	if strings.HasSuffix(id, "/heartbeat") {
 		s.handleSessionHeartbeat(w, strings.TrimSuffix(id, "/heartbeat"))
+		return
+	}
+	if strings.HasSuffix(id, "/pty") {
+		s.handleSessionPTY(w, r, strings.TrimSuffix(id, "/pty"))
 		return
 	}
 	if !strings.HasSuffix(id, "/stop") {

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -195,7 +195,7 @@
 | M3.11 | CLI 命令完善：`login/logout` + `update` 自更新 | `[x]` | 旧命令保留别名；update 校验/备份/原子替换 | #64 #65 |
 | M3.12 | CLI 多语种（i18n） | `[x]` | zh/en 语言包；`--lang` > 环境变量 > 英文兜底 | #67 |
 | M3.13 | 第三方登录：Google / Email（OAuth + 邮箱验证码） | `[ ]` | GitHub OAuth 已完成（M1.18 #105）；Google（国内可用性低）、Email（需 SMTP）暂缓 | — |
-| M3.14 | 托管模式无感化：`riffpad run` 后电脑终端照常显示/操作 CLI TUI，手机同步遥控 | `[~]` | Codex：`--remote` 共享 app-server 已完成（#74 #79）；Claude：daemon PTY + hooks 收编，前台 TUI 转发待做（#210）；Kimi：后续；Ctrl-C 退出即退出，持久会话由用户 tmux（docs 强烈推荐） | #74 #79 |
+| M3.14 | 托管模式无感化：`riffpad run` 后电脑终端照常显示/操作 CLI TUI，手机同步遥控 | `[~]` | Codex：`--remote` 共享 app-server 已完成（#74 #79）；Claude：daemon PTY 桥 + per-session hooks 已实现（前台 TUI、事件/审批、`/api/sessions/{id}/pty`），真机验证通过待合并（#230）；Kimi：前台方案待确认（无官方 attach 通道）；Ctrl-C 退出即退出，持久会话由用户 tmux（docs 强烈推荐） | #74 #79 #230 |
 | M3.15 | 容器化部署：relay + Postgres 容器化 | `[x]` | 已随 M1.18 完成：relay 仅监听 127.0.0.1:9090、Postgres 17、healthcheck/restart、nginx/certbot 留宿主；生产运行中 | — |
 | M3.16 | 元数据存储 SQLite → Postgres 迁移 | `[x]` | 已随 M1.18 完成：`apps/relay/cmd/migrate-sqlite` 逐表迁移 + 行数校验，生产已切换 Postgres | — |
 | M3.17 | CI/CD：main push → 自动部署 relay（GitHub Actions + SSH 受限部署密钥） | `[x]` | CI 三 job 通过后自动执行 `/usr/local/bin/riffpad-deploy.sh`（git pull --ff-only + compose up -d --build + 健康检查）；部署密钥仅能执行固定脚本；2026-08-07 已端到端验证 | #108 #112 #113 |


### PR DESCRIPTION
Closes #230

## 改动
- **daemon PTY 附着通道**：`/api/sessions/{id}/pty` WebSocket（in/out/resize/exit），`adapter.TerminalSession` 可选接口，单控制台策略（重跑替换旧 console），`!windows` 构建隔离（Windows 回退 headless）
- **Claude 适配器**：交互式 TUI 以 PTY 启动（creack/pty），注册全量 hooks（SessionStart/End、UserPromptSubmit、MessageDisplay、Pre/PostToolUse、PermissionRequest、Notification）；hook 路由优先 `?session=<daemon id>`，不再产生重复 attach 会话
- **CLI**：`riffpad run claude` 前台附着——raw 终端、SIGWINCH 缩放、5s 心跳租约、进程退出/断开即关闭会话（无静默后台）
- 测试：PTY 双向字节流+resize、hook 路由到托管会话、交互模式 hooks 全量注册与 URL 参数

## 真机验证（本机）
- [x] `riffpad run claude` 前台出现真实 Claude TUI；输入 hi 正常回复；无 hook 404；events.enc 持久化；停止会话后 CLI 干净退出
- [ ] 手机端查看/审批/发指令（需要你配合 app 复测）
- [ ] Kimi 前台方案待确认（Kimi 无官方 attach 通道，见 PR 讨论）