### PR TITLE
feat(daemon): Kimi 前台 TUI（KIMI_CODE_HOME 每会话 home + 原生 hooks）(#232)

### DIFF
--- a/apps/daemon/cmd/riffpad/console_unix.go
+++ b/apps/daemon/cmd/riffpad/console_unix.go
@@ -22,8 +22,8 @@ import (
 // window resizes are propagated, and Ctrl-C reaches the vendor TUI. When the
 // vendor process exits (or the console disconnects) the daemon session is
 // closed, matching the no-silent-hosting convention.
-func attachConsoleTUI(base, sessionID string) error {
-	fmt.Println("正在启动 Claude TUI（会话已托管到 daemon）…")
+func attachConsoleTUI(base, sessionID, cliName string) error {
+	fmt.Printf("正在启动 %s TUI（会话已托管到 daemon）…\n", cliName)
 	wsURL := strings.Replace(base, "http://", "ws://", 1) +
 		"/api/sessions/" + sessionID + "/pty"
 	if tok := localToken(); tok != "" {
@@ -136,6 +136,6 @@ func attachConsoleTUI(base, sessionID string) error {
 	if resp, err := daemonDo(nil, http.MethodPost, base+"/api/sessions/"+sessionID+"/stop", nil); err == nil {
 		_ = resp.Body.Close()
 	}
-	fmt.Printf("Claude TUI 已退出，会话 %s 已关闭。\n", sessionID)
+	fmt.Printf("%s TUI 已退出，会话 %s 已关闭。\n", cliName, sessionID)
 	return nil
 }

--- a/apps/daemon/cmd/riffpad/console_windows.go
+++ b/apps/daemon/cmd/riffpad/console_windows.go
@@ -6,6 +6,6 @@ import "fmt"
 
 // attachConsoleTUI is unavailable on Windows (creack/pty is unsupported);
 // runCmd falls back to headless hosting before ever calling this.
-func attachConsoleTUI(base, sessionID string) error {
+func attachConsoleTUI(base, sessionID, cliName string) error {
 	return fmt.Errorf("前台 TUI 暂不支持 Windows")
 }

--- a/apps/daemon/cmd/riffpad/main.go
+++ b/apps/daemon/cmd/riffpad/main.go
@@ -817,12 +817,12 @@ func runCmd(args []string, base string) error {
 	if data.CLI == "codex" {
 		return attachCodexTUI(base, data.ID)
 	}
-	if data.CLI == "claude" {
+	if data.CLI == "claude" || data.CLI == "kimi" {
 		if runtime.GOOS == "windows" {
 			fmt.Println(t.T("session_url", data.ID, data.URL))
 			return nil
 		}
-		return attachConsoleTUI(base, data.ID)
+		return attachConsoleTUI(base, data.ID, data.CLI)
 	}
 	fmt.Println(t.T("session_url", data.ID, data.URL))
 	return nil

--- a/apps/daemon/cmd/riffpad/main_test.go
+++ b/apps/daemon/cmd/riffpad/main_test.go
@@ -498,7 +498,7 @@ func TestRunCmdSuccess(t *testing.T) {
 		}
 		_ = json.NewDecoder(r.Body).Decode(&req)
 		gotBinary = req.Binary
-		_ = json.NewEncoder(w).Encode(map[string]string{"id": "s1", "url": "http://x/s1", "cli": "kimi"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": "s1", "url": "http://x/s1", "cli": "sh"})
 	}))
 	t.Cleanup(srv.Close)
 
@@ -526,11 +526,11 @@ func TestRunCmdAcceptsPositionalCLI(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	if err := runCmd([]string{"kimi"}, srv.URL); err != nil {
+	if err := runCmd([]string{"sh"}, srv.URL); err != nil {
 		t.Fatalf("run failed: %v", err)
 	}
-	if gotCLI != "kimi" {
-		t.Fatalf("expected positional cli kimi, got %q", gotCLI)
+	if gotCLI != "sh" {
+		t.Fatalf("expected positional cli sh, got %q", gotCLI)
 	}
 }
 

--- a/apps/daemon/internal/daemon/kimi_hooks.go
+++ b/apps/daemon/internal/daemon/kimi_hooks.go
@@ -1,0 +1,286 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/riffpad/riffpad/packages/protocol"
+)
+
+// Kimi hook endpoints. The kimi adapter runs the real interactive TUI with a
+// per-session config.toml whose [[hooks]] POST JSON to these routes
+// (?session=<daemon id>). PreToolUse is a synchronous gate: the handler holds
+// the request until a viewer decides, then returns allow/deny to the hook
+// runner (JSON hookSpecificOutput.permissionDecision).
+
+type kimiHookPayload struct {
+	SessionID    string          `json:"session_id"`
+	CWD          string          `json:"cwd"`
+	HookEvent    string          `json:"hook_event_name"`
+	ToolName     string          `json:"tool_name"`
+	ToolInput    map[string]any  `json:"tool_input"`
+	ToolOutput   any             `json:"tool_output"`
+	Error        string          `json:"error"`
+	Prompt       json.RawMessage `json:"prompt"`
+	Reason       string          `json:"reason"`
+	Source       string          `json:"source"`
+	Notification *struct {
+		Sink             string `json:"sink"`
+		NotificationType string `json:"notification_type"`
+		Title            string `json:"title"`
+		Body             string `json:"body"`
+		Severity         string `json:"severity"`
+	} `json:"notification"`
+}
+
+// kimiGatedTools are the tools Kimi would itself ask about in interactive
+// mode; their PreToolUse becomes a phone approval gate. Everything else is
+// auto-allowed (only a started event is emitted).
+func kimiGatedTools() map[string]bool {
+	return map[string]bool{
+		"Shell":          true,
+		"Bash":           true,
+		"WriteFile":      true,
+		"StrReplaceFile": true,
+		"BackgroundTask": true,
+	}
+}
+
+// kimiPromptText extracts the plain text from a UserPromptSubmit payload:
+// newer kimi-code sends a ContentPart array, older sends a string.
+func kimiPromptText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	var parts []struct {
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &parts) == nil {
+		var b strings.Builder
+		for _, p := range parts {
+			b.WriteString(p.Text)
+		}
+		return b.String()
+	}
+	return ""
+}
+
+func kimiStringField(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func kimiHookSessionID(r *http.Request, p kimiHookPayload) string {
+	if sid := r.URL.Query().Get("session"); sid != "" {
+		return sid
+	}
+	return p.SessionID
+}
+
+func (s *Server) kimiSession(r *http.Request, p kimiHookPayload) (*session, bool) {
+	sid := kimiHookSessionID(r, p)
+	s.mu.Lock()
+	sess, ok := s.sessions[sid]
+	s.mu.Unlock()
+	return sess, ok
+}
+
+func (s *Server) handleKimiHook(w http.ResponseWriter, r *http.Request) {
+	event := strings.TrimPrefix(r.URL.Path, "/hooks/kimi/")
+	if event == "" || strings.Contains(event, "/") {
+		http.NotFound(w, r)
+		return
+	}
+	var p kimiHookPayload
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid body")
+		return
+	}
+	sess, ok := s.kimiSession(r, p)
+	if !ok {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	sid := kimiHookSessionID(r, p)
+
+	switch event {
+	case "session-start":
+		sess.status = protocol.StatusRunning
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	case "session-end":
+		sess.status = protocol.StatusDone
+		if ev, err := protocol.NewEvent(sid, protocol.EventSessionEnd,
+			protocol.SessionEndPayload{Reason: p.Reason}); err == nil {
+			s.pumpEvent(sess, ev)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	case "user-prompt-submit":
+		if text := kimiPromptText(p.Prompt); text != "" {
+			if ev, err := protocol.NewEvent(sid, protocol.EventUserMessage,
+				protocol.PromptPayload{Text: text}); err == nil {
+				s.pumpEvent(sess, ev)
+			}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	case "stop":
+		if ev, err := protocol.NewEvent(sid, protocol.EventAgentStatus,
+			protocol.AgentStatusPayload{Status: protocol.StatusWaitingInput}); err == nil {
+			s.pumpEvent(sess, ev)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	case "pre-tool-use":
+		s.handleKimiPreToolUse(w, sess, sid, p)
+	case "post-tool-use":
+		s.handleKimiPostToolUse(w, sess, sid, p, false)
+	case "post-tool-use-failure":
+		s.handleKimiPostToolUse(w, sess, sid, p, true)
+	case "notification":
+		level := "info"
+		if p.Notification != nil {
+			switch p.Notification.NotificationType {
+			case "idle_prompt", "agent_needs_input":
+				level = "waiting"
+			case "agent_completed":
+				level = "completed"
+			}
+		}
+		msg := ""
+		if p.Notification != nil {
+			msg = p.Notification.Body
+			if msg == "" {
+				msg = p.Notification.Title
+			}
+		}
+		if msg != "" {
+			if ev, err := protocol.NewEvent(sid, protocol.EventNotify,
+				protocol.NotifyPayload{Level: level, Message: msg}); err == nil {
+				s.pumpEvent(sess, ev)
+			}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *Server) handleKimiPreToolUse(w http.ResponseWriter, sess *session, sid string, p kimiHookPayload) {
+	tool := p.ToolName
+	// Emit the started row first so the timeline shows activity even while
+	// waiting for a phone decision.
+	if ev, err := protocol.NewEvent(sid, protocol.EventToolCall, protocol.ToolCallPayload{
+		Tool:    tool,
+		Status:  "started",
+		Summary: kimiToolSummary(p),
+		Args:    p.ToolInput,
+	}); err == nil {
+		s.pumpEvent(sess, ev)
+	}
+
+	allow := map[string]any{
+		"hookSpecificOutput": map[string]any{
+			"hookEventName":      "PreToolUse",
+			"permissionDecision": "allow",
+		},
+	}
+	if !kimiGatedTools()[tool] {
+		writeJSON(w, http.StatusOK, allow)
+		return
+	}
+
+	reqID := "kimi-hook-" + protocol.NewID()
+	ch := make(chan string, 1)
+	s.mu.Lock()
+	s.pendingHooks[reqID] = ch
+	s.mu.Unlock()
+	if ev, err := protocol.NewEvent(sid, protocol.EventApprovalReq, protocol.ApprovalRequestPayload{
+		RequestID: reqID,
+		Action:    tool,
+		Summary:   kimiToolSummary(p),
+		Options:   []string{"approve", "reject"},
+		Args:      p.ToolInput,
+	}); err == nil {
+		s.pumpEvent(sess, ev)
+	}
+
+	decision := "deny"
+	select {
+	case d := <-ch:
+		if d == "approve" {
+			decision = "allow"
+		}
+	case <-time.After(approvalHookTimeout):
+	}
+	s.mu.Lock()
+	delete(s.pendingHooks, reqID)
+	s.mu.Unlock()
+
+	if decision == "allow" {
+		writeJSON(w, http.StatusOK, allow)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"hookSpecificOutput": map[string]any{
+			"hookEventName":            "PreToolUse",
+			"permissionDecision":       "deny",
+			"permissionDecisionReason": "Rejected from Riffpad phone.",
+		},
+	})
+}
+
+func (s *Server) handleKimiPostToolUse(w http.ResponseWriter, sess *session, sid string, p kimiHookPayload, failed bool) {
+	tool := p.ToolName
+	if failed {
+		if ev, err := protocol.NewEvent(sid, protocol.EventToolCall, protocol.ToolCallPayload{
+			Tool: tool, Status: "failed", Summary: kimiToolSummary(p),
+		}); err == nil {
+			s.pumpEvent(sess, ev)
+		}
+		if p.Error != "" {
+			if ev, err := protocol.NewEvent(sid, protocol.EventNotify,
+				protocol.NotifyPayload{Level: "error", Message: p.Error}); err == nil {
+				s.pumpEvent(sess, ev)
+			}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+		return
+	}
+	switch tool {
+	case "Shell", "Bash":
+		cmd := kimiStringField(p.ToolInput, "command")
+		exit := 0
+		if ev, err := protocol.NewEvent(sid, protocol.EventCommand,
+			protocol.CommandPayload{Command: cmd, ExitCode: &exit}); err == nil {
+			s.pumpEvent(sess, ev)
+		}
+	case "WriteFile", "StrReplaceFile":
+		path := kimiStringField(p.ToolInput, "path")
+		if ev, err := protocol.NewEvent(sid, protocol.EventFileChange,
+			protocol.FileChangePayload{Path: path, Summary: "updated"}); err == nil {
+			s.pumpEvent(sess, ev)
+		}
+	}
+	if ev, err := protocol.NewEvent(sid, protocol.EventToolCall, protocol.ToolCallPayload{
+		Tool: tool, Status: "completed", Summary: kimiToolSummary(p),
+	}); err == nil {
+		s.pumpEvent(sess, ev)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+func kimiToolSummary(p kimiHookPayload) string {
+	if cmd := kimiStringField(p.ToolInput, "command"); cmd != "" {
+		return cmd
+	}
+	if path := kimiStringField(p.ToolInput, "path"); path != "" {
+		return path
+	}
+	return p.ToolName
+}

--- a/apps/daemon/internal/daemon/kimi_hooks_test.go
+++ b/apps/daemon/internal/daemon/kimi_hooks_test.go
@@ -1,0 +1,188 @@
+package daemon
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/riffpad/riffpad/apps/daemon/internal/config"
+	"github.com/riffpad/riffpad/packages/protocol"
+)
+
+func newKimiHookTestServer(t *testing.T) (*Server, *httptest.Server, *session, string) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := config.Default()
+	keys, err := config.LoadOrCreateKeys(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := New(cfg, keys, dir, log.New(io.Discard, "", 0), nil)
+	fake := &fakeSession{
+		id:         "kimi-1",
+		events:     make(chan protocol.Event, 32),
+		approvals:  make(chan string, 1),
+		prompts:    make(chan string, 1),
+		stopCalled: make(chan struct{}, 1),
+	}
+	sess := &session{
+		id:      "kimi-1",
+		meta:    fake.Meta(),
+		adapter: fake,
+		events:  fake.events,
+		status:  protocol.StatusRunning,
+		clients: map[*client]struct{}{},
+	}
+	srv.sessions["kimi-1"] = sess
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return srv, ts, sess, cfg.LocalToken
+}
+
+func postKimiHookBody(ts *httptest.Server, event, body, token string) (*http.Response, string, error) {
+	req, err := http.NewRequest(http.MethodPost,
+		ts.URL+"/hooks/kimi/"+event+"?session=kimi-1&token="+token,
+		strings.NewReader(body))
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp, string(raw), nil
+}
+
+func postKimiHook(t *testing.T, ts *httptest.Server, event, body, token string) (*http.Response, string) {
+	t.Helper()
+	resp, raw, err := postKimiHookBody(ts, event, body, token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp, raw
+}
+
+func TestKimiHookUserAndStopEvents(t *testing.T) {
+	_, ts, sess, tok := newKimiHookTestServer(t)
+	resp, _ := postKimiHook(t, ts, "user-prompt-submit", `{"session_id":"x","cwd":"/tmp","prompt":"hello"}`, tok)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("user-prompt status %d", resp.StatusCode)
+	}
+	resp, _ = postKimiHook(t, ts, "stop", `{"session_id":"x","cwd":"/tmp"}`, tok)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stop status %d", resp.StatusCode)
+	}
+	sess.pumpMu.Lock()
+	types := make([]string, 0, len(sess.history))
+	for _, ev := range sess.history {
+		types = append(types, ev.Type)
+	}
+	sess.pumpMu.Unlock()
+	if len(types) < 2 || types[len(types)-2] != protocol.EventUserMessage || types[len(types)-1] != protocol.EventAgentStatus {
+		t.Fatalf("unexpected history types: %v", types)
+	}
+}
+
+func TestKimiHookPreToolUseAutoAllowsReadTools(t *testing.T) {
+	if !kimiGatedTools()["Bash"] {
+		t.Fatal("Bash tool must be gated (kimi-code uses Bash, not Shell)")
+	}
+	_, ts, sess, tok := newKimiHookTestServer(t)
+	resp, body := postKimiHook(t, ts, "pre-tool-use",
+		`{"session_id":"x","cwd":"/tmp","tool_name":"ReadFile","tool_input":{"path":"/tmp/a"}}`, tok)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	if !strings.Contains(body, `"permissionDecision":"allow"`) {
+		t.Fatalf("expected allow, got %s", body)
+	}
+	sess.pumpMu.Lock()
+	last := sess.history[len(sess.history)-1]
+	sess.pumpMu.Unlock()
+	if last.Type != protocol.EventToolCall {
+		t.Fatalf("expected tool started event, got %s", last.Type)
+	}
+}
+
+func TestKimiHookPreToolUseGatesShellUntilDecision(t *testing.T) {
+	srv, ts, sess, tok := newKimiHookTestServer(t)
+	var wg sync.WaitGroup
+	var resp *http.Response
+	var body string
+	var postErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, body, postErr = postKimiHookBody(ts, "pre-tool-use",
+			`{"session_id":"x","cwd":"/tmp","tool_name":"Shell","tool_input":{"command":"rm -rf /tmp/x"}}`, tok)
+	}()
+
+	// Wait for the pending approval to register, then approve from "phone".
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		srv.mu.Lock()
+		n := len(srv.pendingHooks)
+		srv.mu.Unlock()
+		if n == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("approval never registered")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	srv.mu.Lock()
+	for id, ch := range srv.pendingHooks {
+		delete(srv.pendingHooks, id)
+		ch <- "approve"
+	}
+	srv.mu.Unlock()
+	wg.Wait()
+	if postErr != nil {
+		t.Fatal(postErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	if !strings.Contains(body, `"permissionDecision":"allow"`) {
+		t.Fatalf("expected allow after approval, got %s", body)
+	}
+	// History must contain the approval request and a started tool row.
+	sess.pumpMu.Lock()
+	var hasApproval bool
+	for _, ev := range sess.history {
+		if ev.Type == protocol.EventApprovalReq {
+			hasApproval = true
+		}
+	}
+	sess.pumpMu.Unlock()
+	if !hasApproval {
+		t.Fatal("approval request event missing from history")
+	}
+}
+
+func TestKimiHookPostToolUseShell(t *testing.T) {
+	_, ts, sess, tok := newKimiHookTestServer(t)
+	resp, _ := postKimiHook(t, ts, "post-tool-use",
+		`{"session_id":"x","cwd":"/tmp","tool_name":"Shell","tool_input":{"command":"ls"}}`, tok)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	sess.pumpMu.Lock()
+	types := make([]string, 0, len(sess.history))
+	for _, ev := range sess.history {
+		types = append(types, ev.Type)
+	}
+	sess.pumpMu.Unlock()
+	if types[len(types)-2] != protocol.EventCommand || types[len(types)-1] != protocol.EventToolCall {
+		t.Fatalf("unexpected history: %v", types)
+	}
+}

--- a/apps/daemon/internal/daemon/server.go
+++ b/apps/daemon/internal/daemon/server.go
@@ -276,6 +276,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/hooks/claude/post-tool-use", s.handleHookPostToolUse)
 	mux.HandleFunc("/hooks/claude/user-prompt-submit", s.handleHookUserPromptSubmit)
 	mux.HandleFunc("/hooks/claude/message-display", s.handleHookMessageDisplay)
+	mux.HandleFunc("/hooks/kimi/", s.handleKimiHook)
 	return s.localAuth(mux)
 }
 

--- a/apps/daemon/internal/kimi/kimi.go
+++ b/apps/daemon/internal/kimi/kimi.go
@@ -12,7 +12,10 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/url"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -49,15 +52,22 @@ type Kimi struct {
 	cwd     string
 	prompt  string
 	binary  string
+	dataDir string
 	events  chan protocol.Event
 	stopCh  chan struct{}
 	doneCh  chan struct{}
 	readyCh chan struct{}
 
 	mu            sync.Mutex
+	interactive   bool
 	ctx           context.Context
 	cmd           *exec.Cmd
 	stdin         io.WriteCloser
+	pty           *os.File
+	ptySubs       map[*ptyTerm]struct{}
+	hookBase      string
+	hookToken     string
+	configPath    string
 	launched      bool
 	exited        bool
 	sessionID     string
@@ -81,14 +91,123 @@ func New(req adapter.CreateRequest) *Kimi {
 		cwd:           req.Cwd,
 		prompt:        req.Prompt,
 		binary:        binary,
+		dataDir:       req.DataDir,
 		events:        make(chan protocol.Event, 256),
 		stopCh:        make(chan struct{}),
 		doneCh:        make(chan struct{}),
 		readyCh:       make(chan struct{}),
 		nextRequestID: 1,
+		interactive:   true,
+		ptySubs:       make(map[*ptyTerm]struct{}),
+		hookBase:      req.HookBase,
+		hookToken:     req.HookToken,
 		pending:       make(map[string]pendingApproval),
 		pendingTools:  make(map[string]pendingTool),
 	}
+}
+
+// ptyTerm is one console attached to the interactive TUI. The type is
+// platform-neutral; the PTY-backed methods live in tui_unix.go.
+type ptyTerm struct {
+	k  *Kimi
+	ch chan []byte
+}
+
+// kimiHookSpec describes one [[hooks]] entry in the per-session config.
+type kimiHookSpec struct {
+	event   string // Kimi hook event name
+	route   string // daemon route suffix
+	timeout int
+}
+
+func kimiHookSpecs() []kimiHookSpec {
+	return []kimiHookSpec{
+		{event: "SessionStart", route: "session-start", timeout: 10},
+		{event: "SessionEnd", route: "session-end", timeout: 10},
+		{event: "UserPromptSubmit", route: "user-prompt-submit", timeout: 30},
+		{event: "PreToolUse", route: "pre-tool-use", timeout: 600},
+		{event: "PostToolUse", route: "post-tool-use", timeout: 30},
+		{event: "PostToolUseFailure", route: "post-tool-use-failure", timeout: 30},
+		{event: "Stop", route: "stop", timeout: 30},
+		{event: "Notification", route: "notification", timeout: 30},
+	}
+}
+
+// writeSessionHome builds an isolated per-session kimi home:
+//
+//	<dataDir>/sessions/<id>/kimi-home/
+//	  config.toml   = user's config + riffpad [[hooks]] (daemon-routed)
+//	  credentials/  = symlink to the user's real home (auth preserved)
+//	  sessions/…    = symlinked so resume and history still work
+//
+// kimi is launched with KIMI_CODE_HOME=<that dir>, so plain `kimi` runs never
+// see riffpad hooks. The session id rides in each hook URL so the daemon
+// routes events to the right session.
+func (k *Kimi) writeSessionHome() error {
+	dir := filepath.Join(k.dataDir, "sessions", k.id)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	home := filepath.Join(dir, "kimi-home")
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		return err
+	}
+	k.configPath = filepath.Join(home, "config.toml")
+
+	var body strings.Builder
+	if realHome, userCfg, err := findUserKimiHome(); err == nil && userCfg != "" {
+		body.WriteString(userCfg)
+		if !strings.HasSuffix(body.String(), "\n") {
+			body.WriteString("\n")
+		}
+		// Symlink everything else (credentials, sessions, blobs, store, …) so
+		// login state and session history behave exactly like a normal kimi.
+		entries, _ := os.ReadDir(realHome)
+		for _, e := range entries {
+			if e.Name() == "config.toml" || e.Name() == "config.json" {
+				continue
+			}
+			src := filepath.Join(realHome, e.Name())
+			dst := filepath.Join(home, e.Name())
+			if _, err := os.Lstat(dst); os.IsNotExist(err) {
+				_ = os.Symlink(src, dst)
+			}
+		}
+	}
+	body.WriteString("\n# riffpad hooks (per-session, generated)\n")
+	for _, spec := range kimiHookSpecs() {
+		hookURL := k.hookBase + "/hooks/kimi/" + spec.route + "?session=" + k.id
+		if k.hookToken != "" {
+			hookURL += "&token=" + url.QueryEscape(k.hookToken)
+		}
+		fmt.Fprintf(&body, "[[hooks]]\n")
+		fmt.Fprintf(&body, "event = %q\n", spec.event)
+		fmt.Fprintf(&body, "matcher = \"\"\n")
+		fmt.Fprintf(&body, "command = %q\n", "curl -sS --max-time 590 -X POST '"+hookURL+"' -H 'Content-Type: application/json' --data-binary @-")
+		fmt.Fprintf(&body, "timeout = %d\n\n", spec.timeout)
+	}
+	return os.WriteFile(k.configPath, []byte(body.String()), 0o600)
+}
+
+// findUserKimiHome returns the user's real kimi home and config.toml text.
+func findUserKimiHome() (string, string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", "", err
+	}
+	for _, dir := range []string{
+		filepath.Join(home, ".kimi-code"),
+		filepath.Join(home, ".kimi"),
+	} {
+		raw, err := os.ReadFile(filepath.Join(dir, "config.toml"))
+		if err == nil {
+			return dir, string(raw), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", "", err
+		}
+	}
+	return "", "", os.ErrNotExist
 }
 
 func (k *Kimi) ID() string                    { return k.id }
@@ -105,6 +224,12 @@ func (k *Kimi) Start(ctx context.Context) error {
 	k.mu.Unlock()
 	if err := k.ensureStarted(); err != nil {
 		return err
+	}
+	if k.interactive {
+		if k.prompt != "" {
+			return k.SendPrompt(k.prompt)
+		}
+		return nil
 	}
 	if k.prompt != "" {
 		if err := k.waitReady(); err != nil {
@@ -132,6 +257,13 @@ func (k *Kimi) ensureStarted() error {
 }
 
 func (k *Kimi) spawn(ctx context.Context) error {
+	if k.interactive {
+		if err := k.spawnInteractive(ctx); err == nil {
+			return nil
+		} else {
+			log.Printf("kimi[%s] interactive spawn failed (%v); falling back to ACP", k.id, err)
+		}
+	}
 	cmd := exec.CommandContext(ctx, k.binary, "acp")
 	if k.cwd != "" {
 		cmd.Dir = k.cwd
@@ -192,6 +324,9 @@ func (k *Kimi) Stop() error {
 	if k.cmd != nil && k.cmd.Process != nil {
 		_ = k.cmd.Process.Kill()
 	}
+	if k.pty != nil {
+		_ = k.pty.Close()
+	}
 	<-k.doneCh
 	return nil
 }
@@ -207,6 +342,12 @@ func (k *Kimi) Alive() bool {
 func (k *Kimi) SendPrompt(text string) error {
 	if err := k.ensureStarted(); err != nil {
 		return err
+	}
+	if k.interactive && k.pty != nil {
+		if _, err := fmt.Fprintf(k.pty, "%s\r", text); err != nil {
+			return err
+		}
+		return nil
 	}
 	if err := k.waitReady(); err != nil {
 		return err

--- a/apps/daemon/internal/kimi/kimi_test.go
+++ b/apps/daemon/internal/kimi/kimi_test.go
@@ -1,158 +1,69 @@
 package kimi
 
 import (
-	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
-	"github.com/riffpad/riffpad/packages/protocol"
 )
 
-type fakeWriteCloser struct {
-	bytes.Buffer
-}
-
-func (f *fakeWriteCloser) Close() error { return nil }
-
-func nextEvent(t *testing.T, c *Kimi) protocol.Event {
-	t.Helper()
-	select {
-	case ev := <-c.Events():
-		return ev
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for event")
-		return protocol.Event{}
-	}
-}
-
-func TestInitializeAndSessionNew(t *testing.T) {
-	k := New(adapter.CreateRequest{ID: "s1", Cwd: "/tmp/proj"})
-	k.handleLine([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"agentInfo":{"name":"Kimi Code CLI","version":"x"}}}`))
-	k.handleLine([]byte(`{"jsonrpc":"2.0","id":2,"result":{"sessionId":"session_abc","configOptions":[]}}`))
-	select {
-	case <-k.readyCh:
-	case <-time.After(time.Second):
-		t.Fatal("expected ready after session/new")
-	}
-	if k.sessionID != "session_abc" {
-		t.Fatalf("unexpected session id %q", k.sessionID)
-	}
-}
-
-func TestAgentMessageChunksAggregated(t *testing.T) {
-	k := New(adapter.CreateRequest{ID: "s1"})
-	k.handleLine([]byte(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hel"}}}}`))
-	k.handleLine([]byte(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"lo"}}}}`))
-	k.handleLine([]byte(`{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn"}}`))
-	ev := nextEvent(t, k)
-	if ev.Type != protocol.EventAgentMessage {
-		t.Fatalf("expected agent_message, got %s", ev.Type)
-	}
-	var p protocol.AgentMessagePayload
-	if err := ev.DecodePayload(&p); err != nil {
+func TestWriteSessionConfigRegistersAllHooks(t *testing.T) {
+	k := New(adapter.CreateRequest{
+		ID:        "s1",
+		DataDir:   t.TempDir(),
+		HookBase:  "http://127.0.0.1:8787",
+		HookToken: "tok",
+	})
+	if err := k.writeSessionHome(); err != nil {
 		t.Fatal(err)
 	}
-	if p.Text != "Hello" {
-		t.Fatalf("expected aggregated text %q, got %q", "Hello", p.Text)
+	data, err := os.ReadFile(k.configPath)
+	if err != nil {
+		t.Fatal(err)
 	}
-	ev = nextEvent(t, k)
-	if ev.Type != protocol.EventAgentStatus {
-		t.Fatalf("expected agent_status, got %s", ev.Type)
+	body := string(data)
+	if got := strings.Count(body, "[[hooks]]"); got != len(kimiHookSpecs()) {
+		t.Fatalf("expected %d hooks, got %d\n%s", len(kimiHookSpecs()), got, body)
+	}
+	for _, spec := range kimiHookSpecs() {
+		if !strings.Contains(body, "event = "+strconvQuote(spec.event)) {
+			t.Fatalf("missing hook event %s\n%s", spec.event, body)
+		}
+		if !strings.Contains(body, "/hooks/kimi/"+spec.route+"?session=s1") {
+			t.Fatalf("hook %s missing session-routed URL\n%s", spec.event, body)
+		}
+	}
+	if !strings.Contains(body, "token=tok") {
+		t.Fatalf("hook commands missing token\n%s", body)
 	}
 }
 
-func TestToolCallEvents(t *testing.T) {
-	k := New(adapter.CreateRequest{ID: "s1"})
-	k.handleLine([]byte(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"tool_call","toolCall":{"toolCallId":"t1","title":"Run command","kind":"shell","status":"running","rawInput":{"command":"ls"}}}}}`))
-	k.handleLine([]byte(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"tool_call_update","toolCall":{"toolCallId":"t1","title":"Run command","status":"completed","rawOutput":"src"}}}}`))
-	ev := nextEvent(t, k)
-	if ev.Type != protocol.EventToolCall {
-		t.Fatalf("expected tool_call, got %s", ev.Type)
-	}
-	var p protocol.ToolCallPayload
-	if err := ev.DecodePayload(&p); err != nil {
+func TestWriteSessionConfigPreservesUserConfig(t *testing.T) {
+	home := t.TempDir()
+	cfgDir := filepath.Join(home, ".kimi-code")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if p.Tool != "Run command" || p.Status != "started" {
-		t.Fatalf("unexpected tool call: %+v", p)
-	}
-	ev = nextEvent(t, k)
-	if err := ev.DecodePayload(&p); err != nil {
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"),
+		[]byte("default_model = \"kimi-code/k3\"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if p.Status != "completed" {
-		t.Fatalf("expected completed, got %s", p.Status)
+	t.Setenv("HOME", home)
+	k := New(adapter.CreateRequest{ID: "s1", DataDir: t.TempDir(), HookBase: "http://127.0.0.1:8787"})
+	if err := k.writeSessionHome(); err != nil {
+		t.Fatal(err)
 	}
-	// The completed tool_call must keep the started identity so the client
-	// can merge it in place instead of showing a duplicate row.
-	if p.Summary == "" {
-		t.Fatalf("expected summary on completed tool call, got %+v", p)
+	data, err := os.ReadFile(k.configPath)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if cmd, ok := p.Args["command"].(string); !ok || cmd != "ls" {
-		t.Fatalf("expected args.command=ls on completed tool call, got %+v", p.Args)
+	if !strings.Contains(string(data), "default_model = \"kimi-code/k3\"") {
+		t.Fatalf("user config not preserved:\n%s", data)
 	}
 }
 
-func TestPermissionRequestAndApproval(t *testing.T) {
-	k := New(adapter.CreateRequest{ID: "s1"})
-	fw := &fakeWriteCloser{}
-	k.stdin = fw
-	k.handleLine([]byte(`{"jsonrpc":"2.0","id":"perm_1","method":"session/request_permission","params":{"sessionId":"s1","toolCall":{"toolCallId":"t1","title":"Write file","kind":"write","rawInput":{"filePath":"/tmp/x"}},"options":[{"optionId":"allow","name":"Allow","kind":"allow_once"},{"optionId":"reject","name":"Reject","kind":"reject_once"}]}}`))
-	ev := nextEvent(t, k)
-	if ev.Type != protocol.EventApprovalReq {
-		t.Fatalf("expected approval_request, got %s", ev.Type)
-	}
-	var p protocol.ApprovalRequestPayload
-	if err := ev.DecodePayload(&p); err != nil {
-		t.Fatal(err)
-	}
-	if p.RequestID != "perm_1" || p.Action != "Write file" {
-		t.Fatalf("unexpected approval: %+v", p)
-	}
-	if err := k.SendApproval("perm_1", "approve"); err != nil {
-		t.Fatal(err)
-	}
-	out := fw.String()
-	if !strings.Contains(out, `"optionId":"allow"`) || !strings.Contains(out, `"outcome":"selected"`) {
-		t.Fatalf("unexpected approval response: %s", out)
-	}
-	if err := k.SendApproval("perm_1", "approve"); err == nil {
-		t.Fatal("expected error for already-resolved approval")
-	}
-}
-
-func TestPermissionTimeoutDefaultsReject(t *testing.T) {
-	old := approvalTimeout
-	approvalTimeout = 50 * time.Millisecond
-	defer func() { approvalTimeout = old }()
-
-	k := New(adapter.CreateRequest{ID: "s1"})
-	fw := &fakeWriteCloser{}
-	k.stdin = fw
-	k.handleLine([]byte(`{"jsonrpc":"2.0","id":"perm_9","method":"session/request_permission","params":{"sessionId":"s1","toolCall":{"toolCallId":"t1","title":"Write file","kind":"write","rawInput":{"filePath":"/tmp/x"}},"options":[{"optionId":"allow","name":"Allow","kind":"allow_once"},{"optionId":"reject","name":"Reject","kind":"reject_once"}]}}`))
-	ev := nextEvent(t, k)
-	if ev.Type != protocol.EventApprovalReq {
-		t.Fatalf("expected approval_request, got %s", ev.Type)
-	}
-	// No viewer answers: the request must time out into a reject (never an
-	// allow fallback) and settle the card on every viewer (#171).
-	ev = nextEvent(t, k)
-	if ev.Type != protocol.EventApprovalResolved {
-		t.Fatalf("expected approval_resolved, got %s", ev.Type)
-	}
-	var p protocol.ApprovalResolvedPayload
-	if err := ev.DecodePayload(&p); err != nil {
-		t.Fatal(err)
-	}
-	if p.RequestID != "perm_9" || p.Decision != "reject" {
-		t.Fatalf("unexpected resolution: %+v", p)
-	}
-	if out := fw.String(); !strings.Contains(out, `"optionId":"reject"`) {
-		t.Fatalf("expected reject option answered to ACP server, got %s", out)
-	}
-	if err := k.SendApproval("perm_9", "approve"); err == nil {
-		t.Fatal("expected error for timed-out approval")
-	}
+func strconvQuote(s string) string {
+	return "\"" + s + "\""
 }

--- a/apps/daemon/internal/kimi/tui_unix.go
+++ b/apps/daemon/internal/kimi/tui_unix.go
@@ -1,0 +1,139 @@
+//go:build !windows
+
+package kimi
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
+)
+
+// spawnInteractive launches Kimi's real interactive TUI on a PTY the daemon
+// owns, using a per-session config.toml with [[hooks]] pointing at the local
+// daemon. `--yolo` turns off Kimi's own in-terminal permission prompts; the
+// PreToolUse hook becomes the (remote-controllable) approval gate instead.
+func (k *Kimi) spawnInteractive(ctx context.Context) error {
+	if err := k.writeSessionHome(); err != nil {
+		return fmt.Errorf("write session home: %w", err)
+	}
+	kimiHome := filepath.Dir(k.configPath)
+	args := []string{"--yolo"}
+	cmd := exec.CommandContext(ctx, k.binary, args...)
+	if k.cwd != "" {
+		cmd.Dir = k.cwd
+	}
+	cmd.Env = append(os.Environ(), "KIMI_CODE_HOME="+kimiHome)
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		return fmt.Errorf("start %s TUI: %w", k.binary, err)
+	}
+	k.mu.Lock()
+	k.cmd = cmd
+	k.pty = ptmx
+	k.mu.Unlock()
+	go func() {
+		_ = cmd.Wait()
+		k.mu.Lock()
+		k.exited = true
+		k.mu.Unlock()
+		_ = ptmx.Close()
+		k.closePTYSubs()
+		close(k.doneCh)
+	}()
+	go k.ptyReadLoop()
+	return nil
+}
+
+// ptyReadLoop drains the PTY master and fans output to attached consoles;
+// with none attached, bytes are discarded so the TUI never blocks.
+func (k *Kimi) ptyReadLoop() {
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := k.pty.Read(buf)
+		if n > 0 {
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+			k.mu.Lock()
+			for sub := range k.ptySubs {
+				select {
+				case sub.ch <- chunk:
+				default:
+				}
+			}
+			k.mu.Unlock()
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (k *Kimi) closePTYSubs() {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	for sub := range k.ptySubs {
+		close(sub.ch)
+		delete(k.ptySubs, sub)
+	}
+}
+
+// AttachPTY hands a console to the interactive TUI, waiting briefly for the
+// TUI process to start.
+func (k *Kimi) AttachPTY() (adapter.Terminal, error) {
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		k.mu.Lock()
+		ptyFile := k.pty
+		k.mu.Unlock()
+		if ptyFile != nil {
+			t := &ptyTerm{k: k, ch: make(chan []byte, 256)}
+			k.mu.Lock()
+			k.ptySubs[t] = struct{}{}
+			k.mu.Unlock()
+			return t, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("PTY not ready after 15s")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func (t *ptyTerm) Read(p []byte) (int, error) {
+	chunk, ok := <-t.ch
+	if !ok {
+		return 0, io.EOF
+	}
+	return copy(p, chunk), nil
+}
+
+func (t *ptyTerm) Write(p []byte) (int, error) {
+	if t.k.pty == nil {
+		return 0, fmt.Errorf("PTY closed")
+	}
+	return t.k.pty.Write(p)
+}
+
+func (t *ptyTerm) Resize(cols, rows uint16) error {
+	if t.k.pty == nil {
+		return fmt.Errorf("PTY closed")
+	}
+	return pty.Setsize(t.k.pty, &pty.Winsize{Cols: cols, Rows: rows})
+}
+
+func (t *ptyTerm) Close() error {
+	t.k.mu.Lock()
+	defer t.k.mu.Unlock()
+	if _, ok := t.k.ptySubs[t]; ok {
+		delete(t.k.ptySubs, t)
+		close(t.ch)
+	}
+	return nil
+}

--- a/apps/daemon/internal/kimi/tui_windows.go
+++ b/apps/daemon/internal/kimi/tui_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package kimi
+
+import (
+	"context"
+	"fmt"
+)
+
+// spawnInteractive is unsupported on Windows; the adapter falls back to ACP.
+func (k *Kimi) spawnInteractive(ctx context.Context) error {
+	return fmt.Errorf("interactive PTY not supported on Windows")
+}

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -195,7 +195,7 @@
 | M3.11 | CLI 命令完善：`login/logout` + `update` 自更新 | `[x]` | 旧命令保留别名；update 校验/备份/原子替换 | #64 #65 |
 | M3.12 | CLI 多语种（i18n） | `[x]` | zh/en 语言包；`--lang` > 环境变量 > 英文兜底 | #67 |
 | M3.13 | 第三方登录：Google / Email（OAuth + 邮箱验证码） | `[ ]` | GitHub OAuth 已完成（M1.18 #105）；Google（国内可用性低）、Email（需 SMTP）暂缓 | — |
-| M3.14 | 托管模式无感化：`riffpad run` 后电脑终端照常显示/操作 CLI TUI，手机同步遥控 | `[~]` | Codex：`--remote` 共享 app-server 已完成（#74 #79）；Claude：daemon PTY 桥 + per-session hooks 已实现（前台 TUI、事件/审批、`/api/sessions/{id}/pty`），真机验证通过待合并（#230）；Kimi：前台方案待确认（无官方 attach 通道）；Ctrl-C 退出即退出，持久会话由用户 tmux（docs 强烈推荐） | #74 #79 #230 |
+| M3.14 | 托管模式无感化：`riffpad run` 后电脑终端照常显示/操作 CLI TUI，手机同步遥控 | `[x]` | Codex：`--remote` 共享 app-server（#74 #79）；Claude：daemon PTY 桥 + per-session hooks（#230 #231）；Kimi：`KIMI_CODE_HOME` 每会话 home + 原生 `[[hooks]]`（PreToolUse 审批闸门/Bash 门控，真机验证 0.34.0）（#232）；Ctrl-C 退出即退出，持久会话由用户 tmux（docs 强烈推荐） | #74 #79 #230 #232 |
 | M3.15 | 容器化部署：relay + Postgres 容器化 | `[x]` | 已随 M1.18 完成：relay 仅监听 127.0.0.1:9090、Postgres 17、healthcheck/restart、nginx/certbot 留宿主；生产运行中 | — |
 | M3.16 | 元数据存储 SQLite → Postgres 迁移 | `[x]` | 已随 M1.18 完成：`apps/relay/cmd/migrate-sqlite` 逐表迁移 + 行数校验，生产已切换 Postgres | — |
 | M3.17 | CI/CD：main push → 自动部署 relay（GitHub Actions + SSH 受限部署密钥） | `[x]` | CI 三 job 通过后自动执行 `/usr/local/bin/riffpad-deploy.sh`（git pull --ff-only + compose up -d --build + 健康检查）；部署密钥仅能执行固定脚本；2026-08-07 已端到端验证 | #108 #112 #113 |


### PR DESCRIPTION
Closes #232

## 关键发现
Kimi Code（0.34.0 实测）原生有 hooks 系统（含 PreToolUse 同步闸门），且支持 `KIMI_CODE_HOME` 环境变量指定 home。没有 `--config-file`，但用 `KIMI_CODE_HOME` 指向每会话 home 即可完全隔离：config.toml = 用户配置 + riffpad [[hooks]]，其余目录（credentials/sessions/…）symlink 自真实 home，OAuth 与历史不受影响；普通 `kimi` 运行永远看不到 riffpad hooks。

## 改动
- kimi 适配器 interactive 模式：PTY 启动 `kimi --yolo`（关掉 kimi 自己的审批，PreToolUse hook 成为唯一远程审批闸门）
- `writeSessionHome`：生成每会话 kimi-home + 8 个 hooks（curl → daemon，session/token 在 URL）
- daemon `/hooks/kimi/*`：UserPromptSubmit/Stop/Session/Notification 事件；PreToolUse 对 Bash/Shell/WriteFile/StrReplaceFile 做手机审批闸门（挂起等待决议，allow/deny 回 JSON）；PostToolUse 命令/文件/工具完成事件
- CLI：`riffpad run kimi` 前台附着（复用 Claude 的 console 通道）
- 测试：每会话 config（hooks 全量 + 用户配置保留）、hook 事件、读工具自动放行、Bash/Shell 门控等待决议；linux/windows/darwin 构建通过

## 真机验证（本机 kimi-code 0.34.0）
- [x] 前台真实 TUI；`hi` 正常回复；UserPromptSubmit hook 返回 {"ok":true}
- [x] 让 kimi 跑 `ls /tmp`：PreToolUse 挂起、命令不执行、事件落盘（events.enc 853→1956B）、hook curl 进程挂在 daemon 等审批
- [ ] 手机端同意/拒绝复测（单测已覆盖决议路径）