### PR TITLE
fix(daemon): stop hook flips claude session to waiting_input on reply end (#257)

### DIFF
--- a/apps/daemon/internal/claude/claude.go
+++ b/apps/daemon/internal/claude/claude.go
@@ -397,6 +397,10 @@ func (c *Claude) hookSpecs() map[string]hookSpec {
 		"PostToolUse":       {path: "post-tool-use", timeout: 10},
 		"PermissionRequest": {path: "permission", timeout: 600},
 		"Notification":      {path: "notification", timeout: 10},
+		// Stop fires when the previous turn finishes, so the daemon can flip
+		// the session back to waiting_input immediately instead of waiting
+		// for idle_prompt's ~60s heuristic (#257).
+		"Stop": {path: "stop", timeout: 10},
 	}
 }
 

--- a/apps/daemon/internal/claude/claude_test.go
+++ b/apps/daemon/internal/claude/claude_test.go
@@ -298,7 +298,7 @@ func TestWriteSettingsInteractiveRegistersAllHooks(t *testing.T) {
 	}
 	want := []string{
 		"SessionStart", "SessionEnd", "UserPromptSubmit", "MessageDisplay",
-		"PreToolUse", "PostToolUse", "PermissionRequest", "Notification",
+		"PreToolUse", "PostToolUse", "PermissionRequest", "Notification", "Stop",
 	}
 	if len(s.Hooks) != len(want) {
 		t.Fatalf("expected %d hook events, got %d (%v)", len(want), len(s.Hooks), keysOf(s.Hooks))

--- a/apps/daemon/internal/daemon/attach.go
+++ b/apps/daemon/internal/daemon/attach.go
@@ -69,8 +69,11 @@ type hookPayload struct {
 	Final         bool           `json:"final"`
 	MessageID     string         `json:"message_id"`
 	Notification  *struct {
-		Type    string `json:"type"`
-		Message string `json:"message"`
+		// Claude Code sends notification_type; older/community payloads used
+		// type, so both are accepted (see notificationType).
+		Type             string `json:"type"`
+		NotificationType string `json:"notification_type"`
+		Message          string `json:"message"`
 	} `json:"notification"`
 	Reason string `json:"reason"`
 	Source string `json:"source"`
@@ -116,6 +119,18 @@ func (p *hookPayload) toolInput() map[string]any {
 		return p.Input
 	}
 	return nil
+}
+
+// notificationType returns the Notification hook's type, preferring the
+// official notification_type field over the legacy type field.
+func (p *hookPayload) notificationType() string {
+	if p.Notification == nil {
+		return ""
+	}
+	if p.Notification.NotificationType != "" {
+		return p.Notification.NotificationType
+	}
+	return p.Notification.Type
 }
 
 func (p *hookPayload) summary() string {
@@ -412,7 +427,7 @@ func (s *Server) handleHookNotification(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusBadRequest, "invalid hook payload")
 		return
 	}
-	if p.Notification != nil && p.Notification.Type == "permission_prompt" {
+	if p.Notification != nil && p.notificationType() == "permission_prompt" {
 		// Permission prompts are surfaced by the PermissionRequest hook.
 		writeJSON(w, http.StatusOK, map[string]any{})
 		return
@@ -420,8 +435,8 @@ func (s *Server) handleHookNotification(w http.ResponseWriter, r *http.Request) 
 	level := "info"
 	notifType := ""
 	if p.Notification != nil {
-		notifType = p.Notification.Type
-		switch p.Notification.Type {
+		notifType = p.notificationType()
+		switch notifType {
 		case "idle_prompt", "agent_needs_input":
 			level = "waiting"
 		case "agent_completed":
@@ -455,6 +470,29 @@ func (s *Server) handleHookNotification(w http.ResponseWriter, r *http.Request) 
 	ev, err := protocol.NewEvent(sid, protocol.EventNotify, protocol.NotifyPayload{Level: level, Message: p.Message})
 	if err == nil {
 		s.pumpEvent(sess, ev)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+// handleHookStop receives Claude Code's Stop hook, which fires when the
+// previous turn finishes (unlike idle_prompt, which can lag behind by ~60s).
+// A live session that is still marked running immediately flips back to
+// waiting_input so the client's activity indicator clears (#257).
+func (s *Server) handleHookStop(w http.ResponseWriter, r *http.Request) {
+	p, ok := decodeHook(r)
+	if !ok || p.SessionID == "" {
+		writeError(w, http.StatusBadRequest, "invalid hook payload")
+		return
+	}
+	sid := hookSessionID(r, p)
+	sess := s.attachSession(sid, p.CWD)
+	sess.mu.Lock()
+	st := sess.status
+	sess.mu.Unlock()
+	if st != protocol.StatusWaitingInput {
+		if ev, err := protocol.NewEvent(sid, protocol.EventAgentStatus, protocol.AgentStatusPayload{Status: protocol.StatusWaitingInput}); err == nil {
+			s.pumpEvent(sess, ev)
+		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{})
 }

--- a/apps/daemon/internal/daemon/attach_test.go
+++ b/apps/daemon/internal/daemon/attach_test.go
@@ -194,7 +194,7 @@ func TestAttachHookFlow(t *testing.T) {
 	}
 
 	// idle_prompt notification flips the session back to waiting_input.
-	resp = post("/hooks/claude/notification", `{"hook_event_name":"Notification","session_id":"claude-sess-1","notification":{"type":"idle_prompt","message":"Claude is waiting for your input"}}`)
+	resp = post("/hooks/claude/notification", `{"hook_event_name":"Notification","session_id":"claude-sess-1","notification":{"notification_type":"idle_prompt","message":"Claude is waiting for your input"}}`)
 	resp.Body.Close()
 	ev = readEvent()
 	if ev.Type != protocol.EventAgentStatus {
@@ -209,6 +209,45 @@ func TestAttachHookFlow(t *testing.T) {
 	ev = readEvent()
 	if ev.Type != protocol.EventNotify {
 		t.Fatalf("expected notify, got %s", ev.Type)
+	}
+
+	// Stop hook also flips a running session back to waiting_input — and
+	// unlike idle_prompt it fires as soon as the previous turn finishes, so
+	// the client clears the activity indicator without a ~60s lag (#257).
+	attached.mu.Lock()
+	attached.status = protocol.StatusRunning
+	attached.mu.Unlock()
+	resp = post("/hooks/claude/stop", `{"hook_event_name":"Stop","session_id":"claude-sess-1","reason":"turn_end"}`)
+	resp.Body.Close()
+	ev = readEvent()
+	if ev.Type != protocol.EventAgentStatus {
+		t.Fatalf("expected waiting_input agent_status after stop hook, got %s", ev.Type)
+	}
+	if err := ev.DecodePayload(&st); err != nil {
+		t.Fatal(err)
+	}
+	if st.Status != protocol.StatusWaitingInput {
+		t.Fatalf("expected waiting_input after stop hook, got %q", st.Status)
+	}
+	// A Stop hook on an already-waiting session must not emit a duplicate.
+	waitingStatuses := func(events []protocol.Event) int {
+		n := 0
+		for _, hev := range events {
+			if hev.Type != protocol.EventAgentStatus {
+				continue
+			}
+			var p protocol.AgentStatusPayload
+			if hev.DecodePayload(&p) == nil && p.Status == protocol.StatusWaitingInput {
+				n++
+			}
+		}
+		return n
+	}
+	before := waitingStatuses(attached.snapshot())
+	resp = post("/hooks/claude/stop", `{"hook_event_name":"Stop","session_id":"claude-sess-1","reason":"turn_end"}`)
+	resp.Body.Close()
+	if after := waitingStatuses(attached.snapshot()); after != before {
+		t.Fatalf("expected no duplicate waiting_input event, got %d -> %d", before, after)
 	}
 
 	// 4. PermissionRequest hook blocks until the phone approves.

--- a/apps/daemon/internal/daemon/auth_test.go
+++ b/apps/daemon/internal/daemon/auth_test.go
@@ -62,6 +62,7 @@ func TestLocalAuthRejectsMissingToken(t *testing.T) {
 		"/api/sessions",
 		"/api/shutdown",
 		"/hooks/claude/session-start",
+		"/hooks/claude/stop",
 		"/ws",
 	}
 	for _, p := range paths {

--- a/apps/daemon/internal/daemon/server.go
+++ b/apps/daemon/internal/daemon/server.go
@@ -280,6 +280,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/hooks/claude/post-tool-use", s.handleHookPostToolUse)
 	mux.HandleFunc("/hooks/claude/user-prompt-submit", s.handleHookUserPromptSubmit)
 	mux.HandleFunc("/hooks/claude/message-display", s.handleHookMessageDisplay)
+	mux.HandleFunc("/hooks/claude/stop", s.handleHookStop)
 	mux.HandleFunc("/hooks/kimi/", s.handleKimiHook)
 	return s.localAuth(mux)
 }

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -42,6 +42,7 @@
 | 群发邮件 + 退订管理 | `scripts/email`（waitlist API 拉取/去重、SMTP 群发、HMAC 退订链接）+ relay 退订端点 + landing `/unsubscribe`；生产已部署验证 | #218 #219 #222 #223 |
 | 自建 waitlist 表单与存储 | landing 直连 relay `POST /api/waitlist/subscribe`；`waitlist_entries` 表；`scripts/email fetch` 从 relay 拉取；旧 20 邮箱已入库 | #224 #225 |
 | 首跑配对体验 | `riffpad pair` 对 `host offline` 自动重试；daemon 版本号统一（v0.2.4 发布） | #220 #221 |
+| Claude 回复结束状态修复 | 注册 Stop hook 让回复一结束就翻回 `waiting_input`（不再等 idle_prompt 的 ~60s 计时）；Notification hook 兼容官方 `notification_type` 字段 | #257 |
 
 ---
 


### PR DESCRIPTION
## 问题

`riffpad run claude` 的会话在 Claude 回复完成后，client app 仍长时间显示 "Agent is running…"。

## 根因（两个叠加）

1. Claude Code 的 Notification hook 实际发送 `notification_type` 字段，而 daemon 只解析了 `type`，导致 `idle_prompt` / `agent_needs_input` 永远识别不到，会话状态无法翻回 `waiting_input`。
2. 即使字段解析正确，`idle_prompt` 也要等约 60 秒空闲计时器才触发，回复结束不会立即翻转状态。

## 修复

- 注册 Claude Code **Stop hook**（前一个回合完成时触发），收到后若会话仍在 running，立即发 `agent_status=waiting_input`。
- Notification 结构兼容 `notification_type`（官方）与旧 `type` 字段。
- 测试同步更新：正确 payload 字段 + Stop hook 翻转/不重复触发覆盖。

## 验证

- `go test ./internal/claude/... ./internal/daemon/...` 全部通过
- 人肉步骤：`riffpad run claude` → 让 Claude 回复 → client 应立即显示等待输入，不再卡 running

Closes #257