### PR TITLE
chore(copy): drop "pocket" tagline, standardize messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Riffpad
 
-**The pocket remote for your AI coding agents.**
+**Watch, approve, and steer AI coding agents from your phone.**
 
 Watch, approve, and steer Claude Code, Codex, and other AI coding CLIs from your phone — without staying chained to the desk.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,7 @@
 
 # Riffpad
 
-**AI coding agent 的口袋遥控器。**
+**AI coding agent 的手机遥控器。**
 
 在手机上查看、批准、遥控 Claude Code、Codex 等 AI coding CLI，不用再守在电脑前。
 

--- a/apps/client-beta/index.html
+++ b/apps/client-beta/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content" />
     <title>Riffpad</title>
-    <meta name="description" content="Riffpad — pocket remote for AI coding agents. Watch, approve and steer Claude Code, Codex and other CLI agents from your phone." />
+    <meta name="description" content="Watch, approve, and steer Claude Code, Codex and other CLI agents from your phone. End-to-end encrypted, local-first." />
     <meta name="color-scheme" content="light dark" />
     <meta name="theme-color" content="#121214" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
@@ -43,13 +43,13 @@
         }
       })();
     </script>
-    <meta property="og:title" content="Riffpad — pocket remote for AI coding agents" />
+    <meta property="og:title" content="Riffpad — Watch, approve, and steer AI coding agents from your phone" />
     <meta property="og:description" content="Watch, approve and steer AI coding CLIs from your phone. Local daemon, end-to-end encryption, zero-knowledge relay." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://app.riffpad.ai/" />
     <meta property="og:site_name" content="Riffpad" />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="Riffpad — pocket remote for AI coding agents" />
+    <meta name="twitter:title" content="Riffpad — Watch, approve, and steer AI coding agents from your phone" />
     <meta name="twitter:description" content="Watch, approve and steer AI coding CLIs from your phone." />
     <script>
       // Dev convenience: ?relay=1 makes the embedded client behave like the

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -59,7 +59,7 @@ const enSidebar = [
 
 export default defineConfig({
   title: "Riffpad",
-  description: "AI coding agent 的口袋遥控器 / The pocket remote for AI coding agents",
+  description: "AI coding agent 的手机遥控器 / Watch, approve, and steer AI coding agents from your phone",
   base: "/docs/",
   cleanUrls: true,
   ignoreDeadLinks: true,

--- a/apps/landing/DESIGN.md
+++ b/apps/landing/DESIGN.md
@@ -15,7 +15,7 @@ description: |
 
 ## 1. Concept
 
-Riffpad is the pocket remote for AI coding agents. The design language says
+Riffpad lets you watch, approve, and steer AI coding agents from your phone. The design language says
 that in one sentence: **a terminal console and a phone, fused**.
 
 - The page keeps a quiet terminal tone: `//` comment labels, status dots,

--- a/apps/landing/app/layout.tsx
+++ b/apps/landing/app/layout.tsx
@@ -14,7 +14,7 @@ const geistMono = localFont({
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://riffpad.ai"),
-  title: "Riffpad - The pocket remote for your AI coding agents",
+  title: "Riffpad - Watch, approve, and steer AI coding agents from your phone",
   description:
     "Watch, approve and steer Claude Code, Codex and other AI coding CLIs from your phone. Local daemon, end-to-end encryption, zero-knowledge relay.",
   keywords: [
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
     canonical: "/",
   },
   openGraph: {
-    title: "Riffpad - The pocket remote for your AI coding agents",
+    title: "Riffpad - Watch, approve, and steer AI coding agents from your phone",
     description:
       "Watch, approve and steer AI coding CLIs from your phone. Local daemon, end-to-end encryption, zero-knowledge relay.",
     url: "https://riffpad.ai",
@@ -40,7 +40,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Riffpad - The pocket remote for your AI coding agents",
+    title: "Riffpad - Watch, approve, and steer AI coding agents from your phone",
     description:
       "Watch, approve and steer AI coding CLIs from your phone. Local daemon, end-to-end encryption, zero-knowledge relay.",
   },

--- a/apps/landing/lib/i18n.ts
+++ b/apps/landing/lib/i18n.ts
@@ -3,7 +3,7 @@ export type Language = "en" | "zh";
 const en = {
   hero: {
     title1: "Your AI coding agents,",
-    title2: "in your pocket.",
+    title2: "synced to your phone.",
     description:
       "Riffpad bridges Claude Code, Codex and other CLI agents to your phone — watch progress, approve actions and steer sessions without staying chained to the desk.",
     ctaPrimary: "Get Started",
@@ -208,7 +208,7 @@ const en = {
 const zh: typeof en = {
   hero: {
     title1: "你的 AI 编程 Agent，",
-    title2: "装进你的口袋。",
+    title2: "同步到手机。",
     description:
       "Riffpad 把 Claude Code、Codex 等 CLI agent 桥接到手机：随时看进度、批准操作、远程转向，人不必守在电脑前。",
     ctaPrimary: "开始使用",


### PR DESCRIPTION
## What
Replace the "pocket remote" tagline with the new product positioning across all public-facing copy surfaces.

- **New tagline:** Watch, approve, and steer AI coding agents from your phone.
- **New hero H1:** Your AI coding agents, synced to your phone. / 你的 AI 编程 Agent，同步到手机。

## Why
"Pocket" reads as consumer-app fluff for a developer tool and buries the real differentiators (mobile control + end-to-end encryption). Standardizing on literal, action-oriented copy that says what the product does.

## Changed surfaces
- **Landing** (`apps/landing`): hero H1 (en/zh in `i18n.ts`) + `<title>`/OG/Twitter metadata (`layout.tsx`)
- **Docs site** (`apps/docs/.vitepress/config.mts`): site description
- **App** (`apps/client-beta/index.html`): meta description + OG/Twitter title for app.riffpad.ai
- **README** (en + zh): tagline
- **DESIGN.md**: slogan line

## Notes
- Intentionally left the `docs/prd.md` positioning line ("它会在你口袋里叫你") — internal source vision, not public copy.
- Build artifacts (`landing/out/`, `landing/public/docs/`, `webui/dist/`) still contain the old string and regenerate on next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
