### PR TITLE
fix(landing): equalize HowItWorks card heights on desktop (#301)

### DIFF
--- a/apps/landing/components/HowItWorks.tsx
+++ b/apps/landing/components/HowItWorks.tsx
@@ -107,7 +107,7 @@ export function HowItWorks() {
               const Visual = visuals[index % visuals.length];
               return (
                 <ScrollReveal key={index} delay={225 + index * 110}>
-                  <div className="card relative flex flex-col p-6 sm:p-8">
+                  <div className="card relative flex h-full flex-col p-6 sm:p-8">
                     <span className="text-3xl font-bold text-accent">
                       {String(index + 1).padStart(2, "0")}
                     </span>


### PR DESCRIPTION
Closes #301\n\nAdds `h-full` to the HowItWorks card container so it fills the grid item height. The existing `flex flex-col` + `mt-auto` then pushes the visual to the bottom, aligning all three cards on desktop.\n\n- Before: card heights were ~387 / 462 / 369 px\n- After: all three cards are 462 px on desktop\n- Verified with Playwright at 1280×720 and 375×812\n- `pnpm --filter landing lint` passes