### PR TITLE
feat(landing): simplify hero, move docs to top bar and waitlist/discord to footer

### DIFF
--- a/apps/landing/components/Footer.tsx
+++ b/apps/landing/components/Footer.tsx
@@ -2,6 +2,7 @@
 
 import { BookIcon, DiscordIcon, GitHubIcon, MailIcon, XIcon } from "./icons";
 import { useLanguage } from "./LanguageProvider";
+import { WaitlistForm } from "./WaitlistForm";
 
 export function Footer() {
   const { t } = useLanguage();
@@ -9,7 +10,28 @@ export function Footer() {
   return (
     <footer className="border-t border-hairline bg-surface">
       <div className="mx-auto max-w-frame px-4 py-12 sm:px-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col items-center gap-4 border-b border-hairline pb-12 text-center">
+          <p className="text-sm text-body">
+            {t.hero.betaPrefix}{" "}
+            <span className="font-semibold text-ink">{t.hero.betaWaitlist}</span>
+          </p>
+          <WaitlistForm />
+          <p className="text-sm text-body">
+            {t.hero.betaOr}{" "}
+            <a
+              href="https://discord.gg/CDNFTg2QyM"
+              target="_blank"
+              rel="noreferrer"
+              className="group inline-flex items-center gap-1.5 font-semibold text-ink transition-colors hover:text-accent"
+            >
+              <DiscordIcon className="h-4 w-4 shrink-0" />
+              <span className="underline decoration-hairline-strong underline-offset-4 transition-colors group-hover:decoration-accent">
+                {t.hero.betaDiscord}
+              </span>
+            </a>
+          </p>
+        </div>
+        <div className="flex flex-col gap-4 pt-8 sm:flex-row sm:items-center sm:justify-between">
           <div className="text-xs text-mute">{t.footer.copyright}</div>
           <nav
             className="flex flex-wrap items-center gap-4 text-body"

--- a/apps/landing/components/Header.tsx
+++ b/apps/landing/components/Header.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { Logo } from "./Logo";
 import { LanguageSwitch } from "./LanguageSwitch";
 import { ThemeToggle } from "./ThemeToggle";
+import { useLanguage } from "./LanguageProvider";
 
 function formatStars(n: number): string {
   return n >= 1000 ? `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k` : String(n);
@@ -47,6 +48,8 @@ function GitHubLink() {
 }
 
 export function Header() {
+  const { t } = useLanguage();
+
   return (
     <header className="sticky top-0 z-50 border-b border-hairline bg-surface">
       <div className="mx-auto flex h-14 max-w-frame items-center justify-between px-4 sm:px-6">
@@ -59,6 +62,12 @@ export function Header() {
         </a>
 
         <div className="flex items-center gap-2">
+          <a
+            href="https://www.riffpad.ai/docs/guide/quickstart"
+            className="flex h-11 cursor-pointer items-center px-2 text-sm font-medium text-body transition-colors hover:text-ink"
+          >
+            {t.header.docs}
+          </a>
           <LanguageSwitch />
           <ThemeToggle />
           <GitHubLink />

--- a/apps/landing/components/Hero.tsx
+++ b/apps/landing/components/Hero.tsx
@@ -3,8 +3,6 @@
 import { useLanguage } from "./LanguageProvider";
 import { DeviceMockup } from "./DeviceMockup";
 import { InstallCommand } from "./InstallCommand";
-import { WaitlistForm } from "./WaitlistForm";
-import { DiscordIcon } from "./icons";
 
 export function Hero() {
   const { t } = useLanguage();
@@ -32,32 +30,7 @@ export function Hero() {
           >
             {t.hero.ctaPrimary}
           </a>
-          <a
-            href="https://www.riffpad.ai/docs/guide/quickstart"
-            className="btn btn-secondary w-full sm:w-auto"
-          >
-            {t.hero.ctaSecondary}
-          </a>
         </div>
-        <p className="mt-5 text-sm text-body">
-          {t.hero.betaPrefix}{" "}
-          <span className="font-semibold text-ink">{t.hero.betaWaitlist}</span>
-        </p>
-        <WaitlistForm />
-        <p className="mt-3 text-sm text-body">
-          {t.hero.betaOr}{" "}
-          <a
-            href="https://discord.gg/CDNFTg2QyM"
-            target="_blank"
-            rel="noreferrer"
-            className="group inline-flex items-center gap-1.5 font-semibold text-ink transition-colors hover:text-accent"
-          >
-            <DiscordIcon className="h-4 w-4 shrink-0" />
-            <span className="underline decoration-hairline-strong underline-offset-4 transition-colors group-hover:decoration-accent">
-              {t.hero.betaDiscord}
-            </span>
-          </a>
-        </p>
         <InstallCommand />
       </div>
 

--- a/apps/landing/lib/i18n.ts
+++ b/apps/landing/lib/i18n.ts
@@ -1,6 +1,9 @@
 export type Language = "en" | "zh";
 
 const en = {
+  header: {
+    docs: "Docs",
+  },
   hero: {
     title1: "Your AI coding agents,",
     title2: "synced to your phone.",
@@ -207,6 +210,9 @@ const en = {
 };
 
 const zh: typeof en = {
+  header: {
+    docs: "文档",
+  },
   hero: {
     title1: "你的 AI 编程 Agent，",
     title2: "同步到手机。",


### PR DESCRIPTION
## What
Simplifies the landing hero and relocates a few elements.

## Changes
- **Hero**: removed the secondary "Read the docs" button, the waitlist email form, and the Discord link. Hero now shows just the headline, description, primary CTA (Open app), the install command, and the device mockup.
- **Top bar**: added a localized "Docs" / "文档" text link → quickstart.
- **Footer**: added a band at the top with the waitlist email form and the Discord text link; the existing copyright + social icon row stays below it.
- **i18n**: new `header.docs` (en/zh). Waitlist strings stay under `hero.beta*`, reused from the footer.

## Notes
- Generated/unrelated working-tree files (`llms-full.txt`, `tsconfig.tsbuildinfo`) were intentionally excluded from this PR.
- Typecheck passes (`tsc --noEmit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)