### PR TITLE
feat(landing): full-screen hero, unified width, alternating sections

### DIFF
--- a/apps/landing/app/globals.css
+++ b/apps/landing/app/globals.css
@@ -98,13 +98,11 @@
   body {
     @apply bg-canvas font-mono text-ink antialiased;
     text-rendering: optimizeLegibility;
-    /* Subtle dot grid that adds texture without competing with content. */
-    background-image: radial-gradient(
-      circle at center,
-      var(--hairline) 1px,
-      transparent 1px
-    );
-    background-size: 24px 24px;
+    /* Subtle line grid that adds texture without competing with content. */
+    background-image:
+      linear-gradient(to right, color-mix(in srgb, var(--hairline) 50%, transparent) 1px, transparent 1px),
+      linear-gradient(to bottom, color-mix(in srgb, var(--hairline) 50%, transparent) 1px, transparent 1px);
+    background-size: 48px 48px;
   }
 
   ::selection {
@@ -169,8 +167,9 @@
     display: none;
   }
 
-  /* Soft accent glow placed behind the hero mockup. */
-  .hero-glow {
+  /* Aperture spotlight behind the hero mockup: a defined circular pool
+     of light with a visible edge, like a stage spot. */
+  .hero-aperture {
     position: absolute;
     top: 50%;
     right: 0;
@@ -180,8 +179,9 @@
     pointer-events: none;
     background: radial-gradient(
       circle at 50% 50%,
-      color-mix(in srgb, var(--accent) 10%, transparent) 0%,
-      transparent 70%
+      color-mix(in srgb, var(--accent) 16%, transparent) 0%,
+      color-mix(in srgb, var(--accent) 8%, transparent) 40%,
+      transparent 65%
     );
     z-index: 0;
   }

--- a/apps/landing/app/globals.css
+++ b/apps/landing/app/globals.css
@@ -100,9 +100,9 @@
     text-rendering: optimizeLegibility;
     /* Subtle line grid that adds texture without competing with content. */
     background-image:
-      linear-gradient(to right, color-mix(in srgb, var(--hairline) 50%, transparent) 1px, transparent 1px),
-      linear-gradient(to bottom, color-mix(in srgb, var(--hairline) 50%, transparent) 1px, transparent 1px);
-    background-size: 48px 48px;
+      linear-gradient(to right, color-mix(in srgb, var(--hairline) 35%, transparent) 1px, transparent 1px),
+      linear-gradient(to bottom, color-mix(in srgb, var(--hairline) 35%, transparent) 1px, transparent 1px);
+    background-size: 72px 72px;
   }
 
   ::selection {
@@ -167,22 +167,24 @@
     display: none;
   }
 
-  /* Aperture spotlight behind the hero mockup: a defined circular pool
-     of light with a visible edge, like a stage spot. */
+  /* Bubble-like aperture behind the hero mockup: off-center, with a
+     defined round edge and a small highlight sheen. */
   .hero-aperture {
     position: absolute;
-    top: 50%;
-    right: 0;
-    width: 90%;
+    top: 5%;
+    right: -5%;
+    width: 80%;
     height: 90%;
-    transform: translateY(-50%);
     pointer-events: none;
-    background: radial-gradient(
-      circle at 50% 50%,
-      color-mix(in srgb, var(--accent) 16%, transparent) 0%,
-      color-mix(in srgb, var(--accent) 8%, transparent) 40%,
-      transparent 65%
-    );
+    background:
+      radial-gradient(circle at 38% 32%, rgba(255, 255, 255, 0.08) 0%, transparent 14%),
+      radial-gradient(
+        circle at 55% 45%,
+        color-mix(in srgb, var(--accent) 18%, transparent) 0%,
+        color-mix(in srgb, var(--accent) 8%, transparent) 38%,
+        color-mix(in srgb, var(--accent) 3%, transparent) 58%,
+        transparent 72%
+      );
     z-index: 0;
   }
 }

--- a/apps/landing/app/globals.css
+++ b/apps/landing/app/globals.css
@@ -98,6 +98,13 @@
   body {
     @apply bg-canvas font-mono text-ink antialiased;
     text-rendering: optimizeLegibility;
+    /* Subtle dot grid that adds texture without competing with content. */
+    background-image: radial-gradient(
+      circle at center,
+      var(--hairline) 1px,
+      transparent 1px
+    );
+    background-size: 24px 24px;
   }
 
   ::selection {
@@ -160,6 +167,23 @@
 
   .no-scrollbar::-webkit-scrollbar {
     display: none;
+  }
+
+  /* Soft accent glow placed behind the hero mockup. */
+  .hero-glow {
+    position: absolute;
+    top: 50%;
+    right: 0;
+    width: 90%;
+    height: 90%;
+    transform: translateY(-50%);
+    pointer-events: none;
+    background: radial-gradient(
+      circle at 50% 50%,
+      color-mix(in srgb, var(--accent) 10%, transparent) 0%,
+      transparent 70%
+    );
+    z-index: 0;
   }
 }
 

--- a/apps/landing/app/page.tsx
+++ b/apps/landing/app/page.tsx
@@ -11,13 +11,19 @@ export default function Home() {
   return (
     <>
       <Header />
-      <main>
+      <main className="relative">
         <Hero />
-        <Architecture />
+        <div className="bg-surface-muted">
+          <Architecture />
+        </div>
         <HowItWorks />
-        <Security />
+        <div className="bg-surface-muted">
+          <Security />
+        </div>
         <FAQ />
-        <CTA />
+        <div className="bg-surface-muted">
+          <CTA />
+        </div>
       </main>
       <Footer />
     </>

--- a/apps/landing/components/CTA.tsx
+++ b/apps/landing/components/CTA.tsx
@@ -1,36 +1,56 @@
 "use client";
 
 import { useLanguage } from "./LanguageProvider";
+import { DiscordIcon } from "./icons";
+import { WaitlistForm } from "./WaitlistForm";
 import { ScrollReveal } from "./ScrollReveal";
 
 export function CTA() {
   const { t } = useLanguage();
 
   return (
-    <section className="mx-auto max-w-frame px-4 py-12 text-center sm:px-6 sm:py-16 lg:py-32">
-      <ScrollReveal>
-        <h2 className="mx-auto max-w-content text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
-          {t.cta.title}
-        </h2>
-      </ScrollReveal>
-      <ScrollReveal delay={75}>
-        <p className="mx-auto mt-4 max-w-[560px] text-base text-body">
-          {t.cta.description}
-        </p>
-      </ScrollReveal>
-      <ScrollReveal delay={150}>
-        <a
-          href="https://app.riffpad.ai"
-          target="_blank"
-          rel="noreferrer"
-          className="btn btn-primary mt-10 h-12 px-8"
-        >
-          {t.cta.button} <span aria-hidden="true">→</span>
-        </a>
-      </ScrollReveal>
-      <ScrollReveal delay={225}>
-        <p className="mt-4 text-xs text-mute">{t.cta.note}</p>
-      </ScrollReveal>
+    <section className="mx-auto max-w-frame px-4 py-12 sm:px-6 sm:py-16 lg:py-32">
+      <div className="grid items-start gap-10 lg:grid-cols-2 lg:gap-16">
+        <ScrollReveal className="min-w-0 text-left">
+          <h2 className="max-w-content text-balance text-2xl font-bold leading-[1.25] tracking-[-0.01em] sm:text-3xl">
+            {t.cta.title}
+          </h2>
+          <p className="mt-4 max-w-[560px] text-base text-body">
+            {t.cta.description}
+          </p>
+          <a
+            href="https://app.riffpad.ai"
+            target="_blank"
+            rel="noreferrer"
+            className="btn btn-primary mt-8 h-12 px-8 sm:mt-10"
+          >
+            {t.cta.button} <span aria-hidden="true">→</span>
+          </a>
+          <p className="mt-4 text-xs text-mute">{t.cta.note}</p>
+        </ScrollReveal>
+
+        <ScrollReveal delay={150} className="min-w-0 text-left">
+          <p className="text-sm text-body">
+            {t.hero.betaPrefix}{" "}
+            <span className="font-semibold text-ink">{t.hero.betaWaitlist}</span>
+          </p>
+          <WaitlistForm className="items-start" />
+          <p className="mt-4 text-sm text-body">
+            {t.hero.betaOr}{" "}
+            <a
+              href="https://discord.gg/CDNFTg2QyM"
+              target="_blank"
+              rel="noreferrer"
+              className="group inline-flex items-center gap-1.5 font-semibold text-ink transition-colors hover:text-accent"
+            >
+              <DiscordIcon className="h-4 w-4 shrink-0" />
+              <span className="underline decoration-hairline-strong underline-offset-4 transition-colors group-hover:decoration-accent">
+                {t.hero.betaDiscord}
+              </span>
+            </a>
+          </p>
+        </ScrollReveal>
+      </div>
     </section>
   );
 }

--- a/apps/landing/components/Footer.tsx
+++ b/apps/landing/components/Footer.tsx
@@ -3,7 +3,6 @@
 import { BookIcon, DiscordIcon, GitHubIcon, MailIcon, XIcon } from "./icons";
 import { useLanguage } from "./LanguageProvider";
 import { useTheme } from "./ThemeProvider";
-import { WaitlistForm } from "./WaitlistForm";
 import { ScrollReveal } from "./ScrollReveal";
 
 export function Footer() {
@@ -14,30 +13,7 @@ export function Footer() {
     <footer className="border-t border-hairline bg-surface">
       <div className="mx-auto max-w-frame px-4 py-12 sm:px-6">
         <ScrollReveal>
-          <div className="flex flex-col items-center gap-4 border-b border-hairline pb-12 text-center">
-            <p className="text-sm text-body">
-              {t.hero.betaPrefix}{" "}
-              <span className="font-semibold text-ink">{t.hero.betaWaitlist}</span>
-            </p>
-            <WaitlistForm />
-            <p className="text-sm text-body">
-              {t.hero.betaOr}{" "}
-              <a
-                href="https://discord.gg/CDNFTg2QyM"
-                target="_blank"
-                rel="noreferrer"
-                className="group inline-flex items-center gap-1.5 font-semibold text-ink transition-colors hover:text-accent"
-              >
-                <DiscordIcon className="h-4 w-4 shrink-0" />
-                <span className="underline decoration-hairline-strong underline-offset-4 transition-colors group-hover:decoration-accent">
-                  {t.hero.betaDiscord}
-                </span>
-              </a>
-            </p>
-          </div>
-        </ScrollReveal>
-        <ScrollReveal delay={100}>
-          <div className="flex flex-col gap-4 pt-8 sm:flex-row sm:items-end sm:justify-between">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
             <div className="text-xs text-mute">{t.footer.copyright}</div>
             <div className="flex flex-wrap items-center gap-4 sm:gap-6">
               <nav

--- a/apps/landing/components/Hero.tsx
+++ b/apps/landing/components/Hero.tsx
@@ -10,9 +10,10 @@ export function Hero() {
   return (
     <section
       id="top"
-      className="flex min-h-[calc(100svh-3.5rem)] scroll-mt-14 items-center px-4 sm:px-6 lg:px-8"
+      className="relative flex min-h-[calc(100svh-3.5rem)] scroll-mt-14 items-center px-4 sm:px-6 lg:px-8"
     >
-      <div className="mx-auto grid w-full max-w-[1280px] items-center gap-8 py-10 sm:gap-10 sm:py-12 lg:grid-cols-[minmax(0,0.75fr)_minmax(0,1.25fr)] lg:gap-16">
+      <div aria-hidden="true" className="hero-glow" />
+      <div className="relative z-10 mx-auto grid w-full max-w-frame items-center gap-8 py-10 sm:gap-10 sm:py-12 lg:grid-cols-[minmax(0,0.65fr)_minmax(0,1.35fr)] lg:gap-16">
         <div className="text-left">
           <h1 className="text-balance text-[28px] font-bold leading-[1.1] tracking-[-0.02em] sm:text-[40px] lg:text-[52px]">
             {t.hero.title1}
@@ -36,7 +37,7 @@ export function Hero() {
         </div>
 
         <div className="relative flex min-w-0 items-center justify-center">
-          <div className="origin-center scale-[0.68] sm:scale-[0.8] lg:scale-[0.88] xl:scale-100">
+          <div className="origin-center scale-[0.68] sm:scale-[0.8] lg:scale-[0.92]">
             <DeviceMockup />
           </div>
         </div>

--- a/apps/landing/components/Hero.tsx
+++ b/apps/landing/components/Hero.tsx
@@ -10,9 +10,8 @@ export function Hero() {
   return (
     <section
       id="top"
-      className="relative flex min-h-[calc(100svh-3.5rem)] scroll-mt-14 items-center px-4 sm:px-6 lg:px-8"
+      className="relative flex min-h-[calc(100svh-3.5rem)] scroll-mt-14 items-center px-4 sm:px-6"
     >
-      <div aria-hidden="true" className="hero-aperture" />
       <div className="relative z-10 mx-auto grid w-full max-w-frame items-center gap-8 py-10 sm:gap-10 sm:py-12 lg:grid-cols-[minmax(0,0.7fr)_minmax(0,1.3fr)] lg:gap-16">
         <div className="text-left">
           <h1 className="text-balance text-[28px] font-bold leading-[1.1] tracking-[-0.02em] sm:text-[40px] lg:text-[52px]">

--- a/apps/landing/components/Hero.tsx
+++ b/apps/landing/components/Hero.tsx
@@ -12,7 +12,7 @@ export function Hero() {
       id="top"
       className="relative flex min-h-[calc(100svh-3.5rem)] scroll-mt-14 items-center px-4 sm:px-6 lg:px-8"
     >
-      <div aria-hidden="true" className="hero-glow" />
+      <div aria-hidden="true" className="hero-aperture" />
       <div className="relative z-10 mx-auto grid w-full max-w-frame items-center gap-8 py-10 sm:gap-10 sm:py-12 lg:grid-cols-[minmax(0,0.65fr)_minmax(0,1.35fr)] lg:gap-16">
         <div className="text-left">
           <h1 className="text-balance text-[28px] font-bold leading-[1.1] tracking-[-0.02em] sm:text-[40px] lg:text-[52px]">

--- a/apps/landing/components/Hero.tsx
+++ b/apps/landing/components/Hero.tsx
@@ -3,7 +3,6 @@
 import { useLanguage } from "./LanguageProvider";
 import { DeviceMockup } from "./DeviceMockup";
 import { InstallCommand } from "./InstallCommand";
-import { ScrollReveal } from "./ScrollReveal";
 
 export function Hero() {
   const { t } = useLanguage();
@@ -11,23 +10,19 @@ export function Hero() {
   return (
     <section
       id="top"
-      className="mx-auto max-w-frame scroll-mt-20 px-4 pb-12 pt-10 sm:px-6 sm:pb-28 sm:pt-20"
+      className="flex min-h-[calc(100svh-3.5rem)] scroll-mt-14 items-center px-4 sm:px-6 lg:px-8"
     >
-      <div className="mx-auto max-w-content text-center">
-        <ScrollReveal>
-          <h1 className="text-balance text-[28px] font-bold leading-[1.15] tracking-[-0.02em] sm:text-[40px]">
+      <div className="mx-auto grid w-full max-w-[1280px] items-center gap-8 py-10 sm:gap-10 sm:py-12 lg:grid-cols-[minmax(0,0.75fr)_minmax(0,1.25fr)] lg:gap-16">
+        <div className="text-left">
+          <h1 className="text-balance text-[28px] font-bold leading-[1.1] tracking-[-0.02em] sm:text-[40px] lg:text-[52px]">
             {t.hero.title1}
             <br />
             {t.hero.title2}
           </h1>
-        </ScrollReveal>
-        <ScrollReveal delay={75}>
-          <p className="mx-auto mt-6 max-w-[560px] text-base leading-[1.7] text-body">
+          <p className="mt-5 max-w-[540px] text-base leading-[1.7] text-body sm:mt-6 sm:text-lg">
             {t.hero.description}
           </p>
-        </ScrollReveal>
-        <ScrollReveal delay={150}>
-          <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <div className="mt-6 flex flex-col items-start gap-3 sm:mt-8 sm:flex-row">
             <a
               href="https://app.riffpad.ai"
               target="_blank"
@@ -37,17 +32,15 @@ export function Hero() {
               {t.hero.ctaPrimary}
             </a>
           </div>
-        </ScrollReveal>
-        <ScrollReveal delay={225}>
-          <InstallCommand />
-        </ScrollReveal>
-      </div>
-
-      <ScrollReveal delay={300}>
-        <div className="mt-16 sm:mt-20">
-          <DeviceMockup />
+          <InstallCommand className="mt-8 sm:mt-10" />
         </div>
-      </ScrollReveal>
+
+        <div className="relative flex min-w-0 items-center justify-center">
+          <div className="origin-center scale-[0.68] sm:scale-[0.8] lg:scale-[0.88] xl:scale-100">
+            <DeviceMockup />
+          </div>
+        </div>
+      </div>
     </section>
   );
 }

--- a/apps/landing/components/Hero.tsx
+++ b/apps/landing/components/Hero.tsx
@@ -13,7 +13,7 @@ export function Hero() {
       className="relative flex min-h-[calc(100svh-3.5rem)] scroll-mt-14 items-center px-4 sm:px-6 lg:px-8"
     >
       <div aria-hidden="true" className="hero-aperture" />
-      <div className="relative z-10 mx-auto grid w-full max-w-frame items-center gap-8 py-10 sm:gap-10 sm:py-12 lg:grid-cols-[minmax(0,0.65fr)_minmax(0,1.35fr)] lg:gap-16">
+      <div className="relative z-10 mx-auto grid w-full max-w-frame items-center gap-8 py-10 sm:gap-10 sm:py-12 lg:grid-cols-[minmax(0,0.7fr)_minmax(0,1.3fr)] lg:gap-16">
         <div className="text-left">
           <h1 className="text-balance text-[28px] font-bold leading-[1.1] tracking-[-0.02em] sm:text-[40px] lg:text-[52px]">
             {t.hero.title1}

--- a/apps/landing/components/InstallCommand.tsx
+++ b/apps/landing/components/InstallCommand.tsx
@@ -5,7 +5,7 @@ import { useLanguage } from "./LanguageProvider";
 
 const COMMAND = "curl -fsSL https://riffpad.ai/SKILL.md";
 
-export function InstallCommand() {
+export function InstallCommand({ className = "" }: { className?: string }) {
   const { t } = useLanguage();
   const [copied, setCopied] = useState(false);
 
@@ -20,7 +20,7 @@ export function InstallCommand() {
   };
 
   return (
-    <div className="mx-auto mt-10 w-full max-w-[560px]">
+    <div className={`w-full max-w-[560px] ${className}`}>
       <p className="mb-3 text-sm font-semibold text-ink">
         {t.install.tagline}
       </p>

--- a/apps/landing/components/WaitlistForm.tsx
+++ b/apps/landing/components/WaitlistForm.tsx
@@ -9,7 +9,7 @@ const WAITLIST_ENDPOINT = `${API_URL}/api/waitlist/subscribe`;
 
 type Status = "idle" | "submitting" | "success" | "error";
 
-export function WaitlistForm() {
+export function WaitlistForm({ className = "" }: { className?: string }) {
   const { t } = useLanguage();
   const [status, setStatus] = useState<Status>("idle");
 
@@ -43,7 +43,7 @@ export function WaitlistForm() {
   }
 
   return (
-    <div className="mt-3 flex flex-col items-center gap-2">
+    <div className={`mt-3 flex flex-col gap-2 ${className}`}>
       <form
         onSubmit={handleSubmit}
         className="flex items-stretch gap-2"

--- a/apps/landing/tailwind.config.ts
+++ b/apps/landing/tailwind.config.ts
@@ -76,7 +76,7 @@ const config: Config = {
       },
       maxWidth: {
         content: "960px",
-        frame: "1200px",
+        frame: "1320px",
       },
     },
   },

--- a/apps/landing/tailwind.config.ts
+++ b/apps/landing/tailwind.config.ts
@@ -76,7 +76,7 @@ const config: Config = {
       },
       maxWidth: {
         content: "960px",
-        frame: "1100px",
+        frame: "1200px",
       },
     },
   },


### PR DESCRIPTION
Redesigns the landing page hero to be full-screen, left-aligned, with the device mockup on the right. Also unifies content width, adds a subtle line grid background, and merges the CTA/waitlist into a two-column footer section.

### Changes
- Hero: full viewport height, left-aligned text, mockup on the right, no entrance animation
- Global: unified max-width (1320px), subtle line-grid background
- Sections: alternating canvas/surface-muted backgrounds
- CTA/Footer: merged CTA and waitlist into a left-right split section; footer is now just copyright + social links

### Verification
- [ ] 
> landing@0.1.0 lint /home/hv/projs/riffpad/apps/landing
> next lint


./components/Footer.tsx
71:17  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
89:17  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules passes
- [ ] Dev server renders correctly at 1440px and 375px
- [ ] Light and dark themes both look correct
- [ ] Header/content left edges align