### PR TITLE
fix(daemon): claude hook tool events keep in-place identity, bash renders one row (#259)

### DIFF
--- a/apps/daemon/internal/daemon/attach.go
+++ b/apps/daemon/internal/daemon/attach.go
@@ -296,6 +296,20 @@ func (s *Server) handleHookPreToolUse(w http.ResponseWriter, r *http.Request) {
 	}
 	sid := hookSessionID(r, p)
 	sess := s.attachSession(sid, p.CWD)
+	if name := p.toolName(); name == "Bash" {
+		// Bash renders as a single "$ cmd" row: started here (no exit code)
+		// for the spinner, completed in handleHookPostToolUse (with exit
+		// code) for the green check. No tool_call row — it would duplicate
+		// the command row (#216, mirrored from the codex/claude adapters).
+		if cmd, _ := p.toolInput()["command"].(string); cmd != "" {
+			ev, err := protocol.NewEvent(sid, protocol.EventCommand, protocol.CommandPayload{Command: cmd})
+			if err == nil {
+				s.pumpEvent(sess, ev)
+			}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{})
+		return
+	}
 	ev, err := protocol.NewEvent(sid, protocol.EventToolCall, protocol.ToolCallPayload{
 		Tool:    p.toolName(),
 		Status:  "started",
@@ -321,6 +335,10 @@ func (s *Server) handleHookPostToolUse(w http.ResponseWriter, r *http.Request) {
 	switch name {
 	case "Bash":
 		cmd, _ := input["command"].(string)
+		if cmd == "" {
+			writeJSON(w, http.StatusOK, map[string]any{})
+			return
+		}
 		// Attach hooks don't expose the shell exit status; default to 0 so the
 		// row resolves to done instead of spinning forever (the client treats
 		// a missing exit code as "running").
@@ -329,6 +347,8 @@ func (s *Server) handleHookPostToolUse(w http.ResponseWriter, r *http.Request) {
 		if err == nil {
 			s.pumpEvent(sess, ev)
 		}
+		writeJSON(w, http.StatusOK, map[string]any{})
+		return
 	case "Write", "Edit", "MultiEdit", "NotepadEdit":
 		path, _ := input["file_path"].(string)
 		if path == "" {
@@ -339,7 +359,12 @@ func (s *Server) handleHookPostToolUse(w http.ResponseWriter, r *http.Request) {
 			s.pumpEvent(sess, ev)
 		}
 	}
-	ev, err := protocol.NewEvent(sid, protocol.EventToolCall, protocol.ToolCallPayload{Tool: name, Status: "completed"})
+	// Carry the same summary/args as the "started" event so the client's
+	// in-place merge keys match; otherwise it shows a duplicate row
+	// (spinner + completed) for the same tool call (#210).
+	ev, err := protocol.NewEvent(sid, protocol.EventToolCall, protocol.ToolCallPayload{
+		Tool: name, Status: "completed", Summary: p.summary(), Args: p.toolInput(),
+	})
 	if err == nil {
 		s.pumpEvent(sess, ev)
 	}

--- a/apps/daemon/internal/daemon/attach_test.go
+++ b/apps/daemon/internal/daemon/attach_test.go
@@ -126,12 +126,33 @@ func TestAttachHookFlow(t *testing.T) {
 		t.Fatalf("expected session_start, got %s", ev.Type)
 	}
 
-	// 3. Tool use hook -> tool_call event.
+	// 3. Tool use hook -> Bash renders as a single "$ cmd" row: started
+	// without an exit code, completed with one. No tool_call row (which
+	// would show a duplicate spinner + completed pair).
 	resp = post("/hooks/claude/pre-tool-use", `{"hook_event_name":"PreToolUse","session_id":"claude-sess-1","tool_use_id":"tu1","tool_use":{"name":"Bash","input":{"command":"ls"}}}`)
 	resp.Body.Close()
 	ev = readEvent()
-	if ev.Type != protocol.EventToolCall {
-		t.Fatalf("expected tool_call, got %s", ev.Type)
+	if ev.Type != protocol.EventCommand {
+		t.Fatalf("expected command, got %s", ev.Type)
+	}
+	var cp protocol.CommandPayload
+	if err := ev.DecodePayload(&cp); err != nil {
+		t.Fatal(err)
+	}
+	if cp.Command != "ls" || cp.ExitCode != nil {
+		t.Fatalf("expected running command ls, got %+v", cp)
+	}
+	resp = post("/hooks/claude/post-tool-use", `{"hook_event_name":"PostToolUse","session_id":"claude-sess-1","tool_use_id":"tu1","tool_use":{"name":"Bash","input":{"command":"ls"}}}`)
+	resp.Body.Close()
+	ev = readEvent()
+	if ev.Type != protocol.EventCommand {
+		t.Fatalf("expected completed command, got %s", ev.Type)
+	}
+	if err := ev.DecodePayload(&cp); err != nil {
+		t.Fatal(err)
+	}
+	if cp.Command != "ls" || cp.ExitCode == nil || *cp.ExitCode != 0 {
+		t.Fatalf("expected completed command ls with exit 0, got %+v", cp)
 	}
 
 	// 3b. User prompt and assistant message hooks flow into the timeline.
@@ -331,6 +352,65 @@ func TestAttachHookFlow(t *testing.T) {
 	}
 	if np.Level != "error" || np.RequestID != ap.RequestID {
 		t.Fatalf("unexpected notify: %+v", np)
+	}
+}
+
+// TestAttachToolCompletionKeepsInPlaceIdentity covers #210 for the hook path:
+// the completed tool_call must carry the same summary/args as the started one
+// so the client's in-place merge key matches (no duplicate spinner + completed
+// rows).
+func TestAttachToolCompletionKeepsInPlaceIdentity(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	keys, err := config.LoadOrCreateKeys(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := log.New(io.Discard, "", 0)
+	srv := New(cfg, keys, dir, logger, nil)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	post := func(path, body string) {
+		t.Helper()
+		resp := authRequest(t, http.MethodPost, ts.URL+path, cfg.LocalToken, strings.NewReader(body))
+		resp.Body.Close()
+	}
+
+	post("/hooks/claude/session-start", `{"hook_event_name":"SessionStart","session_id":"claude-sess-3","cwd":"/tmp/proj"}`)
+	post("/hooks/claude/pre-tool-use", `{"hook_event_name":"PreToolUse","session_id":"claude-sess-3","tool_use_id":"tu3","tool_use":{"name":"Write","input":{"file_path":"/tmp/a.txt"}}}`)
+	post("/hooks/claude/post-tool-use", `{"hook_event_name":"PostToolUse","session_id":"claude-sess-3","tool_use_id":"tu3","tool_use":{"name":"Write","input":{"file_path":"/tmp/a.txt"}}}`)
+
+	sess := srv.getSession("claude-sess-3")
+	var started, completed *protocol.ToolCallPayload
+	var fileChanged bool
+	for _, hev := range sess.snapshot() {
+		switch hev.Type {
+		case protocol.EventToolCall:
+			var p protocol.ToolCallPayload
+			if err := hev.DecodePayload(&p); err != nil {
+				t.Fatal(err)
+			}
+			switch p.Status {
+			case "started":
+				started = &p
+			case "completed":
+				completed = &p
+			}
+		case protocol.EventFileChange:
+			fileChanged = true
+		}
+	}
+	if started == nil || completed == nil {
+		t.Fatalf("expected started and completed tool_call, got %+v / %+v", started, completed)
+	}
+	if started.Summary != completed.Summary || started.Tool != completed.Tool {
+		t.Fatalf("completed tool_call identity mismatch: started=%+v completed=%+v", started, completed)
+	}
+	if completed.Args == nil || completed.Args["file_path"] != "/tmp/a.txt" {
+		t.Fatalf("completed tool_call missing args: %+v", completed)
+	}
+	if !fileChanged {
+		t.Fatal("expected file_change event")
 	}
 }
 

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -43,6 +43,7 @@
 | 自建 waitlist 表单与存储 | landing 直连 relay `POST /api/waitlist/subscribe`；`waitlist_entries` 表；`scripts/email fetch` 从 relay 拉取；旧 20 邮箱已入库 | #224 #225 |
 | 首跑配对体验 | `riffpad pair` 对 `host offline` 自动重试；daemon 版本号统一（v0.2.4 发布） | #220 #221 |
 | Claude 回复结束状态修复 | 注册 Stop hook 让回复一结束就翻回 `waiting_input`（不再等 idle_prompt 的 ~60s 计时）；Notification hook 兼容官方 `notification_type` 字段 | #257 |
+| Claude hook 工具行重复渲染修复 | Bash 改为单行 `command`（spinner→原地变绿），非 Bash 工具 completed 事件携带与 started 相同的 summary/args，client 按 key 原地合并 | #259 |
 
 ---
 


### PR DESCRIPTION
## 问题

`riffpad run claude` 会话里执行命令后，client app 在命令下方额外渲染“执行完成”行，而不是把原来的 spinner 行原地变成完成状态。

## 根因

Claude hook 路径没有应用 #210 的“工具完成事件保持同一身份”修复：

- Bash：PreToolUse 发 `tool_call(started)`（`tool:Bash:<cmd>` 行）→ PostToolUse 发 `command`（`cmd:<cmd>` 行）+ `tool_call(completed)` 不带 summary/args（`tool:Bash:` 行），三个 key 互不匹配，重复渲染。
- 非 Bash 工具：`tool_call(completed)` 同样缺 summary/args，无法原地合并。

## 修复

- Bash 只发 `command`：PreToolUse（无 exit code → spinner）→ PostToolUse（exit 0 → 原地变绿），与 codex / claude stream-json 一致，不再发 `tool_call`。
- 非 Bash 工具：`tool_call(completed)` 带与 started 相同的 summary/args，client 按 key 原地合并。
- 补测试：Bash 单行渲染、Write 完成事件身份一致性。

## 验证

- `go test ./internal/daemon/... ./internal/claude/...` 全部通过
- 人肉：`riffpad run claude` 执行命令 → client 只显示一行 `$ cmd`，spinner 原地变绿

Closes #259