### PR TITLE
chore: ignore *.tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bin/
 apps/relay/dist/
 __pycache__/
 *.pyc
+*.tsbuildinfo
 .env
 *.log
 .DS_Store


### PR DESCRIPTION
Adds `*.tsbuildinfo` (e.g. `apps/landing/tsconfig.tsbuildinfo`) to `.gitignore`. Placed near the other compiler-cache entries; `.bro/` is intentionally left out here since it already ships in #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)