### PR TITLE
fix(claude): drop interactive SendPrompt echo to avoid duplicate user messages (#243)

### DIFF
--- a/apps/daemon/internal/claude/claude.go
+++ b/apps/daemon/internal/claude/claude.go
@@ -283,14 +283,14 @@ func (c *Claude) SendPrompt(text string) error {
 	if err := c.ensureStarted(); err != nil {
 		return err
 	}
-	// Mirror codex/kimi: echo the user's message back as an event so the
-	// phone client renders it (the daemon itself never sees the text again).
-	_ = c.emit(protocol.EventUserMessage, protocol.AgentMessagePayload{Text: text})
 	if c.interactive && c.pty != nil {
 		if _, err := fmt.Fprintf(c.pty, "%s\r", text); err != nil {
 			return err
 		}
 		return nil
+	}
+	if c.promptEcho() {
+		_ = c.emit(protocol.EventUserMessage, protocol.AgentMessagePayload{Text: text})
 	}
 	msg := map[string]any{
 		"type": "user",
@@ -300,6 +300,15 @@ func (c *Claude) SendPrompt(text string) error {
 		},
 	}
 	return c.writeLine(msg)
+}
+
+// promptEcho reports whether SendPrompt should emit a user_message event for
+// the text it writes. The interactive TUI streams the prompt back through the
+// UserPromptSubmit hook (handleHookUserPromptSubmit), so an extra echo would
+// render every client-sent message twice; headless stream-json mode never sees
+// the text again and needs the local echo.
+func (c *Claude) promptEcho() bool {
+	return !(c.interactive && c.pty != nil)
 }
 
 func (c *Claude) writeLine(v any) error {

--- a/apps/daemon/internal/claude/claude_test.go
+++ b/apps/daemon/internal/claude/claude_test.go
@@ -11,6 +11,27 @@ import (
 	"github.com/riffpad/riffpad/packages/protocol"
 )
 
+func TestSendPromptEchoPolicy(t *testing.T) {
+	c := New(adapter.CreateRequest{ID: "s1"})
+	if !c.interactive {
+		t.Fatal("expected interactive mode by default")
+	}
+	// PTY not attached yet (lazy start / fallback headless): keep the echo.
+	if !c.promptEcho() {
+		t.Fatal("expected echo before the interactive PTY is attached")
+	}
+	c.pty = &os.File{}
+	// Interactive TUI: the UserPromptSubmit hook already streams the prompt
+	// back to viewers; echoing here would duplicate every client message.
+	if c.promptEcho() {
+		t.Fatal("interactive TUI must not echo; the UserPromptSubmit hook provides the message")
+	}
+	c.interactive = false
+	if !c.promptEcho() {
+		t.Fatal("headless stream-json mode needs the local echo")
+	}
+}
+
 func TestHandleLineAssistantAndUser(t *testing.T) {
 	c := New(adapter.CreateRequest{ID: "s1", Name: "demo"})
 	c.handleLine([]byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}`))


### PR DESCRIPTION
Closes #243

## Root cause
In Claude interactive (PTY bridge) mode, a client-sent prompt was emitted twice as `user_message`:
- `Claude.SendPrompt` echoed the text locally before writing it to the PTY.
- The per-session `UserPromptSubmit` hook streamed the same prompt back through `handleHookUserPromptSubmit`.

Different event ids meant the client's replay dedupe could not collapse them. Codex/Kimi are unaffected (their SendPrompt never echoes; each emits via its own single channel).

## Fix
Interactive PTY mode no longer emits the local echo and relies on the UserPromptSubmit hook (same path as typing locally). Headless stream-json mode keeps the echo because the text never comes back through a hook there.

## Verification
- [x] go test ./internal/claude/... ./internal/daemon/... passes
- [x] New regression test: interactive+PTY => no echo; headless / PTY not attached => echo
- [ ] Manual: client sends a message into `riffpad run claude`; timeline shows it exactly once
- [ ] CI green