### PR TITLE
feat(landing): add scroll-reveal animations (#288)

### DIFF
--- a/apps/landing/components/Architecture.tsx
+++ b/apps/landing/components/Architecture.tsx
@@ -2,6 +2,7 @@
 
 import { useLanguage } from "./LanguageProvider";
 import { BRAND_ICONS } from "./brand-icons";
+import { ScrollReveal } from "./ScrollReveal";
 
 const NODE_W = 160;
 const NODE_H = 96;
@@ -131,13 +132,20 @@ export function Architecture() {
       className="mx-auto max-w-frame scroll-mt-20 px-4 py-12 sm:px-6 sm:py-16 lg:py-32"
     >
       <div className="mx-auto max-w-content">
-        <span className="label">{`// ${a.label}`}</span>
-        <h2 className="mt-6 text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
-          {a.title}
-        </h2>
-        <p className="mt-3 text-base text-body">{a.description}</p>
+        <ScrollReveal>
+          <span className="label">{`// ${a.label}`}</span>
+        </ScrollReveal>
+        <ScrollReveal delay={100}>
+          <h2 className="mt-6 text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
+            {a.title}
+          </h2>
+        </ScrollReveal>
+        <ScrollReveal delay={200}>
+          <p className="mt-3 text-base text-body">{a.description}</p>
+        </ScrollReveal>
 
-        <div className="mt-12 overflow-x-auto border border-hairline">
+        <ScrollReveal delay={300}>
+          <div className="mt-12 overflow-x-auto border border-hairline">
           <div className="relative min-w-[680px]">
             <div className="arch-grid absolute inset-0" aria-hidden="true" />
             <svg
@@ -257,6 +265,7 @@ export function Architecture() {
             </svg>
           </div>
         </div>
+        </ScrollReveal>
       </div>
     </section>
   );

--- a/apps/landing/components/CTA.tsx
+++ b/apps/landing/components/CTA.tsx
@@ -1,28 +1,36 @@
 "use client";
 
 import { useLanguage } from "./LanguageProvider";
+import { ScrollReveal } from "./ScrollReveal";
 
 export function CTA() {
   const { t } = useLanguage();
 
   return (
     <section className="mx-auto max-w-frame px-4 py-12 text-center sm:px-6 sm:py-16 lg:py-32">
-      <h2 className="mx-auto max-w-content text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
-        {t.cta.title}
-      </h2>
-      <p className="mx-auto mt-4 max-w-[560px] text-base text-body">
-        {t.cta.description}
-      </p>
-
-      <a
-        href="https://app.riffpad.ai"
-        target="_blank"
-        rel="noreferrer"
-        className="btn btn-primary mt-10 h-12 px-8"
-      >
-        {t.cta.button} <span aria-hidden="true">→</span>
-      </a>
-      <p className="mt-4 text-xs text-mute">{t.cta.note}</p>
+      <ScrollReveal>
+        <h2 className="mx-auto max-w-content text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
+          {t.cta.title}
+        </h2>
+      </ScrollReveal>
+      <ScrollReveal delay={100}>
+        <p className="mx-auto mt-4 max-w-[560px] text-base text-body">
+          {t.cta.description}
+        </p>
+      </ScrollReveal>
+      <ScrollReveal delay={200}>
+        <a
+          href="https://app.riffpad.ai"
+          target="_blank"
+          rel="noreferrer"
+          className="btn btn-primary mt-10 h-12 px-8"
+        >
+          {t.cta.button} <span aria-hidden="true">→</span>
+        </a>
+      </ScrollReveal>
+      <ScrollReveal delay={300}>
+        <p className="mt-4 text-xs text-mute">{t.cta.note}</p>
+      </ScrollReveal>
     </section>
   );
 }

--- a/apps/landing/components/FAQ.tsx
+++ b/apps/landing/components/FAQ.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useLanguage } from "./LanguageProvider";
+import { ScrollReveal } from "./ScrollReveal";
 
 export function FAQ() {
   const { t } = useLanguage();
@@ -13,12 +14,17 @@ export function FAQ() {
       className="mx-auto max-w-frame scroll-mt-20 px-4 py-12 sm:px-6 sm:py-16 lg:py-32"
     >
       <div className="mx-auto max-w-content">
-        <span className="label">{`// ${t.faq.label}`}</span>
-        <h2 className="mt-6 text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
-          {t.faq.title}
-        </h2>
+        <ScrollReveal>
+          <span className="label">{`// ${t.faq.label}`}</span>
+        </ScrollReveal>
+        <ScrollReveal delay={100}>
+          <h2 className="mt-6 text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
+            {t.faq.title}
+          </h2>
+        </ScrollReveal>
 
-        <div className="card mt-12 divide-y divide-hairline p-2 sm:p-4">
+        <ScrollReveal delay={200}>
+          <div className="card mt-12 divide-y divide-hairline p-2 sm:p-4">
           {t.faq.items.map((item, index) => {
             const isOpen = open === index;
             return (
@@ -43,6 +49,7 @@ export function FAQ() {
             );
           })}
         </div>
+        </ScrollReveal>
       </div>
     </section>
   );

--- a/apps/landing/components/Footer.tsx
+++ b/apps/landing/components/Footer.tsx
@@ -4,6 +4,7 @@ import { BookIcon, DiscordIcon, GitHubIcon, MailIcon, XIcon } from "./icons";
 import { useLanguage } from "./LanguageProvider";
 import { useTheme } from "./ThemeProvider";
 import { WaitlistForm } from "./WaitlistForm";
+import { ScrollReveal } from "./ScrollReveal";
 
 export function Footer() {
   const { t } = useLanguage();
@@ -12,96 +13,100 @@ export function Footer() {
   return (
     <footer className="border-t border-hairline bg-surface">
       <div className="mx-auto max-w-frame px-4 py-12 sm:px-6">
-        <div className="flex flex-col items-center gap-4 border-b border-hairline pb-12 text-center">
-          <p className="text-sm text-body">
-            {t.hero.betaPrefix}{" "}
-            <span className="font-semibold text-ink">{t.hero.betaWaitlist}</span>
-          </p>
-          <WaitlistForm />
-          <p className="text-sm text-body">
-            {t.hero.betaOr}{" "}
-            <a
-              href="https://discord.gg/CDNFTg2QyM"
-              target="_blank"
-              rel="noreferrer"
-              className="group inline-flex items-center gap-1.5 font-semibold text-ink transition-colors hover:text-accent"
-            >
-              <DiscordIcon className="h-4 w-4 shrink-0" />
-              <span className="underline decoration-hairline-strong underline-offset-4 transition-colors group-hover:decoration-accent">
-                {t.hero.betaDiscord}
-              </span>
-            </a>
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 pt-8 sm:flex-row sm:items-end sm:justify-between">
-          <div className="text-xs text-mute">{t.footer.copyright}</div>
-          <div className="flex flex-wrap items-center gap-4 sm:gap-6">
-            <nav
-              className="flex flex-wrap items-center gap-4 text-body"
-              aria-label="Footer"
-            >
-              <a
-                href="https://github.com/riffpad/riffpad"
-                target="_blank"
-                rel="noreferrer"
-                aria-label={t.footer.github}
-                className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
-              >
-                <GitHubIcon className="h-4 w-4" />
-              </a>
-              <a
-                href="https://www.riffpad.ai/docs/guide/quickstart"
-                aria-label={t.footer.docs}
-                className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
-              >
-                <BookIcon className="h-4 w-4" />
-              </a>
+        <ScrollReveal>
+          <div className="flex flex-col items-center gap-4 border-b border-hairline pb-12 text-center">
+            <p className="text-sm text-body">
+              {t.hero.betaPrefix}{" "}
+              <span className="font-semibold text-ink">{t.hero.betaWaitlist}</span>
+            </p>
+            <WaitlistForm />
+            <p className="text-sm text-body">
+              {t.hero.betaOr}{" "}
               <a
                 href="https://discord.gg/CDNFTg2QyM"
                 target="_blank"
                 rel="noreferrer"
-                aria-label={t.footer.discord}
-                className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
+                className="group inline-flex items-center gap-1.5 font-semibold text-ink transition-colors hover:text-accent"
               >
-                <DiscordIcon className="h-4 w-4" />
+                <DiscordIcon className="h-4 w-4 shrink-0" />
+                <span className="underline decoration-hairline-strong underline-offset-4 transition-colors group-hover:decoration-accent">
+                  {t.hero.betaDiscord}
+                </span>
               </a>
-              <a
-                href="https://x.com/riffpad_ai"
-                target="_blank"
-                rel="noreferrer"
-                aria-label={t.footer.x}
-                className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
-              >
-                <XIcon className="h-4 w-4" />
-              </a>
-              <a
-                href="mailto:hi@riffpad.ai"
-                aria-label={t.footer.contact}
-                className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
-              >
-                <MailIcon className="h-4 w-4" />
-              </a>
-            </nav>
-            <a
-              href="https://launchkiwi.com/p/riffpad"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Featured on LaunchKiwi"
-            >
-              <img
-                src={
-                  theme === "dark"
-                    ? "https://launchkiwi.com/badge-dark.svg"
-                    : "https://launchkiwi.com/badge-light.svg"
-                }
-                alt="Featured on LaunchKiwi"
-                width="198"
-                height="62"
-                className="block h-8 w-auto opacity-80 transition-opacity hover:opacity-100"
-              />
-            </a>
+            </p>
           </div>
-        </div>
+        </ScrollReveal>
+        <ScrollReveal delay={150}>
+          <div className="flex flex-col gap-4 pt-8 sm:flex-row sm:items-end sm:justify-between">
+            <div className="text-xs text-mute">{t.footer.copyright}</div>
+            <div className="flex flex-wrap items-center gap-4 sm:gap-6">
+              <nav
+                className="flex flex-wrap items-center gap-4 text-body"
+                aria-label="Footer"
+              >
+                <a
+                  href="https://github.com/riffpad/riffpad"
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={t.footer.github}
+                  className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
+                >
+                  <GitHubIcon className="h-4 w-4" />
+                </a>
+                <a
+                  href="https://www.riffpad.ai/docs/guide/quickstart"
+                  aria-label={t.footer.docs}
+                  className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
+                >
+                  <BookIcon className="h-4 w-4" />
+                </a>
+                <a
+                  href="https://discord.gg/CDNFTg2QyM"
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={t.footer.discord}
+                  className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
+                >
+                  <DiscordIcon className="h-4 w-4" />
+                </a>
+                <a
+                  href="https://x.com/riffpad_ai"
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={t.footer.x}
+                  className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
+                >
+                  <XIcon className="h-4 w-4" />
+                </a>
+                <a
+                  href="mailto:hi@riffpad.ai"
+                  aria-label={t.footer.contact}
+                  className="inline-flex h-8 w-8 items-center justify-center transition-colors hover:text-ink"
+                >
+                  <MailIcon className="h-4 w-4" />
+                </a>
+              </nav>
+              <a
+                href="https://launchkiwi.com/p/riffpad"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Featured on LaunchKiwi"
+              >
+                <img
+                  src={
+                    theme === "dark"
+                      ? "https://launchkiwi.com/badge-dark.svg"
+                      : "https://launchkiwi.com/badge-light.svg"
+                  }
+                  alt="Featured on LaunchKiwi"
+                  width="198"
+                  height="62"
+                  className="block h-8 w-auto opacity-80 transition-opacity hover:opacity-100"
+                />
+              </a>
+            </div>
+          </div>
+        </ScrollReveal>
       </div>
     </footer>
   );

--- a/apps/landing/components/Hero.tsx
+++ b/apps/landing/components/Hero.tsx
@@ -3,6 +3,7 @@
 import { useLanguage } from "./LanguageProvider";
 import { DeviceMockup } from "./DeviceMockup";
 import { InstallCommand } from "./InstallCommand";
+import { ScrollReveal } from "./ScrollReveal";
 
 export function Hero() {
   const { t } = useLanguage();
@@ -13,30 +14,40 @@ export function Hero() {
       className="mx-auto max-w-frame scroll-mt-20 px-4 pb-12 pt-10 sm:px-6 sm:pb-28 sm:pt-20"
     >
       <div className="mx-auto max-w-content text-center">
-        <h1 className="text-balance text-[28px] font-bold leading-[1.15] tracking-[-0.02em] sm:text-[40px]">
-          {t.hero.title1}
-          <br />
-          {t.hero.title2}
-        </h1>
-        <p className="mx-auto mt-6 max-w-[560px] text-base leading-[1.7] text-body">
-          {t.hero.description}
-        </p>
-        <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
-          <a
-            href="https://app.riffpad.ai"
-            target="_blank"
-            rel="noreferrer"
-            className="btn btn-primary w-full sm:w-auto"
-          >
-            {t.hero.ctaPrimary}
-          </a>
-        </div>
-        <InstallCommand />
+        <ScrollReveal>
+          <h1 className="text-balance text-[28px] font-bold leading-[1.15] tracking-[-0.02em] sm:text-[40px]">
+            {t.hero.title1}
+            <br />
+            {t.hero.title2}
+          </h1>
+        </ScrollReveal>
+        <ScrollReveal delay={100}>
+          <p className="mx-auto mt-6 max-w-[560px] text-base leading-[1.7] text-body">
+            {t.hero.description}
+          </p>
+        </ScrollReveal>
+        <ScrollReveal delay={200}>
+          <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <a
+              href="https://app.riffpad.ai"
+              target="_blank"
+              rel="noreferrer"
+              className="btn btn-primary w-full sm:w-auto"
+            >
+              {t.hero.ctaPrimary}
+            </a>
+          </div>
+        </ScrollReveal>
+        <ScrollReveal delay={300}>
+          <InstallCommand />
+        </ScrollReveal>
       </div>
 
-      <div className="mt-16 sm:mt-20">
-        <DeviceMockup />
-      </div>
+      <ScrollReveal delay={400}>
+        <div className="mt-16 sm:mt-20">
+          <DeviceMockup />
+        </div>
+      </ScrollReveal>
     </section>
   );
 }

--- a/apps/landing/components/HowItWorks.tsx
+++ b/apps/landing/components/HowItWorks.tsx
@@ -2,6 +2,7 @@
 
 import { useLanguage } from "./LanguageProvider";
 import { BRAND_ICONS } from "./brand-icons";
+import { ScrollReveal } from "./ScrollReveal";
 
 // Pseudo-QR pairing pattern: 1 = ink cell, 2 = accent finder block, 0 = empty.
 const QR_ROWS = [
@@ -84,11 +85,17 @@ export function HowItWorks() {
       className="mx-auto max-w-frame scroll-mt-20 px-4 py-12 sm:px-6 sm:py-16 lg:py-32"
     >
       <div className="mx-auto max-w-content">
-        <span className="label">{`// ${t.how.label}`}</span>
-        <h2 className="mt-6 text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
-          {t.how.title}
-        </h2>
-        <p className="mt-3 text-base text-body">{t.how.subtitle}</p>
+        <ScrollReveal>
+          <span className="label">{`// ${t.how.label}`}</span>
+        </ScrollReveal>
+        <ScrollReveal delay={100}>
+          <h2 className="mt-6 text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
+            {t.how.title}
+          </h2>
+        </ScrollReveal>
+        <ScrollReveal delay={200}>
+          <p className="mt-3 text-base text-body">{t.how.subtitle}</p>
+        </ScrollReveal>
 
         <div className="relative mt-12">
           <div
@@ -99,23 +106,22 @@ export function HowItWorks() {
             {t.how.steps.map((step, index) => {
               const Visual = visuals[index % visuals.length];
               return (
-                <div
-                  key={index}
-                  className="card relative flex flex-col p-6 sm:p-8"
-                >
-                  <span className="text-3xl font-bold text-accent">
-                    {String(index + 1).padStart(2, "0")}
-                  </span>
-                  <h3 className="mt-4 text-lg font-bold text-ink">
-                    {step.title}
-                  </h3>
-                  <p className="mt-2 text-base leading-[1.7] text-body">
-                    {step.description}
-                  </p>
-                  <div className="mt-auto pt-6">
-                    <Visual />
+                <ScrollReveal key={index} delay={300 + index * 150}>
+                  <div className="card relative flex flex-col p-6 sm:p-8">
+                    <span className="text-3xl font-bold text-accent">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    <h3 className="mt-4 text-lg font-bold text-ink">
+                      {step.title}
+                    </h3>
+                    <p className="mt-2 text-base leading-[1.7] text-body">
+                      {step.description}
+                    </p>
+                    <div className="mt-auto pt-6">
+                      <Visual />
+                    </div>
                   </div>
-                </div>
+                </ScrollReveal>
               );
             })}
           </div>

--- a/apps/landing/components/ScrollReveal.tsx
+++ b/apps/landing/components/ScrollReveal.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+type ScrollRevealProps = {
+  children: ReactNode;
+  delay?: number;
+  className?: string;
+};
+
+export function ScrollReveal({ children, delay = 0, className = "" }: ScrollRevealProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+  const [reducedMotion, setReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReducedMotion(media.matches);
+
+    const handler = () => setReducedMotion(media.matches);
+    media.addEventListener("change", handler);
+    return () => media.removeEventListener("change", handler);
+  }, []);
+
+  useEffect(() => {
+    if (reducedMotion) return;
+
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.unobserve(el);
+        }
+      },
+      { threshold: 0.1, rootMargin: "0px 0px -50px 0px" }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [reducedMotion]);
+
+  return (
+    <div
+      ref={ref}
+      className={`${className} ${
+        reducedMotion
+          ? ""
+          : visible
+            ? "translate-y-0 opacity-100"
+            : "translate-y-6 opacity-0"
+      } transition-all duration-700 ease-out`}
+      style={reducedMotion ? undefined : { transitionDelay: `${delay}ms` }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/landing/components/Security.tsx
+++ b/apps/landing/components/Security.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useLanguage } from "./LanguageProvider";
+import { ScrollReveal } from "./ScrollReveal";
 import type { Messages } from "@/lib/i18n";
 
 // Deterministic PRNG so server and client render the same ciphertext.
@@ -141,7 +142,7 @@ export function Security() {
     >
       <div className="mx-auto max-w-content">
         <div className="grid items-start gap-10 lg:grid-cols-2">
-          <div className="min-w-0">
+          <ScrollReveal className="min-w-0">
             <span className="label">{`// ${t.security.label}`}</span>
             <h2 className="mt-6 text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
               {t.security.title}
@@ -162,9 +163,11 @@ export function Security() {
                 </div>
               ))}
             </div>
-          </div>
+          </ScrollReveal>
 
-          <CipherFlow t={t} />
+          <ScrollReveal delay={200}>
+            <CipherFlow t={t} />
+          </ScrollReveal>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Closes #288

Adds a reusable `ScrollReveal` component that uses `IntersectionObserver` to fade in and slide up content as users scroll down the landing page. Major sections (Hero, Architecture, HowItWorks, Security, FAQ, CTA, Footer) are wrapped with staggered delays.

- Respects `prefers-reduced-motion`.
- Keeps existing layout unchanged; only adds animation wrappers.
- Verified locally with Playwright: element opacity transitions from 0 to 1 after scrolling into view.