### PR TITLE
fix(relay): keep per-session lastSeenAt on announce (#245)

### DIFF
--- a/apps/daemon/internal/daemon/relay.go
+++ b/apps/daemon/internal/daemon/relay.go
@@ -20,11 +20,12 @@ import (
 
 // RelaySession is the session metadata announced to the relay.
 type RelaySession struct {
-	ID     string `json:"id"`
-	Name   string `json:"name"`
-	CLI    string `json:"cli"`
-	Cwd    string `json:"cwd"`
-	Status string `json:"status"`
+	ID         string    `json:"id"`
+	Name       string    `json:"name"`
+	CLI        string    `json:"cli"`
+	Cwd        string    `json:"cwd"`
+	Status     string    `json:"status"`
+	LastSeenAt time.Time `json:"lastSeenAt,omitempty"`
 }
 
 // RelayJoin describes a viewer that connected through the relay.

--- a/apps/daemon/internal/daemon/server.go
+++ b/apps/daemon/internal/daemon/server.go
@@ -1022,9 +1022,12 @@ func (s *Server) announceSessions() {
 		if sess.ended {
 			continue
 		}
+		sess.mu.Lock()
+		lastSeen := sess.lastSeen
+		sess.mu.Unlock()
 		list = append(list, RelaySession{
 			ID: sess.id, Name: sess.meta.Name, CLI: sess.meta.CLI,
-			Cwd: sess.meta.Cwd, Status: sess.status,
+			Cwd: sess.meta.Cwd, Status: sess.status, LastSeenAt: lastSeen,
 		})
 	}
 	s.mu.Unlock()

--- a/apps/relay/internal/hub/hub.go
+++ b/apps/relay/internal/hub/hub.go
@@ -1155,15 +1155,16 @@ func (h *Hub) hostReadLoop(host *hostConn) {
 						delete(h.sessions, sid)
 					}
 				}
-				now := time.Now()
 				for _, s := range fr.Sessions {
 					s.HostID = host.id
-					// The announce frame carries no timestamp; these sessions
-					// are live right now, so stamp them here (mirrors
-					// Store.UpsertSessions). Otherwise the in-memory snapshot
-					// served by /api/sessions would report Go's zero time and
-					// clients would show "739835d ago".
-					s.LastSeenAt = now
+					if s.LastSeenAt.IsZero() {
+						// Older daemons announce without a timestamp; these
+						// sessions are live right now, so stamp them here
+						// (mirrors Store.UpsertSessions). Otherwise the
+						// in-memory snapshot would report Go's zero time and
+						// clients would show "739835d ago".
+						s.LastSeenAt = time.Now()
+					}
 					h.sessions[s.ID] = s
 					h.sessionHosts[s.ID] = host.id
 				}

--- a/apps/relay/internal/hub/hub_test.go
+++ b/apps/relay/internal/hub/hub_test.go
@@ -1154,6 +1154,29 @@ func waitForSessions(t *testing.T, ts *httptest.Server, token string, want ...st
 	}
 }
 
+// sessionMetaMap fetches the live session list as a map keyed by session id.
+func sessionMetaMap(t *testing.T, ts *httptest.Server, token string) map[string]SessionMeta {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/sessions", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Sessions []SessionMeta `json:"sessions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	m := map[string]SessionMeta{}
+	for _, s := range out.Sessions {
+		m[s.ID] = s
+	}
+	return m
+}
+
 // One host re-announcing its sessions must not clear the sessions announced
 // by another host of the same account (desktop + laptop) (#169).
 func TestHostAnnouncesDoNotClearOtherHosts(t *testing.T) {
@@ -1206,6 +1229,46 @@ func TestAnnouncedSessionsGetLiveLastSeenAt(t *testing.T) {
 		if s.LastSeenAt.IsZero() || time.Since(s.LastSeenAt) > time.Minute {
 			t.Fatalf("expected live lastSeenAt, got %v", s.LastSeenAt)
 		}
+	}
+}
+
+// Re-announcing one session must not refresh the LastSeenAt of the others:
+// every session carries its own timestamp and the relay has to keep it. The
+// relay used to stamp every announced session with now, so activity in one
+// session made the whole list show "just now".
+func TestAnnouncedSessionsKeepTheirOwnLastSeenAt(t *testing.T) {
+	_, ts := newTestHub(t)
+	token := registerUser(t, ts, "lastseen-own")
+	hostID, secret := registerHost(t, ts, token, "laptop")
+	conn := dialHostWS(t, ts, hostID, secret)
+
+	old1 := time.Now().Add(-30 * time.Minute)
+	old2 := time.Now().Add(-5 * time.Minute)
+	announceSessions(t, conn,
+		SessionMeta{ID: "s1", CLI: "claude", Status: "running", LastSeenAt: old1},
+		SessionMeta{ID: "s2", CLI: "claude", Status: "running", LastSeenAt: old2},
+	)
+	waitForSessions(t, ts, token, "s1", "s2")
+
+	// s2 just had activity: only its timestamp advances on re-announce.
+	announceSessions(t, conn,
+		SessionMeta{ID: "s1", CLI: "claude", Status: "running", LastSeenAt: old1},
+		SessionMeta{ID: "s2", CLI: "claude", Status: "running", LastSeenAt: time.Now()},
+	)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		got := sessionMetaMap(t, ts, token)
+		if len(got) == 2 && got["s2"].LastSeenAt.After(old2.Add(time.Minute)) {
+			if delta := got["s1"].LastSeenAt.Sub(old1); delta > time.Minute || delta < -time.Minute {
+				t.Fatalf("s1 lastSeenAt refreshed to %v; want %v", got["s1"].LastSeenAt, old1)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("second announce never landed: s1=%v s2=%v", got["s1"].LastSeenAt, got["s2"].LastSeenAt)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }
 

--- a/apps/relay/internal/hub/store.go
+++ b/apps/relay/internal/hub/store.go
@@ -403,9 +403,14 @@ func (s *Store) SessionsForHosts(hostIDs []string) ([]SessionMeta, error) {
 }
 
 func (s *Store) UpsertSessions(hostID string, sessions []SessionMeta) error {
+	now := time.Now()
 	for i := range sessions {
 		sessions[i].HostID = hostID
-		sessions[i].LastSeenAt = time.Now()
+		if sessions[i].LastSeenAt.IsZero() {
+			// Older daemons announce without a timestamp: fall back to "live
+			// right now" instead of persisting Go's zero time.
+			sessions[i].LastSeenAt = now
+		}
 		if err := s.db.Save(&sessions[i]).Error; err != nil {
 			return err
 		}

--- a/apps/relay/internal/hub/store_test.go
+++ b/apps/relay/internal/hub/store_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"testing"
+	"time"
 )
 
 func TestFindOrCreateGitHubUser(t *testing.T) {
@@ -56,5 +57,37 @@ func TestGitHubUserLoginFailsWithoutPassword(t *testing.T) {
 	}
 	if _, err := s.VerifyLogin(u.Username, "anything"); err == nil {
 		t.Fatal("passwordless github user should not accept password login")
+	}
+}
+
+func TestUpsertSessionsKeepsAnnouncedLastSeenAt(t *testing.T) {
+	s, err := OpenStore(t.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-30 * time.Minute)
+	if err := s.UpsertSessions("host1", []SessionMeta{
+		{ID: "s1", CLI: "claude", Status: "running", LastSeenAt: old},
+		{ID: "s2", CLI: "claude", Status: "running"}, // no timestamp: legacy daemon
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var got []SessionMeta
+	if err := s.db.Where("host_id = ?", "host1").Find(&got).Error; err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]SessionMeta{}
+	for _, m := range got {
+		byID[m.ID] = m
+	}
+	if len(byID) != 2 {
+		t.Fatalf("expected 2 session rows, got %d", len(byID))
+	}
+	if delta := byID["s1"].LastSeenAt.Sub(old); delta > time.Minute || delta < -time.Minute {
+		t.Fatalf("s1 lastSeenAt overwritten: got %v want %v", byID["s1"].LastSeenAt, old)
+	}
+	if byID["s2"].LastSeenAt.IsZero() || time.Since(byID["s2"].LastSeenAt) > time.Minute {
+		t.Fatalf("zero timestamp not stamped live: %v", byID["s2"].LastSeenAt)
 	}
 }


### PR DESCRIPTION
Closes #245

## Root cause
The daemon's `sessions` announce frame carried no per-session timestamp. The relay stamped **every** session in the frame with `time.Now()` (in-memory snapshot in hub.go + `Store.UpsertSessions`). Any event in one session triggers `announceSessions()`, which re-sends the whole active list — so all timestamps advanced together and the client showed `just now` for every session.

## Changes
- daemon: `RelaySession.LastSeenAt`; `announceSessions()` now sends each session's own `lastSeen` (locked read).
- relay: keep the announced `LastSeenAt` in both the in-memory snapshot and the store; fall back to `time.Now()` only for zero values (old daemon / legacy frame), preserving the old "739835d ago" guard.

## Verification
- [x] `TestAnnouncedSessionsKeepTheirOwnLastSeenAt`: re-announcing one session leaves the other's timestamp untouched.
- [x] `TestUpsertSessionsKeepsAnnouncedLastSeenAt`: store preserves announced timestamps and stamps only zero values.
- [x] go test daemon + relay pass locally.
- [ ] Manual: two live sessions, activity in one -> only that one shows `just now`.
- [ ] CI green.