### PR TITLE
chore(landing): remove DevHunt banner (voting locked till 2027)

### DIFF
--- a/apps/landing/app/layout.tsx
+++ b/apps/landing/app/layout.tsx
@@ -116,15 +116,6 @@ export default function RootLayout({
         <ThemeProvider>
           <LanguageProvider>{children}</LanguageProvider>
         </ThemeProvider>
-        {/* DevHunt launch banner — must be a plain deferred <script>, NOT
-            next/script: the widget hooks window.onload, and lazyOnload loads
-            it after onload has already fired, so the banner never rendered.
-            Remove this block after the launch window. */}
-        <script
-          defer
-          data-url="https://devhunt.org/tool/riffpad"
-          src="https://cdn.jsdelivr.net/gh/sidiDev/devhunt-banner/indexV0.js"
-        />
       </body>
     </html>
   );


### PR DESCRIPTION
Removes the DevHunt banner widget added in #266/#267.

The DevHunt free launch slot is booked to March 2027, so voting on the listing
is locked until then — the banner was sending visitors to a page where they
couldn't vote. Drop it for now; re-add (or pay for a nearer launch week) closer
to an actual launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
