### PR TITLE
feat(landing): polish nav bar with favicon logo and mobile hamburger

### DIFF
--- a/apps/landing/components/Header.tsx
+++ b/apps/landing/components/Header.tsx
@@ -4,13 +4,21 @@ import { useEffect, useState } from "react";
 import { Logo } from "./Logo";
 import { LanguageSwitch } from "./LanguageSwitch";
 import { ThemeToggle } from "./ThemeToggle";
+import { MobileMenu } from "./MobileMenu";
+import { GitHubIcon, BookIcon } from "./icons";
 import { useLanguage } from "./LanguageProvider";
 
 function formatStars(n: number): string {
   return n >= 1000 ? `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k` : String(n);
 }
 
-function GitHubLink() {
+function GitHubLink({
+  compact = false,
+  className = "",
+}: {
+  compact?: boolean;
+  className?: string;
+}) {
   const [stars, setStars] = useState<number | null>(null);
 
   useEffect(() => {
@@ -30,26 +38,54 @@ function GitHubLink() {
       target="_blank"
       rel="noreferrer"
       aria-label="GitHub"
-      className="flex h-11 cursor-pointer items-center gap-1.5 px-2 text-body transition-colors hover:text-ink"
+      className={`flex cursor-pointer items-center justify-center gap-1.5 text-mute transition-colors hover:text-ink active:bg-surface-muted active:text-ink ${
+        compact ? "h-9 w-9" : "h-9 px-2"
+      } ${className}`}
     >
-      <svg
-        viewBox="0 0 24 24"
-        fill="currentColor"
-        className="h-4 w-4"
-        aria-hidden="true"
-      >
-        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
-      </svg>
-      {stars !== null && (
+      <GitHubIcon className="h-4 w-4" />
+      {!compact && stars !== null && (
         <span className="text-xs font-bold leading-none">{formatStars(stars)}</span>
       )}
     </a>
   );
 }
 
-export function Header() {
+function DocsLink({
+  compact = false,
+  className = "",
+}: {
+  compact?: boolean;
+  className?: string;
+}) {
   const { t } = useLanguage();
 
+  return (
+    <a
+      href="https://www.riffpad.ai/docs/guide/quickstart"
+      target="_blank"
+      rel="noreferrer"
+      aria-label={t.header.docs}
+      className={`flex cursor-pointer items-center justify-center text-mute transition-colors hover:text-ink active:bg-surface-muted active:text-ink h-9 ${
+        compact ? "w-9" : "w-9"
+      } ${className}`}
+    >
+      <BookIcon className="h-4 w-4" />
+    </a>
+  );
+}
+
+function ControlGroup() {
+  return (
+    <div className="hidden items-center gap-1 md:flex">
+      <DocsLink />
+      <LanguageSwitch />
+      <ThemeToggle />
+      <GitHubLink />
+    </div>
+  );
+}
+
+export function Header() {
   return (
     <header className="sticky top-0 z-50 border-b border-hairline bg-surface">
       <div className="mx-auto flex h-14 max-w-frame items-center justify-between px-4 sm:px-6">
@@ -62,15 +98,13 @@ export function Header() {
         </a>
 
         <div className="flex items-center gap-2">
-          <a
-            href="https://www.riffpad.ai/docs/guide/quickstart"
-            className="flex h-11 cursor-pointer items-center px-2 text-sm font-medium text-body transition-colors hover:text-ink"
-          >
-            {t.header.docs}
-          </a>
-          <LanguageSwitch />
-          <ThemeToggle />
-          <GitHubLink />
+          <ControlGroup />
+          <MobileMenu>
+            <DocsLink compact />
+            <LanguageSwitch />
+            <ThemeToggle />
+            <GitHubLink compact />
+          </MobileMenu>
         </div>
       </div>
     </header>

--- a/apps/landing/components/LanguageSwitch.tsx
+++ b/apps/landing/components/LanguageSwitch.tsx
@@ -1,20 +1,31 @@
 "use client";
 
+import { GlobeIcon } from "./icons";
 import { useLanguage } from "./LanguageProvider";
 import type { Language } from "@/lib/i18n";
 
-export function LanguageSwitch() {
+export function LanguageSwitch({ className = "" }: { className?: string }) {
   const { lang, setLang } = useLanguage();
   const next: Language = lang === "en" ? "zh" : "en";
+  const fullWidth = /w-full/.test(className);
 
   return (
     <button
       type="button"
       onClick={() => setLang(next)}
-      className="flex h-11 cursor-pointer items-center justify-center px-3 text-xs font-bold text-mute transition-colors hover:text-ink"
+      className={`relative flex h-9 w-9 cursor-pointer items-center justify-center text-mute transition-colors hover:text-ink active:bg-surface-muted active:text-ink ${className}`}
       aria-label={lang === "en" ? "Switch to 中文" : "Switch to English"}
     >
-      {lang === "en" ? "中" : "EN"}
+      <GlobeIcon className="h-4 w-4" />
+      <span
+        className={`text-[8px] font-bold leading-none ${
+          fullWidth
+            ? "ml-1"
+            : "absolute bottom-1.5 right-1"
+        }`}
+      >
+        {lang === "en" ? "EN" : "中"}
+      </span>
     </button>
   );
 }

--- a/apps/landing/components/Logo.tsx
+++ b/apps/landing/components/Logo.tsx
@@ -7,12 +7,12 @@ export function Logo({ className = "h-6 w-6" }: { className?: string }) {
       fill="currentColor"
     >
       <g transform="rotate(-90, 150, 150)">
-        <rect x="70" y="70" width="40" height="40" fill="var(--accent)" />
-        <rect x="130" y="70" width="40" height="40" fill="var(--accent)" />
-        <rect x="190" y="70" width="40" height="40" fill="var(--accent)" />
-        <rect x="70" y="130" width="100" height="40" fill="var(--accent)" />
-        <rect x="190" y="130" width="40" height="40" fill="var(--accent)" />
-        <rect x="70" y="190" width="160" height="40" fill="var(--accent)" />
+        <rect x="70" y="70" width="40" height="40" />
+        <rect x="130" y="70" width="40" height="40" />
+        <rect x="190" y="70" width="40" height="40" />
+        <rect x="70" y="130" width="100" height="40" />
+        <rect x="190" y="130" width="40" height="40" />
+        <rect x="70" y="190" width="160" height="40" />
       </g>
     </svg>
   );

--- a/apps/landing/components/MobileMenu.tsx
+++ b/apps/landing/components/MobileMenu.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { MenuIcon, CloseIcon } from "./icons";
+
+type MobileMenuProps = {
+  children: ReactNode;
+};
+
+export function MobileMenu({ children }: MobileMenuProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="relative md:hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex h-9 w-9 cursor-pointer items-center justify-center text-mute transition-colors hover:text-ink"
+        aria-label={open ? "Close menu" : "Open menu"}
+        aria-expanded={open}
+      >
+        {open ? <CloseIcon className="h-4 w-4" /> : <MenuIcon className="h-4 w-4" />}
+      </button>
+
+      {open && (
+        <div
+          className="absolute right-0 top-full mt-2 border border-hairline bg-surface p-2 shadow-card"
+          onClick={() => setOpen(false)}
+        >
+          <div className="flex flex-col gap-1">
+            {children}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/landing/components/ThemeToggle.tsx
+++ b/apps/landing/components/ThemeToggle.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { SunIcon, MoonIcon } from "./icons";
 import { useTheme } from "./ThemeProvider";
 
-export function ThemeToggle() {
+export function ThemeToggle({ className = "" }: { className?: string }) {
   const { theme, setTheme } = useTheme();
   const next = theme === "light" ? "dark" : "light";
 
@@ -10,10 +11,14 @@ export function ThemeToggle() {
     <button
       type="button"
       onClick={() => setTheme(next)}
-      className="flex h-11 cursor-pointer items-center justify-center px-3 text-xs font-bold text-mute transition-colors hover:text-ink"
+      className={`flex h-9 w-9 cursor-pointer items-center justify-center text-mute transition-colors hover:text-ink active:bg-surface-muted active:text-ink ${className}`}
       aria-label={theme === "light" ? "Switch to dark theme" : "Switch to light theme"}
     >
-      {next === "dark" ? "Dark" : "Light"}
+      {theme === "light" ? (
+        <SunIcon className="h-4 w-4" />
+      ) : (
+        <MoonIcon className="h-4 w-4" />
+      )}
     </button>
   );
 }

--- a/apps/landing/components/icons.tsx
+++ b/apps/landing/components/icons.tsx
@@ -77,3 +77,90 @@ export function MailIcon({ className = "h-4 w-4" }: IconProps) {
     </svg>
   );
 }
+
+export function MenuIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4 6h16M4 12h16M4 18h16" />
+    </svg>
+  );
+}
+
+export function CloseIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M18 6 6 18M6 6l12 12" />
+    </svg>
+  );
+}
+
+export function SunIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+    </svg>
+  );
+}
+
+export function MoonIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+    </svg>
+  );
+}
+
+export function GlobeIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
Closes #286

Polish the landing page header:

- Replace green accent logo with the same monochrome grid mark as favicon.svg
- Group Docs, language, theme, and GitHub controls into a harmonious row of icon buttons on desktop
- Add a mobile hamburger menu that opens a compact dropdown with the same icon buttons
- Ensure LanguageSwitch looks identical in desktop and mobile menus
- Add active tap feedback on all nav buttons

Files changed:
- apps/landing/components/Header.tsx
- apps/landing/components/Logo.tsx
- apps/landing/components/LanguageSwitch.tsx
- apps/landing/components/ThemeToggle.tsx
- apps/landing/components/icons.tsx
- apps/landing/components/MobileMenu.tsx (new)

Verification:
- [ ] Desktop nav shows monochrome logo + icon controls
- [ ] Mobile nav shows hamburger + compact dropdown
- [ ] Language toggle renders identically in both contexts
- [ ] Theme toggle switches light/dark
- [ ] All nav buttons show tap feedback
- [ ] pnpm --filter landing lint passes