### PR TITLE
feat(daemon): demo 会话模式——脚本化 mock 事件源，打磨 client UI 零 API 消耗 (#235)

### DIFF
--- a/apps/daemon/cmd/riffpad/main.go
+++ b/apps/daemon/cmd/riffpad/main.go
@@ -817,6 +817,10 @@ func runCmd(args []string, base string) error {
 	if data.CLI == "codex" {
 		return attachCodexTUI(base, data.ID)
 	}
+	if data.CLI == "demo" {
+		fmt.Println(t.T("session_url", data.ID, data.URL))
+		return nil
+	}
 	if data.CLI == "claude" || data.CLI == "kimi" {
 		if runtime.GOOS == "windows" {
 			fmt.Println(t.T("session_url", data.ID, data.URL))

--- a/apps/daemon/internal/daemon/demo_test.go
+++ b/apps/daemon/internal/daemon/demo_test.go
@@ -1,0 +1,46 @@
+package daemon
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/riffpad/riffpad/apps/daemon/internal/config"
+)
+
+// TestDemoSessionFactoryWiring: cli=demo must produce a runnable session
+// through the real HTTP create path, and stop cleanly.
+func TestDemoSessionFactoryWiring(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	keys, err := config.LoadOrCreateKeys(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := New(cfg, keys, dir, log.New(io.Discard, "", 0), nil)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp := authRequest(t, http.MethodPost, ts.URL+"/api/sessions", cfg.LocalToken,
+		strings.NewReader(`{"cli":"demo","cwd":"/tmp"}`))
+	var sess struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&sess); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || sess.ID == "" {
+		t.Fatalf("demo session create failed: status %d id %q", resp.StatusCode, sess.ID)
+	}
+
+	stop := authRequest(t, http.MethodPost, ts.URL+"/api/sessions/"+sess.ID+"/stop", cfg.LocalToken, nil)
+	stop.Body.Close()
+	if stop.StatusCode != http.StatusOK {
+		t.Fatalf("demo session stop failed: %d", stop.StatusCode)
+	}
+}

--- a/apps/daemon/internal/daemon/server.go
+++ b/apps/daemon/internal/daemon/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/riffpad/riffpad/apps/daemon/internal/claude"
 	"github.com/riffpad/riffpad/apps/daemon/internal/codex"
 	"github.com/riffpad/riffpad/apps/daemon/internal/config"
+	"github.com/riffpad/riffpad/apps/daemon/internal/demo"
 	"github.com/riffpad/riffpad/apps/daemon/internal/kimi"
 	"github.com/riffpad/riffpad/apps/daemon/internal/version"
 	"github.com/riffpad/riffpad/packages/protocol"
@@ -247,6 +248,8 @@ func DefaultFactory() adapter.Factory {
 			return kimi.New(req), nil
 		case "codex":
 			return codex.New(req), nil
+		case "demo":
+			return demo.New(req), nil
 		default:
 			return nil, fmt.Errorf("unsupported cli %q", req.CLI)
 		}

--- a/apps/daemon/internal/demo/demo.go
+++ b/apps/daemon/internal/demo/demo.go
@@ -1,0 +1,271 @@
+// Package demo provides a scripted adapter.Session that replays a unified
+// protocol event timeline (thinking, tool spinner → completed, file change,
+// approval card, agent reply) so the client UI can be exercised without a
+// real coding CLI or any API quota.
+package demo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
+	"github.com/riffpad/riffpad/packages/protocol"
+)
+
+// Delay is the pause between scripted events. A var so tests can set it to 0.
+var Delay = 450 * time.Millisecond
+
+// Demo is a scripted session.
+type Demo struct {
+	id     string
+	name   string
+	cwd    string
+	events chan protocol.Event
+	stopCh chan struct{}
+	doneCh chan struct{}
+
+	mu              sync.Mutex
+	started         bool
+	approval        map[string]chan string
+	nextApprovalSeq int
+}
+
+// New creates a scripted demo session.
+func New(req adapter.CreateRequest) *Demo {
+	return &Demo{
+		id:       req.ID,
+		name:     req.Name,
+		cwd:      req.Cwd,
+		events:   make(chan protocol.Event, 64),
+		stopCh:   make(chan struct{}),
+		doneCh:   make(chan struct{}),
+		approval: make(map[string]chan string),
+	}
+}
+
+func (d *Demo) ID() string                    { return d.id }
+func (d *Demo) Events() <-chan protocol.Event { return d.events }
+func (d *Demo) Meta() protocol.SessionStartPayload {
+	return protocol.SessionStartPayload{Name: d.name, CLI: "demo", Cwd: d.cwd}
+}
+
+// Start launches the welcome timeline.
+func (d *Demo) Start(_ context.Context) error {
+	d.mu.Lock()
+	if d.started {
+		d.mu.Unlock()
+		return nil
+	}
+	d.started = true
+	d.mu.Unlock()
+	go d.welcome()
+	return nil
+}
+
+func (d *Demo) emit(typ string, payload any) bool {
+	ev, err := protocol.NewEvent(d.id, typ, payload)
+	if err != nil {
+		return false
+	}
+	select {
+	case d.events <- ev:
+		return true
+	case <-d.stopCh:
+		return false
+	}
+}
+
+func (d *Demo) sleep() bool {
+	if Delay <= 0 {
+		return true
+	}
+	select {
+	case <-time.After(Delay):
+		return true
+	case <-d.stopCh:
+		return false
+	}
+}
+
+func (d *Demo) welcome() {
+	defer close(d.doneCh)
+	if !d.emit(protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: protocol.StatusRunning}) {
+		return
+	}
+	if !d.sleep() {
+		return
+	}
+	d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: "Hi! I'm the **Riffpad demo agent** — a scripted timeline, no real model, no API quota.\n\nTry sending me:\n- `tool` — watch a command spinner turn green\n- `approval` — trigger a phone approval card\n- `markdown` — rich formatting (code, lists, tables)"})
+	if !d.sleep() {
+		return
+	}
+	if !d.emitTool("npm test") {
+		return
+	}
+	if !d.sleep() {
+		return
+	}
+	d.emit(protocol.EventFileChange, protocol.FileChangePayload{
+		Path: "src/auth/middleware.ts", Summary: "updated",
+	})
+	if !d.sleep() {
+		return
+	}
+	decided, ok := d.requestApproval("Bash", "rm src/old.ts", "删除不再使用的文件")
+	if !ok {
+		return
+	}
+	text := "Approved — `src/old.ts` removed, tests still green."
+	if decided != "approve" {
+		text = "Rejected — the agent paused and will try another approach."
+	}
+	if !d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: text}) {
+		return
+	}
+	if !d.sleep() {
+		return
+	}
+	d.emit(protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: protocol.StatusWaitingInput})
+}
+
+// emitTool plays a Bash tool spinner → command output → completed row.
+func (d *Demo) emitTool(command string) bool {
+	if !d.emit(protocol.EventToolCall, protocol.ToolCallPayload{
+		Tool: "Bash", Status: "started", Summary: command,
+	}) {
+		return false
+	}
+	if !d.sleep() {
+		return false
+	}
+	exit := 0
+	if !d.emit(protocol.EventCommand, protocol.CommandPayload{
+		Command: command, ExitCode: &exit, Output: "42 passed · 0 failed · 1.8s",
+	}) {
+		return false
+	}
+	if !d.sleep() {
+		return false
+	}
+	return d.emit(protocol.EventToolCall, protocol.ToolCallPayload{
+		Tool: "Bash", Status: "completed", Summary: command,
+	})
+}
+
+func (d *Demo) requestApproval(action, summary, detail string) (string, bool) {
+	d.mu.Lock()
+	d.nextApprovalSeq++
+	reqID := fmt.Sprintf("demo-approval-%d", d.nextApprovalSeq)
+	ch := make(chan string, 1)
+	d.approval[reqID] = ch
+	d.mu.Unlock()
+	if !d.emit(protocol.EventApprovalReq, protocol.ApprovalRequestPayload{
+		RequestID: reqID,
+		Action:    action,
+		Summary:   summary,
+		Options:   []string{"approve", "reject"},
+		Args:      map[string]any{"detail": detail},
+	}) {
+		return "", false
+	}
+	select {
+	case dec := <-ch:
+		d.mu.Lock()
+		delete(d.approval, reqID)
+		d.mu.Unlock()
+		return dec, true
+	case <-d.stopCh:
+		return "", false
+	}
+}
+
+// SendApproval resolves a pending scripted approval.
+func (d *Demo) SendApproval(requestID, decision string) error {
+	d.mu.Lock()
+	ch, ok := d.approval[requestID]
+	d.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("no pending approval %s", requestID)
+	}
+	mapped := "reject"
+	if decision == "approve" {
+		mapped = "approve"
+	}
+	ch <- mapped
+	return nil
+}
+
+// SendPrompt starts a scripted reply turn. Keywords switch the demo path.
+func (d *Demo) SendPrompt(text string) error {
+	go d.reply(text)
+	return nil
+}
+
+func (d *Demo) reply(text string) {
+	if !d.emit(protocol.EventUserMessage, protocol.PromptPayload{Text: text}) {
+		return
+	}
+	if !d.sleep() {
+		return
+	}
+	if !d.emit(protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: protocol.StatusRunning}) {
+		return
+	}
+	if !d.sleep() {
+		return
+	}
+	switch {
+	case strings.Contains(strings.ToLower(text), "approval"):
+		decided, ok := d.requestApproval("WriteFile", "src/new-feature.ts", "创建新功能文件")
+		if !ok {
+			return
+		}
+		msg := "Approved — file written."
+		if decided != "approve" {
+			msg = "Rejected — agent paused."
+		}
+		d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: msg})
+	case strings.Contains(strings.ToLower(text), "tool"):
+		if !d.emitTool("pnpm test") {
+			return
+		}
+		if !d.sleep() {
+			return
+		}
+		d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: "All checks passed ✅"})
+	case strings.Contains(strings.ToLower(text), "markdown") || strings.Contains(strings.ToLower(text), "code"):
+		d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: "Here's a **markdown** demo:\n\n1. First item\n2. Second item\n\n```ts\nconst ok = (x: number) => x * 2;\nconsole.log(ok(21)); // 42\n```\n\n| cli | status |\n|---|---|\n| codex | foreground |\n| claude | foreground |\n| kimi | foreground |"})
+	default:
+		d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{
+			Text: "You said: " + text + "\n\nThis is a scripted demo reply — send `tool`, `approval` or `markdown` to explore more UI states.",
+		})
+	}
+	if !d.sleep() {
+		return
+	}
+	d.emit(protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: protocol.StatusWaitingInput})
+}
+
+// Alive reports true until Stop is called.
+func (d *Demo) Alive() bool {
+	select {
+	case <-d.stopCh:
+		return false
+	default:
+		return true
+	}
+}
+
+// Stop ends the scripted timeline.
+func (d *Demo) Stop() error {
+	select {
+	case <-d.stopCh:
+	default:
+		close(d.stopCh)
+	}
+	<-d.doneCh
+	return nil
+}

--- a/apps/daemon/internal/demo/demo_test.go
+++ b/apps/daemon/internal/demo/demo_test.go
@@ -1,0 +1,130 @@
+package demo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
+	"github.com/riffpad/riffpad/packages/protocol"
+)
+
+func collectEvents(t *testing.T, d *Demo, untilType string, timeout time.Duration) []protocol.Event {
+	t.Helper()
+	var out []protocol.Event
+	deadline := time.After(timeout)
+	for {
+		select {
+		case ev, ok := <-d.Events():
+			if !ok {
+				t.Fatal("event channel closed unexpectedly")
+			}
+			out = append(out, ev)
+			if ev.Type == untilType {
+				return out
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s; got %d events", untilType, len(out))
+		}
+	}
+}
+
+func approvalRequestID(t *testing.T, ev protocol.Event) string {
+	t.Helper()
+	var p protocol.ApprovalRequestPayload
+	if err := ev.DecodePayload(&p); err != nil {
+		t.Fatal(err)
+	}
+	return p.RequestID
+}
+
+func TestDemoWelcomeTimelineAndApproval(t *testing.T) {
+	old := Delay
+	Delay = 0
+	t.Cleanup(func() { Delay = old })
+
+	d := New(adapter.CreateRequest{ID: "demo-1", Cwd: "/tmp"})
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	evs := collectEvents(t, d, protocol.EventApprovalReq, 5*time.Second)
+	types := make([]string, 0, len(evs))
+	for _, ev := range evs {
+		types = append(types, ev.Type)
+	}
+	// Scripted order: running → agent msg → tool started → command →
+	// tool completed → file change → approval.
+	want := []string{
+		protocol.EventAgentStatus,
+		protocol.EventAgentMessage,
+		protocol.EventToolCall,
+		protocol.EventCommand,
+		protocol.EventToolCall,
+		protocol.EventFileChange,
+		protocol.EventApprovalReq,
+	}
+	if len(types) != len(want) {
+		t.Fatalf("unexpected event count: %v", types)
+	}
+	for i := range want {
+		if types[i] != want[i] {
+			t.Fatalf("event %d: want %s, got %s (%v)", i, want[i], types[i], types)
+		}
+	}
+
+	if err := d.SendApproval(approvalRequestID(t, evs[len(evs)-1]), "approve"); err != nil {
+		t.Fatal(err)
+	}
+	evs = collectEvents(t, d, protocol.EventAgentStatus, 5*time.Second)
+	last := evs[len(evs)-1]
+	var st protocol.AgentStatusPayload
+	if err := last.DecodePayload(&st); err != nil {
+		t.Fatal(err)
+	}
+	if st.Status != protocol.StatusWaitingInput {
+		t.Fatalf("expected waiting_input after approval, got %s", st.Status)
+	}
+}
+
+func TestDemoReplyApprovalPath(t *testing.T) {
+	old := Delay
+	Delay = 0
+	t.Cleanup(func() { Delay = old })
+
+	d := New(adapter.CreateRequest{ID: "demo-2", Cwd: "/tmp"})
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// Resolve the welcome approval so the session is waiting for input.
+	evs := collectEvents(t, d, protocol.EventApprovalReq, 5*time.Second)
+	if err := d.SendApproval(approvalRequestID(t, evs[len(evs)-1]), "approve"); err != nil {
+		t.Fatal(err)
+	}
+	collectEvents(t, d, protocol.EventAgentStatus, 5*time.Second)
+
+	if err := d.SendPrompt("trigger approval"); err != nil {
+		t.Fatal(err)
+	}
+	evs = collectEvents(t, d, protocol.EventApprovalReq, 5*time.Second)
+	var sawUser bool
+	for _, ev := range evs {
+		if ev.Type == protocol.EventUserMessage {
+			sawUser = true
+		}
+	}
+	if !sawUser {
+		t.Fatal("expected user message echo in approval path")
+	}
+	if err := d.SendApproval(approvalRequestID(t, evs[len(evs)-1]), "reject"); err != nil {
+		t.Fatal(err)
+	}
+	evs = collectEvents(t, d, protocol.EventAgentStatus, 5*time.Second)
+	last := evs[len(evs)-1]
+	var st protocol.AgentStatusPayload
+	if err := last.DecodePayload(&st); err != nil {
+		t.Fatal(err)
+	}
+	if st.Status != protocol.StatusWaitingInput {
+		t.Fatalf("expected waiting_input after reject, got %s", st.Status)
+	}
+}

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -208,6 +208,7 @@
 | M3.24 | 群发邮件 + 退订管理：`scripts/email`（waitlist API 拉取/去重、SMTP 群发、HMAC 退订链接、跳过已退订）；relay `/api/waitlist/unsubscribe` + `/api/waitlist/optouts`（`email_optouts` 表，CORS 仅 riffpad.ai/www）；landing `/unsubscribe` 退订页（中英、深浅色一致） | `[x]` | 2026-08-09 生产验证：真实 token 退订成功、伪 token 拒绝、optouts 列表/清理正常；首次公告已发出（HTML+纯文本，20 人） | #218 #219 #222 #223 |
 | M3.25 | 首跑配对体验：`riffpad pair` 对 `host offline` 自动重试（最长 10s，打印等待提示），daemon 状态/启动日志改用 `internal/version.Version` 清理硬编码 `0.1.0-m0` | `[x]` | 单测覆盖重试成功/非重试错误立即返回/超时；真机冷启动 pair 自动等待出码；随 v0.2.4 发布 | #220 #221 |
 | M3.26 | 自建 waitlist 表单 + REST API + 数据库（替代 Formspree）：landing `WaitlistForm` 直连 relay `POST /api/waitlist/subscribe`（CORS/限流/幂等）；新增 `waitlist_entries` 表；`GET /api/waitlist/emails`（admin key）供 `scripts/email fetch` 拉取；旧 20 邮箱已入库 | `[x]` | relay 单测（订阅幂等/校验/限流、列表 admin-only、CORS）；landing 构建通过；2026-08-09 生产验证：订阅 ok、拉取 20 条、fetch 出 CSV | #224 #225 |
+| M3.27 | demo 会话模式：daemon 内置脚本化 mock 适配器（`riffpad run demo`），按统一 protocol 事件时间线回放思考/工具 spinner→绿/文件变更/审批卡/回复，客户端走真实配对+E2EE+WS 链路，零 API 消耗，用于打磨 client UI 与 Playwright 回归 | `[~]` | demo 适配器单测（时间线顺序、审批决议、prompt 关键词路径）；`riffpad run demo` 后 localhost:8787 / app 可见完整演示会话 | #235 |
 
 ---
 


### PR DESCRIPTION
Closes #235

## 改动
- `internal/demo`：脚本化 `adapter.Session`，按统一 protocol 事件时间线回放：running → agent 消息 → Bash spinner → 命令输出 → 变绿 → 文件变更 → **审批卡**（等待决议）→ 回复 → waiting_input
- `SendPrompt` 关键词切换演示路径：`tool`（spinner/绿块）、`approval`（审批卡）、`markdown`（代码块/表格/列表渲染）；`SendApproval` 决议后续时间线
- DefaultFactory 支持 `cli=demo`；`riffpad run demo` 创建会话并打印 URL（无 CLI 进程、不前台附着）
- 测试：时间线顺序、审批 approve/reject 路径、HTTP 工厂接线；linux/windows/darwin 构建通过

## 验证
- [x] 本机 `riffpad run demo`：会话 running、events.enc 持续增长
- [ ] 你在 localhost:8787 / app.riffpad.ai 查看演示会话：工具 spinner→绿、审批卡同意/拒绝、markdown 渲染
- [ ] 后续 Playwright 可基于 demo 断言 UI 状态