### PR TITLE
fix(claude): emit running/waiting_input around turns so client shows activity (#253)

### DIFF
--- a/apps/daemon/internal/claude/claude.go
+++ b/apps/daemon/internal/claude/claude.go
@@ -63,6 +63,7 @@ type Claude struct {
 	ctx              context.Context
 	launched         bool
 	exited           bool
+	agentActive      bool // true between the first assistant output and the turn result
 	pendingTools     map[string]pendingTool
 	pendingApprovals map[string]chan string
 	ptySubs          map[*ptyTerm]struct{}
@@ -292,6 +293,15 @@ func (c *Claude) SendPrompt(text string) error {
 	if c.promptEcho() {
 		_ = c.emit(protocol.EventUserMessage, protocol.AgentMessagePayload{Text: text})
 	}
+	// Flip to running immediately so the client shows the activity indicator
+	// from the moment the prompt is sent, before the first assistant chunk.
+	c.mu.Lock()
+	first := !c.agentActive
+	c.agentActive = true
+	c.mu.Unlock()
+	if first {
+		_ = c.emit(protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: protocol.StatusRunning})
+	}
 	msg := map[string]any{
 		"type": "user",
 		"message": map[string]any{
@@ -446,6 +456,9 @@ func (c *Claude) handleLine(line []byte) {
 	case "result":
 		// A turn finished, but the session is still alive and waiting for
 		// input; "done" is reserved for real process exit (see readLoop).
+		c.mu.Lock()
+		c.agentActive = false
+		c.mu.Unlock()
 		status := protocol.StatusWaitingInput
 		if raw.Subtype == "error" || raw.Subtype == "error_max_turns" {
 			status = protocol.StatusError
@@ -485,6 +498,30 @@ func (c *Claude) handleAssistant(msg json.RawMessage) {
 	}
 	if err := json.Unmarshal(msg, &m); err != nil {
 		return
+	}
+	// The first output of a turn flips the session to running so clients
+	// show the "agent is running" indicator. Turn end (result) flips it back
+	// to waiting_input. Only emit on the transition: stream-json delivers
+	// many assistant chunks per turn.
+	hasOutput := false
+	for _, block := range m.Content {
+		if block.Type == "text" && strings.TrimSpace(block.Text) != "" {
+			hasOutput = true
+			break
+		}
+		if block.Type == "tool_use" {
+			hasOutput = true
+			break
+		}
+	}
+	if hasOutput {
+		c.mu.Lock()
+		first := !c.agentActive
+		c.agentActive = true
+		c.mu.Unlock()
+		if first {
+			_ = c.emit(protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: protocol.StatusRunning})
+		}
 	}
 	for _, block := range m.Content {
 		switch block.Type {

--- a/apps/daemon/internal/claude/claude_test.go
+++ b/apps/daemon/internal/claude/claude_test.go
@@ -39,41 +39,99 @@ func TestHandleLineAssistantAndUser(t *testing.T) {
 	c.handleLine([]byte(`{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"src"}]}}`))
 
 	// Event order for a Bash call:
-	//   agent_message · command(started, no exit code) · command(completed, exit code)
+	//   agent_status(running) · agent_message · command(started, no exit code)
+	//   · command(completed, exit code)
 	// Bash renders as a single row: the started command (no exit code) makes
 	// the client show a spinner; the completed command carries the exit code
 	// and transitions it to green. No tool_call row for Bash (it duplicates).
 	var got []protocol.Event
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		select {
 		case ev := <-c.Events():
 			got = append(got, ev)
 		default:
-			t.Fatalf("expected %d events, got %d", 3, len(got))
+			t.Fatalf("expected %d events, got %d", 4, len(got))
 		}
 	}
-	if got[0].Type != protocol.EventAgentMessage {
-		t.Fatalf("expected agent_message, got %s", got[0].Type)
+	if got[0].Type != protocol.EventAgentStatus {
+		t.Fatalf("expected running agent_status, got %s", got[0].Type)
 	}
-	if got[1].Type != protocol.EventCommand {
-		t.Fatalf("expected started command, got %s", got[1].Type)
+	var runStatus protocol.AgentStatusPayload
+	if err := got[0].DecodePayload(&runStatus); err != nil {
+		t.Fatal(err)
+	}
+	if runStatus.Status != protocol.StatusRunning {
+		t.Fatalf("expected running, got %q", runStatus.Status)
+	}
+	if got[1].Type != protocol.EventAgentMessage {
+		t.Fatalf("expected agent_message, got %s", got[1].Type)
+	}
+	if got[2].Type != protocol.EventCommand {
+		t.Fatalf("expected started command, got %s", got[2].Type)
 	}
 	var cmdStart protocol.CommandPayload
-	if err := got[1].DecodePayload(&cmdStart); err != nil {
+	if err := got[2].DecodePayload(&cmdStart); err != nil {
 		t.Fatal(err)
 	}
 	if cmdStart.Command != "ls" || cmdStart.ExitCode != nil {
 		t.Fatalf("unexpected started command (want no exit code): %+v", cmdStart)
 	}
-	if got[2].Type != protocol.EventCommand {
-		t.Fatalf("expected completed command, got %s", got[2].Type)
+	if got[3].Type != protocol.EventCommand {
+		t.Fatalf("expected completed command, got %s", got[3].Type)
 	}
 	var cmdDone protocol.CommandPayload
-	if err := got[2].DecodePayload(&cmdDone); err != nil {
+	if err := got[3].DecodePayload(&cmdDone); err != nil {
 		t.Fatal(err)
 	}
 	if cmdDone.Command != "ls" || cmdDone.ExitCode == nil || *cmdDone.ExitCode != 0 {
 		t.Fatalf("unexpected completed command (want exit code 0): %+v", cmdDone)
+	}
+}
+
+func TestAssistantEmitsRunningOncePerTurn(t *testing.T) {
+	c := New(adapter.CreateRequest{ID: "s1"})
+
+	// First assistant chunk: running, then the message.
+	c.handleLine([]byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}`))
+	ev := <-c.Events()
+	if ev.Type != protocol.EventAgentStatus {
+		t.Fatalf("expected running agent_status, got %s", ev.Type)
+	}
+	var st protocol.AgentStatusPayload
+	if err := ev.DecodePayload(&st); err != nil {
+		t.Fatal(err)
+	}
+	if st.Status != protocol.StatusRunning {
+		t.Fatalf("expected running, got %q", st.Status)
+	}
+	ev = <-c.Events()
+	if ev.Type != protocol.EventAgentMessage {
+		t.Fatalf("expected agent_message, got %s", ev.Type)
+	}
+
+	// Second chunk of the same turn: message only, no second running event.
+	c.handleLine([]byte(`{"type":"assistant","message":{"content":[{"type":"text","text":" world"}]}}`))
+	ev = <-c.Events()
+	if ev.Type != protocol.EventAgentMessage {
+		t.Fatalf("expected agent_message, got %s", ev.Type)
+	}
+	select {
+	case extra := <-c.Events():
+		t.Fatalf("unexpected extra event: %s", extra.Type)
+	default:
+	}
+
+	// Turn result resets the flag for the next turn.
+	c.handleLine([]byte(`{"type":"result","subtype":"success"}`))
+	ev = <-c.Events()
+	if ev.Type != protocol.EventAgentStatus {
+		t.Fatalf("expected agent_status, got %s", ev.Type)
+	}
+	if err := ev.DecodePayload(&st); err != nil {
+		t.Fatal(err)
+	}
+	if st.Status != protocol.StatusWaitingInput {
+		t.Fatalf("expected waiting_input, got %q", st.Status)
 	}
 }
 

--- a/apps/daemon/internal/daemon/attach.go
+++ b/apps/daemon/internal/daemon/attach.go
@@ -343,6 +343,16 @@ func (s *Server) handleHookUserPromptSubmit(w http.ResponseWriter, r *http.Reque
 	}
 	sid := hookSessionID(r, p)
 	sess := s.attachSession(sid, p.CWD)
+	// A prompt means the agent starts a new turn: flip the session back to
+	// running so the client shows the activity indicator immediately (#253).
+	sess.mu.Lock()
+	st := sess.status
+	sess.mu.Unlock()
+	if st != protocol.StatusRunning {
+		if ev, err := protocol.NewEvent(sid, protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: protocol.StatusRunning}); err == nil {
+			s.pumpEvent(sess, ev)
+		}
+	}
 	ev, err := protocol.NewEvent(sid, protocol.EventUserMessage, protocol.PromptPayload{Text: p.Prompt})
 	if err == nil {
 		s.pumpEvent(sess, ev)
@@ -358,6 +368,17 @@ func (s *Server) handleHookMessageDisplay(w http.ResponseWriter, r *http.Request
 	}
 	sid := hookSessionID(r, p)
 	sess := s.attachSession(sid, p.CWD)
+	// MessageDisplay means the agent started producing output: flip the
+	// session back to running so clients show the activity indicator. The
+	// idle_prompt notification flips it back to waiting_input (#253).
+	sess.mu.Lock()
+	st := sess.status
+	sess.mu.Unlock()
+	if st != protocol.StatusRunning {
+		if ev, err := protocol.NewEvent(sid, protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: protocol.StatusRunning}); err == nil {
+			s.pumpEvent(sess, ev)
+		}
+	}
 	// Accumulate per message_id; emit once when the final batch arrives so the
 	// timeline shows whole assistant messages instead of many partial cards.
 	if p.MessageID != "" && !p.Final {
@@ -408,13 +429,29 @@ func (s *Server) handleHookNotification(w http.ResponseWriter, r *http.Request) 
 		}
 		p.Message = p.Notification.Message
 	}
-	if p.Message == "" {
+	needsTurnReset := notifType == "idle_prompt" || notifType == "agent_needs_input"
+	if !needsTurnReset && p.Message == "" {
 		writeJSON(w, http.StatusOK, map[string]any{})
 		return
 	}
 	sid := hookSessionID(r, p)
-	s.log.Printf("notification hook session=%s type=%s msg=%q", sid, notifType, p.Message)
 	sess := s.attachSession(sid, p.CWD)
+	if needsTurnReset {
+		// The agent finished a turn and is waiting for the next prompt.
+		sess.mu.Lock()
+		st := sess.status
+		sess.mu.Unlock()
+		if st != protocol.StatusWaitingInput {
+			if ev, err := protocol.NewEvent(sid, protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: protocol.StatusWaitingInput}); err == nil {
+				s.pumpEvent(sess, ev)
+			}
+		}
+	}
+	if p.Message == "" {
+		writeJSON(w, http.StatusOK, map[string]any{})
+		return
+	}
+	s.log.Printf("notification hook session=%s type=%s msg=%q", sid, notifType, p.Message)
 	ev, err := protocol.NewEvent(sid, protocol.EventNotify, protocol.NotifyPayload{Level: level, Message: p.Message})
 	if err == nil {
 		s.pumpEvent(sess, ev)

--- a/apps/daemon/internal/daemon/attach_test.go
+++ b/apps/daemon/internal/daemon/attach_test.go
@@ -135,8 +135,28 @@ func TestAttachHookFlow(t *testing.T) {
 	}
 
 	// 3b. User prompt and assistant message hooks flow into the timeline.
+	// A submitted prompt flips a waiting session back to running so the
+	// client shows the activity indicator (#253).
+	srv.mu.Lock()
+	attached := srv.sessions["claude-sess-1"]
+	srv.mu.Unlock()
+	attached.mu.Lock()
+	attached.status = protocol.StatusWaitingInput
+	attached.mu.Unlock()
+
 	resp = post("/hooks/claude/user-prompt-submit", `{"hook_event_name":"UserPromptSubmit","session_id":"claude-sess-1","prompt":"你好"}`)
 	resp.Body.Close()
+	ev = readEvent()
+	if ev.Type != protocol.EventAgentStatus {
+		t.Fatalf("expected running agent_status after prompt, got %s", ev.Type)
+	}
+	var st protocol.AgentStatusPayload
+	if err := ev.DecodePayload(&st); err != nil {
+		t.Fatal(err)
+	}
+	if st.Status != protocol.StatusRunning {
+		t.Fatalf("expected running, got %q", st.Status)
+	}
 	ev = readEvent()
 	if ev.Type != protocol.EventUserMessage {
 		t.Fatalf("expected user_message, got %s", ev.Type)
@@ -149,11 +169,46 @@ func TestAttachHookFlow(t *testing.T) {
 		t.Fatalf("unexpected prompt %q", up.Text)
 	}
 
+	// Simulate a finished turn (waiting for input): the next MessageDisplay
+	// must flip the session back to running so the client shows the activity
+	// indicator (#253).
+	attached.mu.Lock()
+	attached.status = protocol.StatusWaitingInput
+	attached.mu.Unlock()
+
 	resp = post("/hooks/claude/message-display", `{"hook_event_name":"MessageDisplay","session_id":"claude-sess-1","message_id":"m1","delta":"你好！","final":true}`)
 	resp.Body.Close()
 	ev = readEvent()
+	if ev.Type != protocol.EventAgentStatus {
+		t.Fatalf("expected running agent_status before agent_message, got %s", ev.Type)
+	}
+	if err := ev.DecodePayload(&st); err != nil {
+		t.Fatal(err)
+	}
+	if st.Status != protocol.StatusRunning {
+		t.Fatalf("expected running, got %q", st.Status)
+	}
+	ev = readEvent()
 	if ev.Type != protocol.EventAgentMessage {
 		t.Fatalf("expected agent_message, got %s", ev.Type)
+	}
+
+	// idle_prompt notification flips the session back to waiting_input.
+	resp = post("/hooks/claude/notification", `{"hook_event_name":"Notification","session_id":"claude-sess-1","notification":{"type":"idle_prompt","message":"Claude is waiting for your input"}}`)
+	resp.Body.Close()
+	ev = readEvent()
+	if ev.Type != protocol.EventAgentStatus {
+		t.Fatalf("expected waiting_input agent_status, got %s", ev.Type)
+	}
+	if err := ev.DecodePayload(&st); err != nil {
+		t.Fatal(err)
+	}
+	if st.Status != protocol.StatusWaitingInput {
+		t.Fatalf("expected waiting_input, got %q", st.Status)
+	}
+	ev = readEvent()
+	if ev.Type != protocol.EventNotify {
+		t.Fatalf("expected notify, got %s", ev.Type)
 	}
 
 	// 4. PermissionRequest hook blocks until the phone approves.


### PR DESCRIPTION
Closes #253

## Root cause
The client's `agent is running…` indicator only renders from `agent_status=running`. Codex emits running at turn start and waiting_input at turn end; Claude never emitted running on either path:
- headless stream-json: only `result` → waiting_input
- foreground hook bridge: MessageDisplay → agent_message only; idle_prompt notification → notify only

## Changes
- **headless** (`claude.go`): `SendPrompt` and the first assistant output emit `running` (once per turn via `agentActive`); `result` resets and emits `waiting_input`.
- **hook bridge** (`attach.go`): `UserPromptSubmit` and `MessageDisplay` flip a non-running session to `running`; `idle_prompt`/`agent_needs_input` notifications flip it back to `waiting_input` (kept notify emission unchanged).

## Verification
- [x] `TestAssistantEmitsRunningOncePerTurn` (headless: running once, waiting_input on result)
- [x] attach flow test: prompt → running; MessageDisplay → running; idle_prompt → waiting_input
- [x] go test ./internal/claude/... ./internal/daemon/... passes
- [ ] Manual: send a message into `riffpad run claude`; indicator shows immediately and stops when the reply finishes
- [ ] CI green