### PR TITLE
fix(landing): prevent horizontal overflow on mobile (#290)

### DIFF
--- a/apps/landing/components/ScrollReveal.tsx
+++ b/apps/landing/components/ScrollReveal.tsx
@@ -45,7 +45,7 @@ export function ScrollReveal({ children, delay = 0, className = "" }: ScrollReve
   return (
     <div
       ref={ref}
-      className={`${className} ${
+      className={`${className} min-w-0 ${
         reducedMotion
           ? ""
           : visible


### PR DESCRIPTION
Closes #290

Adds `min-w-0` to the `ScrollReveal` wrapper so that grid/flex items can shrink below their content's intrinsic width. This prevents the Security cipher-stream animation and the Architecture diagram from forcing the mobile page width beyond the viewport.

- Verified with Playwright at 375×812: document width equals viewport width.
- Also verified at 1280×720 desktop: no horizontal overflow.
- `pnpm --filter landing lint` passes.