### PR TITLE
feat(demo): 交织真实工作流时间线 + error/long 场景 (#237)

### DIFF
--- a/apps/daemon/internal/demo/demo.go
+++ b/apps/daemon/internal/demo/demo.go
@@ -98,27 +98,57 @@ func (d *Demo) welcome() {
 	if !d.sleep() {
 		return
 	}
-	d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: "Hi! I'm the **Riffpad demo agent** — a scripted timeline, no real model, no API quota.\n\nTry sending me:\n- `tool` — watch a command spinner turn green\n- `approval` — trigger a phone approval card\n- `markdown` — rich formatting (code, lists, tables)"})
+	// A realistic interleaved workflow: message → tool → message → tool →
+	// message → tool (with approval) → final summary.
+	d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: "I'll refactor the auth middleware to use the new session store."})
 	if !d.sleep() {
 		return
 	}
-	if !d.emitTool("npm test") {
+	d.emit(protocol.EventNotify, protocol.NotifyPayload{Level: "info", Message: "Reading src/auth/middleware.ts…"})
+	if !d.sleep() {
+		return
+	}
+	if !d.emitTool("ReadFile", "src/auth/middleware.ts", "") {
 		return
 	}
 	if !d.sleep() {
+		return
+	}
+	d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: "The middleware is a 120-line monolith — extracting session handling into its own module."})
+	if !d.sleep() {
+		return
+	}
+	if !d.emitTool("Edit", "src/auth/middleware.ts", "") {
 		return
 	}
 	d.emit(protocol.EventFileChange, protocol.FileChangePayload{
-		Path: "src/auth/middleware.ts", Summary: "updated",
+		Path: "src/auth/session.ts", Summary: "new file",
 	})
 	if !d.sleep() {
+		return
+	}
+	d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: "Middleware updated. Running the test suite…"})
+	if !d.sleep() {
+		return
+	}
+	if !d.emitTool("Bash", "npm test", "42 passed · 0 failed · 1.8s") {
+		return
+	}
+	if !d.sleep() {
+		return
+	}
+	d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: "All green. One leftover: `src/old.ts` is unused — removing it."})
+	if !d.sleep() {
+		return
+	}
+	if !d.emitTool("Bash", "rm src/old.ts", "") {
 		return
 	}
 	decided, ok := d.requestApproval("Bash", "rm src/old.ts", "删除不再使用的文件")
 	if !ok {
 		return
 	}
-	text := "Approved — `src/old.ts` removed, tests still green."
+	text := "Done — middleware refactored, 42 tests green, dead file removed."
 	if decided != "approve" {
 		text = "Rejected — the agent paused and will try another approach."
 	}
@@ -131,27 +161,29 @@ func (d *Demo) welcome() {
 	d.emit(protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: protocol.StatusWaitingInput})
 }
 
-// emitTool plays a Bash tool spinner → command output → completed row.
-func (d *Demo) emitTool(command string) bool {
+// emitTool plays a tool spinner → (optional) command output → completed row.
+func (d *Demo) emitTool(tool, summary, output string) bool {
 	if !d.emit(protocol.EventToolCall, protocol.ToolCallPayload{
-		Tool: "Bash", Status: "started", Summary: command,
+		Tool: tool, Status: "started", Summary: summary,
 	}) {
 		return false
 	}
 	if !d.sleep() {
 		return false
 	}
-	exit := 0
-	if !d.emit(protocol.EventCommand, protocol.CommandPayload{
-		Command: command, ExitCode: &exit, Output: "42 passed · 0 failed · 1.8s",
-	}) {
-		return false
-	}
-	if !d.sleep() {
-		return false
+	if tool == "Bash" {
+		exit := 0
+		if !d.emit(protocol.EventCommand, protocol.CommandPayload{
+			Command: summary, ExitCode: &exit, Output: output,
+		}) {
+			return false
+		}
+		if !d.sleep() {
+			return false
+		}
 	}
 	return d.emit(protocol.EventToolCall, protocol.ToolCallPayload{
-		Tool: "Bash", Status: "completed", Summary: command,
+		Tool: tool, Status: "completed", Summary: summary,
 	})
 }
 
@@ -229,18 +261,54 @@ func (d *Demo) reply(text string) {
 		}
 		d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: msg})
 	case strings.Contains(strings.ToLower(text), "tool"):
-		if !d.emitTool("pnpm test") {
+		if !d.emitTool("Bash", "pnpm test", "42 passed · 0 failed · 1.8s") {
 			return
 		}
 		if !d.sleep() {
 			return
 		}
 		d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: "All checks passed ✅"})
+	case strings.Contains(strings.ToLower(text), "error"):
+		if !d.emitTool("Bash", "pnpm deploy", "") {
+			return
+		}
+		fail := 1
+		if !d.emit(protocol.EventCommand, protocol.CommandPayload{
+			Command: "pnpm deploy", ExitCode: &fail,
+			Output: "ERROR ENOENT: deploy target not found",
+		}) {
+			return
+		}
+		if !d.sleep() {
+			return
+		}
+		if !d.emit(protocol.EventToolCall, protocol.ToolCallPayload{
+			Tool: "Bash", Status: "failed", Summary: "pnpm deploy",
+		}) {
+			return
+		}
+		d.emit(protocol.EventNotify, protocol.NotifyPayload{Level: "error", Message: "deploy failed: ENOENT"})
+		if !d.sleep() {
+			return
+		}
+		d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: "Deploy failed — falling back to the previous build."})
+	case strings.Contains(strings.ToLower(text), "long"):
+		for i := 1; i <= 24; i++ {
+			if !d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{
+				Text: fmt.Sprintf("Chunk %02d — this is a long history item to exercise scrolling, pagination and layout. `x=%d`", i, i*7),
+			}) {
+				return
+			}
+			if Delay > 0 {
+				time.Sleep(15 * time.Millisecond)
+			}
+		}
+		d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: "That was 24 messages — long history done."})
 	case strings.Contains(strings.ToLower(text), "markdown") || strings.Contains(strings.ToLower(text), "code"):
 		d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{Text: "Here's a **markdown** demo:\n\n1. First item\n2. Second item\n\n```ts\nconst ok = (x: number) => x * 2;\nconsole.log(ok(21)); // 42\n```\n\n| cli | status |\n|---|---|\n| codex | foreground |\n| claude | foreground |\n| kimi | foreground |"})
 	default:
 		d.emit(protocol.EventAgentMessage, protocol.AgentMessagePayload{
-			Text: "You said: " + text + "\n\nThis is a scripted demo reply — send `tool`, `approval` or `markdown` to explore more UI states.",
+			Text: "You said: " + text + "\n\nThis is a scripted demo reply — send `tool`, `approval`, `markdown`, `error` or `long` to explore more UI states.",
 		})
 	}
 	if !d.sleep() {

--- a/apps/daemon/internal/demo/demo_test.go
+++ b/apps/daemon/internal/demo/demo_test.go
@@ -52,24 +52,28 @@ func TestDemoWelcomeTimelineAndApproval(t *testing.T) {
 	for _, ev := range evs {
 		types = append(types, ev.Type)
 	}
-	// Scripted order: running → agent msg → tool started → command →
-	// tool completed → file change → approval.
-	want := []string{
-		protocol.EventAgentStatus,
-		protocol.EventAgentMessage,
-		protocol.EventToolCall,
-		protocol.EventCommand,
+	if types[0] != protocol.EventAgentStatus {
+		t.Fatalf("timeline must start with running status, got %v", types)
+	}
+	// Interleaved workflow markers must appear in order: tool activity →
+	// file change → command → the approval-gated removal.
+	if !containsSubseq(types, []string{
 		protocol.EventToolCall,
 		protocol.EventFileChange,
+		protocol.EventCommand,
+		protocol.EventToolCall,
 		protocol.EventApprovalReq,
+	}) {
+		t.Fatalf("timeline missing interleaved workflow markers: %v", types)
 	}
-	if len(types) != len(want) {
-		t.Fatalf("unexpected event count: %v", types)
-	}
-	for i := range want {
-		if types[i] != want[i] {
-			t.Fatalf("event %d: want %s, got %s (%v)", i, want[i], types[i], types)
+	msgCount := 0
+	for _, typ := range types {
+		if typ == protocol.EventAgentMessage {
+			msgCount++
 		}
+	}
+	if msgCount < 3 {
+		t.Fatalf("expected several interleaved agent messages, got %d (%v)", msgCount, types)
 	}
 
 	if err := d.SendApproval(approvalRequestID(t, evs[len(evs)-1]), "approve"); err != nil {
@@ -84,6 +88,16 @@ func TestDemoWelcomeTimelineAndApproval(t *testing.T) {
 	if st.Status != protocol.StatusWaitingInput {
 		t.Fatalf("expected waiting_input after approval, got %s", st.Status)
 	}
+}
+
+func containsSubseq(haystack, needle []string) bool {
+	i := 0
+	for _, h := range haystack {
+		if i < len(needle) && h == needle[i] {
+			i++
+		}
+	}
+	return i == len(needle)
 }
 
 func TestDemoReplyApprovalPath(t *testing.T) {


### PR DESCRIPTION
Closes #237

## 改动
- welcome 时间线改为交织工作流：running → 消息 → notify → ReadFile（spinner→完成）→ 消息 → Edit + 文件变更 → 消息 → Bash npm test（命令输出）→ 消息 → Bash rm + **审批卡** → 总结 → waiting
- prompt 关键词新增：`error`（工具 failed + 错误 notify + 降级回复）、`long`（24 条消息快速回放，练滚动/分页/性能）
- 测试改为子序列断言（tool→file→command→tool→approval）并校验消息数量

## 验证
- [x] 单测通过；本机 `riffpad run demo` 事件流正常（events.enc 6365B）
- [ ] 你打开 localhost:8787 的 demo 会话看交织效果，并试 `error` / `long`