### PR TITLE
fix(landing): DevHunt banner never rendered (next/script onload race)

### DIFF
--- a/apps/landing/app/layout.tsx
+++ b/apps/landing/app/layout.tsx
@@ -4,7 +4,6 @@ import type { ReactNode } from "react";
 import "./globals.css";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { LanguageProvider } from "@/components/LanguageProvider";
-import Script from "next/script";
 
 const geistMono = localFont({
   src: "./fonts/GeistMonoVF.woff",
@@ -117,10 +116,14 @@ export default function RootLayout({
         <ThemeProvider>
           <LanguageProvider>{children}</LanguageProvider>
         </ThemeProvider>
-        <Script
-          src="https://cdn.jsdelivr.net/gh/sidiDev/devhunt-banner/indexV0.js"
-          strategy="lazyOnload"
+        {/* DevHunt launch banner — must be a plain deferred <script>, NOT
+            next/script: the widget hooks window.onload, and lazyOnload loads
+            it after onload has already fired, so the banner never rendered.
+            Remove this block after the launch window. */}
+        <script
+          defer
           data-url="https://devhunt.org/tool/riffpad"
+          src="https://cdn.jsdelivr.net/gh/sidiDev/devhunt-banner/indexV0.js"
         />
       </body>
     </html>


### PR DESCRIPTION
Fix: the DevHunt banner never showed.

The widget registers its render on `window.onload`, but `next/script` with
`strategy="lazyOnload"` loads the script *after* `onload` has already fired —
so the handler never ran and the banner was never prepended.

Switch to a plain `<script defer>` (DevHunt's original snippet): defer scripts
run before `window.onload`, so the handler registers in time. Inline comment
explains why this stays a raw script and not `next/script`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
