### PR TITLE
feat(landing): add Featured on Uneed badge (#305)

### DIFF
--- a/apps/landing/components/Footer.tsx
+++ b/apps/landing/components/Footer.tsx
@@ -104,6 +104,24 @@ export function Footer() {
                   className="block h-8 w-auto opacity-80 transition-opacity hover:opacity-100"
                 />
               </a>
+              <a
+                href="https://www.uneed.best/tool/riffpad"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Featured on Uneed"
+              >
+                <img
+                  src={
+                    theme === "dark"
+                      ? "https://www.uneed.best/EMBED1.png"
+                      : "https://www.uneed.best/EMBED1A.png"
+                  }
+                  alt="Featured on Uneed"
+                  width="250"
+                  height="62"
+                  className="block h-8 w-auto opacity-80 transition-opacity hover:opacity-100"
+                />
+              </a>
             </div>
           </div>
         </ScrollReveal>


### PR DESCRIPTION
Closes #305\n\nAdds a "Featured on Uneed" badge to the landing page footer, next to the existing LaunchKiwi badge. Uses the dark-theme badge in dark mode and the light-theme badge in light mode, matching the current LaunchKiwi pattern.\n\n- Verified locally with Playwright\n- `pnpm --filter landing lint` passes