### PR TITLE
fix(kimi): emit running/waiting_input around turns so client shows activity (#255)

### DIFF
--- a/apps/daemon/internal/daemon/kimi_hooks.go
+++ b/apps/daemon/internal/daemon/kimi_hooks.go
@@ -123,6 +123,17 @@ func (s *Server) handleKimiHook(w http.ResponseWriter, r *http.Request) {
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 	case "user-prompt-submit":
+		// A prompt starts a new turn: flip the session back to running so
+		// the client shows the activity indicator (#255).
+		sess.mu.Lock()
+		st := sess.status
+		sess.mu.Unlock()
+		if st != protocol.StatusRunning {
+			if ev, err := protocol.NewEvent(sid, protocol.EventAgentStatus,
+				protocol.AgentStatusPayload{Status: protocol.StatusRunning}); err == nil {
+				s.pumpEvent(sess, ev)
+			}
+		}
 		if text := kimiPromptText(p.Prompt); text != "" {
 			if ev, err := protocol.NewEvent(sid, protocol.EventUserMessage,
 				protocol.PromptPayload{Text: text}); err == nil {
@@ -144,7 +155,9 @@ func (s *Server) handleKimiHook(w http.ResponseWriter, r *http.Request) {
 		s.handleKimiPostToolUse(w, sess, sid, p, true)
 	case "notification":
 		level := "info"
+		notifType := ""
 		if p.Notification != nil {
+			notifType = p.Notification.NotificationType
 			switch p.Notification.NotificationType {
 			case "idle_prompt", "agent_needs_input":
 				level = "waiting"
@@ -157,6 +170,18 @@ func (s *Server) handleKimiHook(w http.ResponseWriter, r *http.Request) {
 			msg = p.Notification.Body
 			if msg == "" {
 				msg = p.Notification.Title
+			}
+		}
+		if notifType == "idle_prompt" || notifType == "agent_needs_input" {
+			// The agent finished a turn and is waiting for the next prompt.
+			sess.mu.Lock()
+			st := sess.status
+			sess.mu.Unlock()
+			if st != protocol.StatusWaitingInput {
+				if ev, err := protocol.NewEvent(sid, protocol.EventAgentStatus,
+					protocol.AgentStatusPayload{Status: protocol.StatusWaitingInput}); err == nil {
+					s.pumpEvent(sess, ev)
+				}
 			}
 		}
 		if msg != "" {
@@ -173,6 +198,17 @@ func (s *Server) handleKimiHook(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleKimiPreToolUse(w http.ResponseWriter, sess *session, sid string, p kimiHookPayload) {
 	tool := p.ToolName
+	// Tool execution belongs to an active turn: keep the running indicator
+	// lit (also while a phone approval is pending) (#255).
+	sess.mu.Lock()
+	st := sess.status
+	sess.mu.Unlock()
+	if st != protocol.StatusRunning {
+		if ev, err := protocol.NewEvent(sid, protocol.EventAgentStatus,
+			protocol.AgentStatusPayload{Status: protocol.StatusRunning}); err == nil {
+			s.pumpEvent(sess, ev)
+		}
+	}
 	// Emit the started row first so the timeline shows activity even while
 	// waiting for a phone decision.
 	if ev, err := protocol.NewEvent(sid, protocol.EventToolCall, protocol.ToolCallPayload{

--- a/apps/daemon/internal/daemon/kimi_hooks_test.go
+++ b/apps/daemon/internal/daemon/kimi_hooks_test.go
@@ -91,6 +91,42 @@ func TestKimiHookUserAndStopEvents(t *testing.T) {
 	}
 }
 
+func TestKimiHookPromptFlippedRunningAndIdleFlippedWaiting(t *testing.T) {
+	_, ts, sess, tok := newKimiHookTestServer(t)
+
+	// A finished turn (waiting for input): the next prompt must flip the
+	// session back to running so the client shows the activity indicator.
+	sess.mu.Lock()
+	sess.status = protocol.StatusWaitingInput
+	sess.mu.Unlock()
+	resp, _ := postKimiHook(t, ts, "user-prompt-submit", `{"session_id":"x","cwd":"/tmp","prompt":"hello"}`, tok)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("user-prompt status %d", resp.StatusCode)
+	}
+
+	// idle_prompt notification ends the turn: back to waiting_input.
+	resp, _ = postKimiHook(t, ts, "notification", `{"session_id":"x","cwd":"/tmp","notification":{"notification_type":"idle_prompt","body":"Kimi is waiting for your input"}}`, tok)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("notification status %d", resp.StatusCode)
+	}
+
+	sess.pumpMu.Lock()
+	types := make([]string, 0, len(sess.history))
+	for _, ev := range sess.history {
+		types = append(types, ev.Type)
+	}
+	sess.pumpMu.Unlock()
+	want := []string{
+		protocol.EventAgentStatus, // running
+		protocol.EventUserMessage,
+		protocol.EventAgentStatus, // waiting_input
+		protocol.EventNotify,
+	}
+	if strings.Join(types, ",") != strings.Join(want, ",") {
+		t.Fatalf("history types = %v, want %v", types, want)
+	}
+}
+
 func TestKimiHookPreToolUseAutoAllowsReadTools(t *testing.T) {
 	if !kimiGatedTools()["Bash"] {
 		t.Fatal("Bash tool must be gated (kimi-code uses Bash, not Shell)")

--- a/apps/daemon/internal/kimi/kimi.go
+++ b/apps/daemon/internal/kimi/kimi.go
@@ -77,6 +77,7 @@ type Kimi struct {
 	pendingTools  map[string]pendingTool
 	msgBuf        strings.Builder
 	msgActive     bool
+	turnActive    bool // true between a prompt and the turn result (client "running" indicator)
 }
 
 // New creates a Kimi Code ACP session adapter.
@@ -352,6 +353,16 @@ func (k *Kimi) SendPrompt(text string) error {
 	if err := k.waitReady(); err != nil {
 		return err
 	}
+	// Flip to running immediately so the client shows the activity indicator
+	// from the moment the prompt is sent, before any session/update arrives
+	// (#255). The turn result flips it back to waiting_input.
+	k.mu.Lock()
+	first := !k.turnActive
+	k.turnActive = true
+	k.mu.Unlock()
+	if first {
+		_ = k.emit(protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: protocol.StatusRunning})
+	}
 	return k.request("session/prompt", map[string]any{
 		"sessionId": k.sessionID,
 		"prompt":    []any{map[string]any{"type": "text", "text": text}},
@@ -554,6 +565,9 @@ func (k *Kimi) handleResponse(id json.RawMessage, result json.RawMessage) {
 	default:
 		// A session/prompt response ends the current turn.
 		k.flushMessage()
+		k.mu.Lock()
+		k.turnActive = false
+		k.mu.Unlock()
 		// The turn is over but the session is still alive and waiting for
 		// input; "done" is reserved for real process exit.
 		status := protocol.StatusWaitingInput

--- a/apps/daemon/internal/kimi/kimi_test.go
+++ b/apps/daemon/internal/kimi/kimi_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/riffpad/riffpad/apps/daemon/internal/adapter"
+	"github.com/riffpad/riffpad/packages/protocol"
 )
 
 func TestWriteSessionConfigRegistersAllHooks(t *testing.T) {
@@ -66,4 +67,32 @@ func TestWriteSessionConfigPreservesUserConfig(t *testing.T) {
 
 func strconvQuote(s string) string {
 	return "\"" + s + "\""
+}
+
+func TestKimiTurnResultResetsRunning(t *testing.T) {
+	k := New(adapter.CreateRequest{ID: "s1"})
+	// SendPrompt flips turnActive on; the turn result must flip it back and
+	// emit waiting_input so the client stops the running indicator (#255).
+	k.mu.Lock()
+	k.turnActive = true
+	k.mu.Unlock()
+
+	k.handleLine([]byte(`{"jsonrpc":"2.0","id":3,"result":{"sessionId":"s1","stopReason":"end_turn"}}`))
+	ev := <-k.Events()
+	if ev.Type != protocol.EventAgentStatus {
+		t.Fatalf("expected agent_status, got %s", ev.Type)
+	}
+	var st protocol.AgentStatusPayload
+	if err := ev.DecodePayload(&st); err != nil {
+		t.Fatal(err)
+	}
+	if st.Status != protocol.StatusWaitingInput {
+		t.Fatalf("expected waiting_input, got %q", st.Status)
+	}
+	k.mu.Lock()
+	active := k.turnActive
+	k.mu.Unlock()
+	if active {
+		t.Fatal("turnActive not reset after turn result")
+	}
 }


### PR DESCRIPTION
Closes #255

Same issue as #253 but for Kimi: the client never saw `agent_status=running`, so the activity indicator never appeared.

## Changes
- **ACP mode** (`kimi.go`): `SendPrompt` flips `turnActive` and emits running once per turn; the session/prompt turn result resets it and emits waiting_input (existing behavior kept).
- **Foreground hook bridge** (`kimi_hooks.go`): `user-prompt-submit` and `pre-tool-use` flip a non-running session to running; `idle_prompt`/`agent_needs_input` notifications flip it back to waiting_input.

## Verification
- [x] `TestKimiTurnResultResetsRunning` (turnActive reset + waiting_input)
- [x] `TestKimiHookPromptFlippedRunningAndIdleFlippedWaiting` (prompt → running; idle → waiting_input)
- [x] go test ./internal/kimi/... ./internal/daemon/... passes
- [ ] Manual: send a message into a Kimi session; indicator appears and stops when the turn ends
- [ ] CI green