### PR TITLE
feat(landing): speed up scroll-reveal animations (#292)

### DIFF
--- a/apps/landing/components/Architecture.tsx
+++ b/apps/landing/components/Architecture.tsx
@@ -135,16 +135,16 @@ export function Architecture() {
         <ScrollReveal>
           <span className="label">{`// ${a.label}`}</span>
         </ScrollReveal>
-        <ScrollReveal delay={100}>
+        <ScrollReveal delay={75}>
           <h2 className="mt-6 text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
             {a.title}
           </h2>
         </ScrollReveal>
-        <ScrollReveal delay={200}>
+        <ScrollReveal delay={150}>
           <p className="mt-3 text-base text-body">{a.description}</p>
         </ScrollReveal>
 
-        <ScrollReveal delay={300}>
+        <ScrollReveal delay={225}>
           <div className="mt-12 overflow-x-auto border border-hairline">
           <div className="relative min-w-[680px]">
             <div className="arch-grid absolute inset-0" aria-hidden="true" />

--- a/apps/landing/components/CTA.tsx
+++ b/apps/landing/components/CTA.tsx
@@ -13,12 +13,12 @@ export function CTA() {
           {t.cta.title}
         </h2>
       </ScrollReveal>
-      <ScrollReveal delay={100}>
+      <ScrollReveal delay={75}>
         <p className="mx-auto mt-4 max-w-[560px] text-base text-body">
           {t.cta.description}
         </p>
       </ScrollReveal>
-      <ScrollReveal delay={200}>
+      <ScrollReveal delay={150}>
         <a
           href="https://app.riffpad.ai"
           target="_blank"
@@ -28,7 +28,7 @@ export function CTA() {
           {t.cta.button} <span aria-hidden="true">→</span>
         </a>
       </ScrollReveal>
-      <ScrollReveal delay={300}>
+      <ScrollReveal delay={225}>
         <p className="mt-4 text-xs text-mute">{t.cta.note}</p>
       </ScrollReveal>
     </section>

--- a/apps/landing/components/FAQ.tsx
+++ b/apps/landing/components/FAQ.tsx
@@ -17,13 +17,13 @@ export function FAQ() {
         <ScrollReveal>
           <span className="label">{`// ${t.faq.label}`}</span>
         </ScrollReveal>
-        <ScrollReveal delay={100}>
+        <ScrollReveal delay={75}>
           <h2 className="mt-6 text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
             {t.faq.title}
           </h2>
         </ScrollReveal>
 
-        <ScrollReveal delay={200}>
+        <ScrollReveal delay={150}>
           <div className="card mt-12 divide-y divide-hairline p-2 sm:p-4">
           {t.faq.items.map((item, index) => {
             const isOpen = open === index;

--- a/apps/landing/components/Footer.tsx
+++ b/apps/landing/components/Footer.tsx
@@ -36,7 +36,7 @@ export function Footer() {
             </p>
           </div>
         </ScrollReveal>
-        <ScrollReveal delay={150}>
+        <ScrollReveal delay={100}>
           <div className="flex flex-col gap-4 pt-8 sm:flex-row sm:items-end sm:justify-between">
             <div className="text-xs text-mute">{t.footer.copyright}</div>
             <div className="flex flex-wrap items-center gap-4 sm:gap-6">

--- a/apps/landing/components/Hero.tsx
+++ b/apps/landing/components/Hero.tsx
@@ -21,12 +21,12 @@ export function Hero() {
             {t.hero.title2}
           </h1>
         </ScrollReveal>
-        <ScrollReveal delay={100}>
+        <ScrollReveal delay={75}>
           <p className="mx-auto mt-6 max-w-[560px] text-base leading-[1.7] text-body">
             {t.hero.description}
           </p>
         </ScrollReveal>
-        <ScrollReveal delay={200}>
+        <ScrollReveal delay={150}>
           <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
             <a
               href="https://app.riffpad.ai"
@@ -38,12 +38,12 @@ export function Hero() {
             </a>
           </div>
         </ScrollReveal>
-        <ScrollReveal delay={300}>
+        <ScrollReveal delay={225}>
           <InstallCommand />
         </ScrollReveal>
       </div>
 
-      <ScrollReveal delay={400}>
+      <ScrollReveal delay={300}>
         <div className="mt-16 sm:mt-20">
           <DeviceMockup />
         </div>

--- a/apps/landing/components/HowItWorks.tsx
+++ b/apps/landing/components/HowItWorks.tsx
@@ -88,12 +88,12 @@ export function HowItWorks() {
         <ScrollReveal>
           <span className="label">{`// ${t.how.label}`}</span>
         </ScrollReveal>
-        <ScrollReveal delay={100}>
+        <ScrollReveal delay={75}>
           <h2 className="mt-6 text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
             {t.how.title}
           </h2>
         </ScrollReveal>
-        <ScrollReveal delay={200}>
+        <ScrollReveal delay={150}>
           <p className="mt-3 text-base text-body">{t.how.subtitle}</p>
         </ScrollReveal>
 
@@ -106,7 +106,7 @@ export function HowItWorks() {
             {t.how.steps.map((step, index) => {
               const Visual = visuals[index % visuals.length];
               return (
-                <ScrollReveal key={index} delay={300 + index * 150}>
+                <ScrollReveal key={index} delay={225 + index * 110}>
                   <div className="card relative flex flex-col p-6 sm:p-8">
                     <span className="text-3xl font-bold text-accent">
                       {String(index + 1).padStart(2, "0")}

--- a/apps/landing/components/ScrollReveal.tsx
+++ b/apps/landing/components/ScrollReveal.tsx
@@ -51,7 +51,7 @@ export function ScrollReveal({ children, delay = 0, className = "" }: ScrollReve
           : visible
             ? "translate-y-0 opacity-100"
             : "translate-y-6 opacity-0"
-      } transition-all duration-700 ease-out`}
+      } transition-all duration-500 ease-out`}
       style={reducedMotion ? undefined : { transitionDelay: `${delay}ms` }}
     >
       {children}

--- a/apps/landing/components/Security.tsx
+++ b/apps/landing/components/Security.tsx
@@ -165,7 +165,7 @@ export function Security() {
             </div>
           </ScrollReveal>
 
-          <ScrollReveal delay={200}>
+          <ScrollReveal delay={150}>
             <CipherFlow t={t} />
           </ScrollReveal>
         </div>


### PR DESCRIPTION
Closes #292

Makes the landing page scroll-reveal animations snappier.

- Transition duration: 700ms → 500ms
- Stagger delays scaled down by ~25% across Hero, Architecture, HowItWorks, Security, FAQ, CTA and Footer

Verified:
- Animations still trigger correctly after scrolling (Playwright).
- No horizontal overflow on mobile (375×812) or desktop (1280×720).
- 
> landing@0.1.0 lint /home/hv/projs/riffpad/apps/landing
> next lint


./components/Footer.tsx
95:17  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules passes.