### PR TITLE
fix(client): stable session list order by lastSeenAt (#249)

### DIFF
--- a/apps/client-beta/src/components/SessionListView.tsx
+++ b/apps/client-beta/src/components/SessionListView.tsx
@@ -28,6 +28,19 @@ function saveCwdHistory(list: string[]) {
 
 type TFunc = ReturnType<typeof useI18n>["t"];
 
+// sortSessions returns a stable, meaningful order for the session list:
+// most recently active first, missing/zero timestamps last, id as a
+// tiebreaker. Backends range over Go maps, so the raw API order is random
+// and would reshuffle the list on every 5s poll (#249).
+function sortSessions(list: SessionInfo[]): SessionInfo[] {
+  return [...list].sort((a, b) => {
+    const ta = new Date(a.lastSeenAt || 0).getTime();
+    const tb = new Date(b.lastSeenAt || 0).getTime();
+    if (ta !== tb) return tb - ta;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+}
+
 function timeAgo(iso: string | undefined, t: TFunc): string {
   if (!iso) return "";
   const ts = new Date(iso).getTime();
@@ -95,7 +108,7 @@ export default function SessionListView({ onOpen }: Props) {
     try {
       const res = await api("/api/sessions");
       const data = await res.json();
-      setSessions(data.sessions || []);
+      setSessions(sortSessions(data.sessions || []));
       setOffline(!res.ok);
       if (res.ok) setHostOffline(isRelay && data.hostOnline === false);
     } catch {

--- a/apps/daemon/internal/daemon/server.go
+++ b/apps/daemon/internal/daemon/server.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -682,6 +683,21 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 				"lastSeen": lastSeen,
 			})
 		}
+		// Stable, meaningful order for the client: most recently active first,
+		// zero timestamps (restored sessions without activity) last, id as a
+		// tiebreaker. Ranging over a Go map yields a random order per request,
+		// which made the client list reshuffle on every 5s poll (#249).
+		sort.Slice(list, func(i, j int) bool {
+			a := list[i]["lastSeen"].(time.Time)
+			b := list[j]["lastSeen"].(time.Time)
+			if a.IsZero() != b.IsZero() {
+				return !a.IsZero()
+			}
+			if !a.Equal(b) {
+				return a.After(b)
+			}
+			return list[i]["id"].(string) < list[j]["id"].(string)
+		})
 		s.mu.Unlock()
 		writeJSON(w, http.StatusOK, map[string]any{"sessions": list})
 	case http.MethodPost:

--- a/apps/daemon/internal/daemon/server_test.go
+++ b/apps/daemon/internal/daemon/server_test.go
@@ -40,6 +40,46 @@ func TestHistorySlice(t *testing.T) {
 	}
 }
 
+func TestHandleSessionsSortsByLastSeen(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	keys, err := config.LoadOrCreateKeys(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := New(cfg, keys, dir, log.New(io.Discard, "", 0), nil)
+
+	old := time.Now().Add(-10 * time.Minute)
+	newer := time.Now().Add(-time.Minute)
+	srv.sessions = map[string]*session{
+		"b": {id: "b", meta: protocol.SessionStartPayload{Name: "b"}, status: protocol.StatusRunning, lastSeen: newer},
+		"a": {id: "a", meta: protocol.SessionStartPayload{Name: "a"}, status: protocol.StatusRunning, lastSeen: old},
+		"c": {id: "c", meta: protocol.SessionStartPayload{Name: "c"}, status: protocol.StatusRunning},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+	rr := httptest.NewRecorder()
+	srv.handleSessions(rr, req)
+	var out struct {
+		Sessions []struct {
+			ID       string    `json:"id"`
+			LastSeen time.Time `json:"lastSeen"`
+		} `json:"sessions"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	ids := make([]string, 0, len(out.Sessions))
+	for _, s := range out.Sessions {
+		ids = append(ids, s.ID)
+	}
+	// Most recently active first, zero timestamp (no activity) last.
+	want := []string{"b", "a", "c"}
+	if strings.Join(ids, ",") != strings.Join(want, ",") {
+		t.Fatalf("session order = %v, want %v", ids, want)
+	}
+}
+
 func TestSnapshotLast(t *testing.T) {
 	sess := &session{}
 	for i := 0; i < 5; i++ {

--- a/apps/relay/internal/hub/hub.go
+++ b/apps/relay/internal/hub/hub.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -972,6 +973,20 @@ func (h *Hub) handleSessions(w http.ResponseWriter, r *http.Request) {
 			liveSessions = append(liveSessions, s)
 		}
 	}
+	// Stable order for the client: most recently active first, zero
+	// timestamps last, id as a tiebreaker. Ranging over a Go map yields a
+	// random order per request, which made the client list reshuffle on
+	// every 5s poll (#249).
+	sort.Slice(liveSessions, func(i, j int) bool {
+		a, b := liveSessions[i], liveSessions[j]
+		if a.LastSeenAt.IsZero() != b.LastSeenAt.IsZero() {
+			return !a.LastSeenAt.IsZero()
+		}
+		if !a.LastSeenAt.Equal(b.LastSeenAt) {
+			return a.LastSeenAt.After(b.LastSeenAt)
+		}
+		return a.ID < b.ID
+	})
 	// hostOnline lets the client tell "daemon offline" (empty list because no
 	// host is connected) apart from "no sessions" (host connected, nothing
 	// running): the two need very different empty states (#174).

--- a/apps/relay/internal/hub/hub_test.go
+++ b/apps/relay/internal/hub/hub_test.go
@@ -1272,6 +1272,58 @@ func TestAnnouncedSessionsKeepTheirOwnLastSeenAt(t *testing.T) {
 	}
 }
 
+// The client polls /api/sessions every few seconds; a random order (Go map
+// range) made the list reshuffle on every poll. The relay must return a
+// stable order: most recently active first.
+func TestSessionsListOrderedByLastSeenAt(t *testing.T) {
+	_, ts := newTestHub(t)
+	token := registerUser(t, ts, "sorted-sessions")
+	hostID, secret := registerHost(t, ts, token, "laptop")
+	conn := dialHostWS(t, ts, hostID, secret)
+
+	old := time.Now().Add(-10 * time.Minute)
+	mid := time.Now().Add(-5 * time.Minute)
+	announceSessions(t, conn,
+		SessionMeta{ID: "old", CLI: "claude", Status: "running", LastSeenAt: old},
+		SessionMeta{ID: "mid", CLI: "claude", Status: "running", LastSeenAt: mid},
+		SessionMeta{ID: "fresh", CLI: "claude", Status: "running", LastSeenAt: time.Now()},
+	)
+
+	var ids []string
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/sessions", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out struct {
+			Sessions []SessionMeta `json:"sessions"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			resp.Body.Close()
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if len(out.Sessions) == 3 {
+			ids = make([]string, 0, 3)
+			for _, s := range out.Sessions {
+				ids = append(ids, s.ID)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("sessions never fully announced (got %d)", len(out.Sessions))
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	want := []string{"fresh", "mid", "old"}
+	if strings.Join(ids, ",") != strings.Join(want, ",") {
+		t.Fatalf("session order = %v, want %v", ids, want)
+	}
+}
+
 // A reconnecting host registers its new connection before the old one's
 // deferred removeHost runs; the old cleanup must not wipe the sessions the
 // new connection just announced (#169).


### PR DESCRIPTION
Closes #249

## Root cause
The client renders `/api/sessions` in the exact returned order and polls every 5s; both daemon and relay build the list by ranging over a Go map, whose iteration order is randomized per call. Result: the list reshuffles every poll even with zero activity.

## Changes
Sort by `lastSeenAt` descending (most recently active first), zero timestamps last, id as stable tiebreaker:
- daemon `handleSessions` (local 8787)
- relay `handleSessions` (cloud /api/sessions)
- client `SessionListView` defensive sort (older backends / local mode)

## Verification
- [x] `TestHandleSessionsSortsByLastSeen` (daemon): order b (newer), a (old), c (zero)
- [x] `TestSessionsListOrderedByLastSeenAt` (relay): fresh, mid, old
- [x] go test daemon + relay pass; client-beta typecheck passes
- [ ] CI green