### PR TITLE
feat(landing): add LaunchKiwi badge to footer

### DIFF
--- a/apps/landing/components/Footer.tsx
+++ b/apps/landing/components/Footer.tsx
@@ -2,10 +2,12 @@
 
 import { BookIcon, DiscordIcon, GitHubIcon, MailIcon, XIcon } from "./icons";
 import { useLanguage } from "./LanguageProvider";
+import { useTheme } from "./ThemeProvider";
 import { WaitlistForm } from "./WaitlistForm";
 
 export function Footer() {
   const { t } = useLanguage();
+  const { theme } = useTheme();
 
   return (
     <footer className="border-t border-hairline bg-surface">
@@ -31,54 +33,74 @@ export function Footer() {
             </a>
           </p>
         </div>
-        <div className="flex flex-col gap-4 pt-8 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-4 pt-8 sm:flex-row sm:items-end sm:justify-between">
           <div className="text-xs text-mute">{t.footer.copyright}</div>
-          <nav
-            className="flex flex-wrap items-center gap-4 text-body"
-            aria-label="Footer"
-          >
+          <div className="flex flex-wrap items-center gap-4 sm:gap-6">
+            <nav
+              className="flex flex-wrap items-center gap-4 text-body"
+              aria-label="Footer"
+            >
+              <a
+                href="https://github.com/riffpad/riffpad"
+                target="_blank"
+                rel="noreferrer"
+                aria-label={t.footer.github}
+                className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
+              >
+                <GitHubIcon className="h-4 w-4" />
+              </a>
+              <a
+                href="https://www.riffpad.ai/docs/guide/quickstart"
+                aria-label={t.footer.docs}
+                className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
+              >
+                <BookIcon className="h-4 w-4" />
+              </a>
+              <a
+                href="https://discord.gg/CDNFTg2QyM"
+                target="_blank"
+                rel="noreferrer"
+                aria-label={t.footer.discord}
+                className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
+              >
+                <DiscordIcon className="h-4 w-4" />
+              </a>
+              <a
+                href="https://x.com/riffpad_ai"
+                target="_blank"
+                rel="noreferrer"
+                aria-label={t.footer.x}
+                className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
+              >
+                <XIcon className="h-4 w-4" />
+              </a>
+              <a
+                href="mailto:hi@riffpad.ai"
+                aria-label={t.footer.contact}
+                className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
+              >
+                <MailIcon className="h-4 w-4" />
+              </a>
+            </nav>
             <a
-              href="https://github.com/riffpad/riffpad"
+              href="https://launchkiwi.com/p/riffpad"
               target="_blank"
-              rel="noreferrer"
-              aria-label={t.footer.github}
-              className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
+              rel="noopener noreferrer"
+              aria-label="Featured on LaunchKiwi"
             >
-              <GitHubIcon className="h-4 w-4" />
+              <img
+                src={
+                  theme === "dark"
+                    ? "https://launchkiwi.com/badge-dark.svg"
+                    : "https://launchkiwi.com/badge-light.svg"
+                }
+                alt="Featured on LaunchKiwi"
+                width="198"
+                height="62"
+                className="block h-8 w-auto opacity-80 transition-opacity hover:opacity-100"
+              />
             </a>
-            <a
-              href="https://www.riffpad.ai/docs/guide/quickstart"
-              aria-label={t.footer.docs}
-              className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
-            >
-              <BookIcon className="h-4 w-4" />
-            </a>
-            <a
-              href="https://discord.gg/CDNFTg2QyM"
-              target="_blank"
-              rel="noreferrer"
-              aria-label={t.footer.discord}
-              className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
-            >
-              <DiscordIcon className="h-4 w-4" />
-            </a>
-            <a
-              href="https://x.com/riffpad_ai"
-              target="_blank"
-              rel="noreferrer"
-              aria-label={t.footer.x}
-              className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
-            >
-              <XIcon className="h-4 w-4" />
-            </a>
-            <a
-              href="mailto:hi@riffpad.ai"
-              aria-label={t.footer.contact}
-              className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
-            >
-              <MailIcon className="h-4 w-4" />
-            </a>
-          </nav>
+          </div>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
Adds the LaunchKiwi directory badge to the landing page footer.

### Changes
- Adds a theme-aware LaunchKiwi badge next to the social icons in the footer
- Badge links to https://launchkiwi.com/p/riffpad
- Uses the light/dark SVG variants based on the current theme
- Sized at h-8 to keep the footer row visually balanced

### Verification
- [ ] Run dev server with `pnpm --filter landing dev`
- [ ] Confirm badge renders in both light and dark themes
- [ ] Confirm badge link points to the correct LaunchKiwi listing