### PR TITLE
feat: one-liner AI-agent install (SKILL.md) across README, docs, landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ AI coding agents are powerful — and needy. They pause for approvals, finish ta
 
 ## Quickstart
 
+> **Using an AI agent?** Paste this into its chat — it reads the skill and sets up Riffpad for you:
+>
+> ```bash
+> curl -fsSL https://riffpad.ai/SKILL.md
+> ```
+
 ### 1. Install the daemon
 
 **macOS / Linux**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,6 +58,12 @@ AI coding agent 很强，也很“粘人”：会停下来等审批、趁你离�
 
 ## 快速开始
 
+> **用 AI agent？** 把这行粘进它的对话框 —— 它会读 skill 并帮你装好、配好 Riffpad：
+>
+> ```bash
+> curl -fsSL https://riffpad.ai/SKILL.md
+> ```
+
 ### 1. 安装 daemon
 
 **macOS / Linux**

--- a/apps/docs/en/guide/quickstart.md
+++ b/apps/docs/en/guide/quickstart.md
@@ -1,5 +1,11 @@
 # Quickstart
 
+> **Using an AI agent?** Paste this into its chat — it reads the skill and sets up Riffpad for you:
+>
+> ```bash
+> curl -fsSL https://riffpad.ai/SKILL.md
+> ```
+
 ## 1. Install the CLI
 
 On your computer:

--- a/apps/docs/guide/quickstart.md
+++ b/apps/docs/guide/quickstart.md
@@ -1,5 +1,11 @@
 # 快速开始
 
+> **用 AI agent？** 把这行粘进它的对话框 —— 它会读 skill 并帮你装好、配好 Riffpad：
+>
+> ```bash
+> curl -fsSL https://riffpad.ai/SKILL.md
+> ```
+
 ## 1. 安装 CLI
 
 在电脑终端执行：

--- a/apps/landing/components/InstallCommand.tsx
+++ b/apps/landing/components/InstallCommand.tsx
@@ -3,21 +3,15 @@
 import { useState } from "react";
 import { useLanguage } from "./LanguageProvider";
 
-const COMMANDS = {
-  unix: "curl -fsSL https://riffpad.ai/install.sh | sh",
-  windows: "irm https://riffpad.ai/install.ps1 | iex",
-} as const;
-
-type Platform = keyof typeof COMMANDS;
+const COMMAND = "curl -fsSL https://riffpad.ai/SKILL.md";
 
 export function InstallCommand() {
   const { t } = useLanguage();
-  const [platform, setPlatform] = useState<Platform>("unix");
   const [copied, setCopied] = useState(false);
 
   const copy = async () => {
     try {
-      await navigator.clipboard.writeText(COMMANDS[platform]);
+      await navigator.clipboard.writeText(COMMAND);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1500);
     } catch {
@@ -25,30 +19,16 @@ export function InstallCommand() {
     }
   };
 
-  const tabs: { id: Platform; label: string }[] = [
-    { id: "unix", label: t.install.unix },
-    { id: "windows", label: t.install.windows },
-  ];
-
   return (
     <div className="mx-auto mt-10 w-full max-w-[560px]">
+      <p className="mb-3 text-sm font-semibold text-ink">
+        {t.install.tagline}
+      </p>
       <div className="border border-hairline bg-console text-on-console shadow-card transition-colors duration-200 hover:border-accent">
         <div className="flex items-stretch border-b border-hairline">
-          {tabs.map((tab) => (
-            <button
-              key={tab.id}
-              type="button"
-              onClick={() => setPlatform(tab.id)}
-              aria-pressed={platform === tab.id}
-              className={`h-10 flex-1 cursor-pointer border-b-2 text-xs font-bold transition-colors sm:flex-none sm:px-5 ${
-                platform === tab.id
-                  ? "border-accent text-on-console"
-                  : "border-transparent text-on-console-mute hover:text-accent"
-              }`}
-            >
-              {tab.label}
-            </button>
-          ))}
+          <span className="flex h-10 items-center px-4 text-xs font-bold uppercase tracking-wide text-on-console-mute">
+            {t.install.label}
+          </span>
           <button
             type="button"
             onClick={copy}
@@ -62,9 +42,7 @@ export function InstallCommand() {
           onClick={copy}
           className="flex w-full cursor-pointer items-center justify-center px-4 py-4"
         >
-          <code className="break-all text-[13px] sm:text-sm">
-            {COMMANDS[platform]}
-          </code>
+          <code className="break-all text-[13px] sm:text-sm">{COMMAND}</code>
         </button>
       </div>
     </div>

--- a/apps/landing/lib/i18n.ts
+++ b/apps/landing/lib/i18n.ts
@@ -17,8 +17,8 @@ const en = {
     betaError: "Couldn't sign you up — try again.",
   },
   install: {
-    unix: "macOS / Linux",
-    windows: "Windows",
+    tagline: "Send this to your AI agent — the rest is automatic.",
+    label: "for your AI agent",
     copy: "copy",
     copied: "copied ✓",
   },
@@ -223,8 +223,8 @@ const zh: typeof en = {
     betaError: "提交失败，请重试。",
   },
   install: {
-    unix: "macOS / Linux",
-    windows: "Windows",
+    tagline: "把这个发给你的 AI agent —— 然后一切就都准备好了。",
+    label: "给 AI agent",
     copy: "复制",
     copied: "已复制 ✓",
   },


### PR DESCRIPTION
Replaces the manual `install.sh` install script on the landing with the one-liner
AI-agent install, and adds it to README + docs.

**Landing** (`InstallCommand`): drops the macOS/Windows tabs, shows
`curl -fsSL https://riffpad.ai/SKILL.md` with the slogan "Send this to your AI
agent — the rest is automatic." (i18n EN/ZH). The agent reads the fetched
SKILL.md and installs + pairs + runs Riffpad.

**README / docs** (EN + ZH): a callout at the top of the Quickstart with the
same one-liner (manual `install.sh` steps kept as the fallback below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
