### PR TITLE
fix(deploy): vercel ignoreCommand handles missing previous SHA in shallow clone (#263)

### DIFF
--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git -C \"$(git rev-parse --show-toplevel)\" diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- apps/landing apps/docs scripts/install.sh scripts/install.ps1 pnpm-lock.yaml package.json"
+  "ignoreCommand": "cd \"$(git rev-parse --show-toplevel)\"&&git cat-file -e $VERCEL_GIT_PREVIOUS_SHA 2>/dev/null&&git diff --quiet $VERCEL_GIT_PREVIOUS_SHA @ -- apps/landing apps/docs scripts/install.sh scripts/install.ps1 pnpm-lock.yaml package.json||exit 1"
 }


### PR DESCRIPTION
## 问题

Vercel production 部署 Error（3s），ignoreCommand 报 `fatal: bad object <sha>`（exit 128）。

## 根因

`apps/landing/vercel.json` 的 ignoreCommand 直接对 `$VERCEL_GIT_PREVIOUS_SHA` 执行 `git diff`；Vercel 浅克隆里没有该对象时 git 退出 128，部署直接失败。

## 修复

diff 前先用 `git cat-file -e` 校验：

- 对象缺失 → `exit 1` → 触发构建（不再 Error）
- 对象存在且无相关改动 → `exit 0` → 跳过
- 有相关改动 → `exit 1` → 构建

## 验证

本地模拟三种情况 exit code 符合预期；合并后 production 部署应恢复正常。

Closes #263