### PR TITLE
feat(landing): add DevHunt vote banner widget

### DIFF
--- a/apps/landing/app/layout.tsx
+++ b/apps/landing/app/layout.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import "./globals.css";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { LanguageProvider } from "@/components/LanguageProvider";
+import Script from "next/script";
 
 const geistMono = localFont({
   src: "./fonts/GeistMonoVF.woff",
@@ -116,6 +117,11 @@ export default function RootLayout({
         <ThemeProvider>
           <LanguageProvider>{children}</LanguageProvider>
         </ThemeProvider>
+        <Script
+          src="https://cdn.jsdelivr.net/gh/sidiDev/devhunt-banner/indexV0.js"
+          strategy="lazyOnload"
+          data-url="https://devhunt.org/tool/riffpad"
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
Embeds the DevHunt launch banner widget — a floating badge that links visitors to
the riffpad listing on DevHunt (https://devhunt.org/tool/riffpad).

Loaded via `next/script` with `strategy="lazyOnload"` so it never blocks first
paint, site-wide, once. Remove after the launch window if you don't want it
permanent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
